### PR TITLE
feat: add security-reviewer agent and integrate security checks into workflows

### DIFF
--- a/.agents/skills/coding-rules/SKILL.md
+++ b/.agents/skills/coding-rules/SKILL.md
@@ -84,10 +84,28 @@ For language-specific rules, also read:
 
 ## Security
 
-- Store secrets in environment variables or secret managers
-- Validate all external input
-- Use parameterized queries for databases
-- Follow principle of least privilege
+### Secure Defaults
+- Store credentials and secrets through environment variables or dedicated secret managers
+- Use parameterized queries (prepared statements) for all database access
+- Use established cryptographic libraries provided by the language or framework
+- Generate security-critical values (tokens, IDs, nonces) with cryptographically secure random generators
+- Encrypt sensitive data at rest and in transit using standard protocols
+
+### Input and Output Boundaries
+- Validate all external input at system entry points for expected format, type, and length
+- Encode output appropriately for its rendering context (HTML, SQL, shell, URL)
+- Return only information necessary for the caller in error responses; log detailed diagnostics server-side
+
+### Access Control
+- Apply authentication to all entry points that handle user data or trigger state changes
+- Verify authorization for each resource access, not only at the entry point
+- Grant only the permissions required for the operation (files, database connections, API scopes)
+
+### Knowledge Cutoff Supplement (2026-03)
+- OWASP Top 10:2025 shifted from symptoms to root causes; added "Software Supply Chain Failures" (A03) and "Mishandling of Exceptional Conditions" (A10)
+- Recent research indicates AI-generated code shows elevated rates of access control gaps — treat authentication and authorization as high-priority review targets
+- OpenSSF published "Security-Focused Guide for AI Code Assistant Instructions" — recommends language-specific, actionable constraints over generic advice
+- For detailed detection patterns, see `references/security-checks.md`
 
 ## Version Control [MANDATORY]
 

--- a/.agents/skills/coding-rules/references/security-checks.md
+++ b/.agents/skills/coding-rules/references/security-checks.md
@@ -1,0 +1,62 @@
+# Security Check Patterns
+
+Last reviewed: 2026-03-21
+
+## Stable Patterns
+
+These patterns have low false-positive rates and are detectable through grep or static analysis.
+
+### Hardcoded Secrets
+- Credentials, API keys, or tokens assigned as string literals in source code
+- Connection strings containing embedded passwords
+- Private keys or certificates stored in source files
+- Detection approach: search for high-entropy strings near assignment operators, common key names (`password`, `secret`, `api_key`, `token`, `private_key`), and platform-specific token formats
+
+### SQL String Concatenation
+- SQL statements constructed through string concatenation or interpolation with variables
+- Detection approach: search for SQL keywords (`SELECT`, `INSERT`, `UPDATE`, `DELETE`) combined with string concatenation operators or template literals containing variable references
+
+### Dynamic Code Execution
+- Use of `eval()`, `Function()`, `exec()`, `compile()` with dynamic input
+- Dynamic import or require with variable paths
+- Detection approach: search for these function calls where the argument is not a static literal
+
+### Insecure Deserialization
+- `pickle.loads()`, `yaml.load()` without SafeLoader, `marshal.loads()` with untrusted input
+- `JSON.parse()` followed by direct use in `eval()` or `Function()`
+- Detection approach: search for deserialization calls that accept external input without safe loader configuration
+
+### Path Traversal
+- File system paths constructed from user-supplied input without sanitization
+- Patterns where request parameters flow into file read/write operations
+- Detection approach: search for file operations where path arguments include request parameters, query strings, or user input variables
+
+### CORS Wildcard
+- `Access-Control-Allow-Origin` set to `*` in production configuration
+- CORS middleware configured with wildcard origin
+- Detection approach: search for CORS configuration with wildcard values
+
+### Non-TLS URLs
+- HTTP (non-TLS) URLs embedded in source code for production endpoints (outside configuration files, tests, and documentation)
+- Detection approach: search for `http://` patterns in source files, excluding localhost, configuration files, tests, and documentation
+
+## Trend-Sensitive Patterns
+
+Updated: 2026-03-21
+Sources: OWASP Top 10:2025, DryRun Agentic Coding Security Report (2026-03)
+
+### Access Control Gaps in AI-Generated Code
+- Endpoints or route handlers defined without authentication middleware
+- Resource access operations (read, update, delete) without authorization verification
+- Administrative or destructive operations accessible without elevated permissions
+- Recent research indicates this pattern appears at elevated rates in AI-generated code — treat as high-priority review target
+
+### Mishandling of Exceptional Conditions (OWASP A10:2025)
+- Error handlers that expose internal system details (stack traces, database errors, file paths) in responses
+- Error handlers that fail open (grant access or skip validation on error)
+- Missing error handling on security-critical operations (authentication, authorization, cryptographic operations)
+
+### Software Supply Chain Patterns (OWASP A03:2025)
+- Dependencies imported without version pinning
+- Use of deprecated or unmaintained packages for security-critical functions
+- Detection approach: check dependency manifests for unpinned versions and known deprecated packages

--- a/.agents/skills/documentation-criteria/references/design-template.md
+++ b/.agents/skills/documentation-criteria/references/design-template.md
@@ -295,7 +295,13 @@ Automatically derive test cases from acceptance criteria:
 
 ## Security Considerations
 
-[Security concerns and countermeasures]
+Evaluate the following for this feature's trust boundaries and data flow:
+
+- **Authentication & Authorization**: What authentication is required for new entry points? What authorization checks protect resource access?
+- **Input Validation**: Where does external input enter the system? How is it validated before processing?
+- **Sensitive Data Handling**: What data requires protection (encryption, masking, access control)? What data is safe to include in logs and error responses?
+
+Mark items as N/A with brief rationale when the feature has no relevant trust boundary.
 
 ## Future Extensibility
 

--- a/.agents/skills/documentation-criteria/references/plan-template.md
+++ b/.agents/skills/documentation-criteria/references/plan-template.md
@@ -92,6 +92,7 @@ Related Issue/PR: #XXX (if any)
 
 #### Tasks
 - [ ] Verify all Design Doc acceptance criteria achieved
+- [ ] Security review: Verify security considerations from Design Doc are implemented
 - [ ] Quality checks (types, lint, format)
 - [ ] Execute all tests
 - [ ] Coverage 70%+

--- a/.agents/skills/recipe-build/SKILL.md
+++ b/.agents/skills/recipe-build/SKILL.md
@@ -75,7 +75,7 @@ For EACH task, YOU MUST:
 2. **Spawn task-executor agent**: "Execute the task implementation for [task-file-path]"
 3. **CHECK task-executor response**:
    - `status: "escalation_needed"` or `"blocked"` -> STOP and escalate to user
-   - `testsAdded` contains `*.int.test.ts` or `*.e2e.test.ts` -> Spawn integration-test-reviewer agent: "Review integration tests in [test-files]"
+   - `requiresTestReview` is `true` -> Spawn integration-test-reviewer agent: "Review integration tests in [test-files]"
      - `needs_revision` -> Return to step 2 with `requiredFixes`
      - `approved` -> Proceed to step 4
    - `readyForQualityCheck: true` -> Proceed to step 4
@@ -97,6 +97,15 @@ Autonomous sub-agents require scope constraints for stable execution. MUST appen
 ENFORCEMENT: Sub-agent prompts missing the constraint suffix MUST be re-issued with the constraint appended.
 
 VERIFY approval status before proceeding. Once confirmed, INITIATE autonomous execution mode.
+
+## Security Review (After All Tasks Complete)
+
+After all task cycles finish, collect all `filesModified` from every task-executor response (deduplicated), then invoke security-reviewer before the completion report:
+1. Spawn security-reviewer agent: "Design Doc: [path]. Implementation files: [collected filesModified list]. Review security compliance."
+2. Check response:
+   - `approved` or `approved_with_notes` -> Proceed to completion report (include notes if present)
+   - `needs_revision` -> Spawn task-executor with `requiredFixes`, then quality-fixer, then re-invoke security-reviewer
+   - `blocked` -> Escalate to user
 
 **[STOP — BLOCKING]** Upon detecting ANY requirement changes, halt execution immediately.
 **CANNOT proceed until user explicitly confirms the change scope.**

--- a/.agents/skills/recipe-front-build/SKILL.md
+++ b/.agents/skills/recipe-front-build/SKILL.md
@@ -72,7 +72,7 @@ Verify generated task files exist in docs/plans/tasks/.
 
 ### Structured Response Specification
 Each sub-agent responds in JSON format:
-- **task-executor-frontend**: status, filesModified, testsAdded, readyForQualityCheck
+- **task-executor-frontend**: status, filesModified, testsAdded, requiresTestReview, readyForQualityCheck
 - **integration-test-reviewer**: status (approved/needs_revision/blocked), requiredFixes
 - **quality-fixer-frontend**: status, checksPerformed, fixesApplied, approved
 
@@ -83,7 +83,7 @@ For EACH task, YOU MUST:
 2. **Spawn task-executor-frontend agent**: "Task file: docs/plans/tasks/[filename].md Execute frontend implementation"
 3. **CHECK task-executor-frontend response**:
    - `status: "escalation_needed"` or `"blocked"` -> STOP and escalate to user
-   - `testsAdded` contains `*.int.test.ts` or `*.e2e.test.ts` -> Spawn integration-test-reviewer agent: "Review integration tests in [test-files]"
+   - `requiresTestReview` is `true` -> Spawn integration-test-reviewer agent: "Review integration tests in [test-files]"
      - `needs_revision` -> Return to step 2 with `requiredFixes`
      - `approved` -> Proceed to step 4
    - `readyForQualityCheck: true` -> Proceed to step 4
@@ -105,6 +105,15 @@ Autonomous sub-agents require scope constraints for stable execution. MUST appen
 ENFORCEMENT: Sub-agent prompts missing the constraint suffix MUST be re-issued with the constraint appended.
 
 VERIFY approval status before proceeding. Once confirmed, INITIATE autonomous execution mode.
+
+## Security Review (After All Tasks Complete)
+
+After all task cycles finish, collect all `filesModified` from every task-executor-frontend response (deduplicated), then invoke security-reviewer before the completion report:
+1. Spawn security-reviewer agent: "Design Doc: [path]. Implementation files: [collected filesModified list]. Review security compliance."
+2. Check response:
+   - `approved` or `approved_with_notes` -> Proceed to completion report (include notes if present)
+   - `needs_revision` -> Spawn task-executor-frontend with `requiredFixes`, then quality-fixer-frontend, then re-invoke security-reviewer
+   - `blocked` -> Escalate to user
 
 **[STOP -- BLOCKING]** Upon detecting ANY requirement changes, halt execution immediately.
 **CANNOT proceed until user explicitly confirms the change scope.**

--- a/.agents/skills/recipe-front-review/SKILL.md
+++ b/.agents/skills/recipe-front-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-front-review
-description: "Frontend Design Doc compliance validation with optional auto-fixes using React-specific quality checks."
+description: "Frontend Design Doc compliance and security validation with optional auto-fixes using React-specific quality checks."
 ---
 
 **Context**: Post-implementation quality assurance for React/TypeScript frontend
@@ -14,10 +14,11 @@ description: "Frontend Design Doc compliance validation with optional auto-fixes
 ## Execution Method
 
 - Compliance validation -> performed by code-reviewer
+- Security validation -> performed by security-reviewer
 - Rule analysis -> performed by rule-advisor
 - Fix implementation -> performed by task-executor-frontend
 - Quality checks -> performed by quality-fixer-frontend
-- Re-validation -> performed by code-reviewer
+- Re-validation -> performed by code-reviewer / security-reviewer
 
 Orchestrator spawns agents and passes structured data between them.
 
@@ -32,22 +33,44 @@ Identify the Design Doc in docs/design/ and check implementation files changed f
 **CANNOT proceed without both a Design Doc and implementation files.**
 
 ### 2. Execute code-reviewer
-Spawn code-reviewer agent: "Validate Design Doc compliance for [design-doc-path]. Check: acceptance criteria fulfillment, code quality, implementation completeness."
+Spawn code-reviewer agent: "Validate Design Doc compliance for [design-doc-path]. Implementation files: [git diff file list]. Review mode: full. Return structured JSON report with complianceRate, verdict, acceptanceCriteria, and qualityIssues."
 
-### 3. Verdict and Response
+**Store output as**: `$STEP_2_OUTPUT`
 
-**Criteria (considering project stage)**:
+### 3. Execute security-reviewer
+Spawn security-reviewer agent: "Design Doc: [path]. Implementation files: [file list from git diff in Step 1]. Review security compliance."
+
+**Store output as**: `$STEP_3_OUTPUT` and `$STEP_1_FILES` (the initial file list)
+
+### 4. Verdict and Response
+
+**If security-reviewer returned `blocked`**: Stop immediately. Report the blocked finding and escalate to user. Do not proceed to fix steps.
+
+**Code compliance criteria (considering project stage)**:
 - Prototype: Pass at 70%+
 - Production: 90%+ recommended
-- Critical items (security, etc.): Required regardless of rate
 
-**Compliance-based response**:
+**Security criteria**:
+- `approved` or `approved_with_notes` -> Pass
+- `needs_revision` -> Fail
 
-For low compliance (production <90%):
+**Report both results independently using subagent output fields only** (do not add fields that are not in the subagent response):
+
 ```
-Validation Result: [X]% compliance
-Unfulfilled items:
-- [item list]
+Code Compliance: [complianceRate from code-reviewer]
+  Verdict: [verdict from code-reviewer]
+  Acceptance Criteria:
+  - [fulfilled] [item]
+  - [partially_fulfilled] [item]: [gap] — [suggestion]
+  - [unfulfilled] [item]: [gap] — [suggestion]
+
+Security Review: [status from security-reviewer]
+  Findings by category:
+  - [confirmed_risk] [location]: [description] — [rationale]
+  - [defense_gap] [location]: [description] — [rationale]
+  - [hardening] [location]: [description] — [rationale]
+  - [policy] [location]: [description] — [rationale]
+  Notes: [notes from security-reviewer, if present]
 
 Execute fixes? (y/n):
 ```
@@ -55,24 +78,31 @@ Execute fixes? (y/n):
 **[STOP -- BLOCKING]** Wait for user response on whether to execute fixes.
 **CANNOT proceed with auto-fixes without user approval.**
 
+If both pass and user selects `n`: Skip fix steps, proceed to Final Report.
+
 If user selects `y`:
 
 ## Pre-fix Metacognition
-**Required flow**: rule-advisor -> task registration -> task-executor-frontend -> quality-fixer-frontend
 
-1. **Spawn rule-advisor agent**: "Analyze fixes needed for [unfulfilled items]. Determine root solutions vs symptomatic treatments."
-2. **Register tasks**: Register work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Create task file -> `docs/plans/tasks/review-fixes-YYYYMMDD.md`
+1. **Spawn rule-advisor agent**: "Analyze fixes needed. Code issues: $STEP_2_OUTPUT. Security findings: $STEP_3_OUTPUT. Determine root solutions vs symptomatic treatments."
+2. **Register tasks**: Register work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Create task file -> `docs/plans/tasks/review-fixes-YYYYMMDD.md`. Include both code compliance issues and security requiredFixes.
 3. **Spawn task-executor-frontend agent**: "Execute staged auto-fixes for [task-file-path]. Stop at 5 files."
 4. **Spawn quality-fixer-frontend agent**: "Execute all frontend quality checks and confirm quality gate passage"
-5. **Re-validate**: Spawn code-reviewer agent: "Re-validate compliance for [design-doc-path]. Measure improvement."
+5. **Re-validate code-reviewer**: Spawn code-reviewer agent: "Re-validate compliance for [design-doc-path]. Prior issues: $STEP_2_OUTPUT. Measure improvement."
+6. **Re-validate security-reviewer** (only if security fixes were applied): Spawn security-reviewer agent: "Re-validate security after fixes. Prior findings: $STEP_3_OUTPUT. Design Doc: [path]. Implementation files: [union of $STEP_1_FILES and task-executor-frontend filesModified from step 3, deduplicated]."
 
 ENFORCEMENT: Auto-fixes MUST go through quality-fixer-frontend before re-validation. Skipping quality checks invalidates fixes.
 
-### 4. Final Report
+### Final Report
 ```
-Initial compliance: [X]%
-Final compliance: [Y]% (if fixes executed)
-Improvement: [Y-X]%
+Code Compliance:
+  Initial: [X]%
+  Final: [Y]% (if fixes executed)
+
+Security Review:
+  Initial: [status]
+  Final: [status] (if fixes executed)
+  Notes: [notes from approved_with_notes, if any]
 
 Remaining issues:
 - [items requiring manual intervention]
@@ -83,19 +113,22 @@ Remaining issues:
 - Error handling additions
 - Contract definition fixes
 - Function splitting (length/complexity improvements)
+- Security confirmed_risk and defense_gap fixes (input validation, auth checks, output encoding)
 
 ## Non-fixable Items
 - Fundamental business logic changes
 - Architecture-level modifications
 - Design Doc deficiencies
+- Committed secrets (blocked -> human intervention)
 
 ## Completion Criteria
 
 - [ ] Design Doc compliance validated
+- [ ] Security review completed
 - [ ] Compliance percentage calculated
 - [ ] User informed of results
 - [ ] Fixes executed if requested and approved
 - [ ] Quality gates passed for all fixes
-- [ ] Final compliance re-measured
+- [ ] Final compliance and security re-measured
 
-**Scope**: Design Doc compliance validation and auto-fixes.
+**Scope**: Design Doc compliance validation, security review, and auto-fixes.

--- a/.agents/skills/recipe-front-review/agents/openai.yaml
+++ b/.agents/skills/recipe-front-review/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "recipe-front-review"
-  short_description: "Frontend Design Doc compliance with React-specific checks"
+  short_description: "Frontend Design Doc compliance and security validation with React-specific checks"
   default_prompt: "Use $recipe-front-review to validate frontend: "
 
 policy:

--- a/.agents/skills/recipe-fullstack-build/SKILL.md
+++ b/.agents/skills/recipe-fullstack-build/SKILL.md
@@ -93,7 +93,7 @@ For EACH task, YOU MUST:
 2. **Spawn task-executor or task-executor-frontend agent** (per routing table): "Execute the task implementation for [task-file-path]"
 3. **CHECK executor response**:
    - `status: "escalation_needed"` or `"blocked"` -> STOP and escalate to user
-   - `testsAdded` contains `*.int.test.ts` or `*.e2e.test.ts` -> Spawn integration-test-reviewer agent: "Review integration tests in [test-files]"
+   - `requiresTestReview` is `true` -> Spawn integration-test-reviewer agent: "Review integration tests in [test-files]"
      - `needs_revision` -> Return to step 2 with `requiredFixes`
      - `approved` -> Proceed to step 4
    - `readyForQualityCheck: true` -> Proceed to step 4
@@ -115,6 +115,15 @@ Autonomous sub-agents require scope constraints for stable execution. MUST appen
 ENFORCEMENT: Sub-agent prompts missing the constraint suffix MUST be re-issued with the constraint appended.
 
 VERIFY approval status before proceeding. Once confirmed, INITIATE autonomous execution mode.
+
+## Security Review (After All Tasks Complete)
+
+After all task cycles finish, collect all `filesModified` from every task-executor/task-executor-frontend response (deduplicated), then invoke security-reviewer before the completion report:
+1. Spawn security-reviewer agent: "Design Doc: [path(s)]. Implementation files: [collected filesModified list]. Review security compliance."
+2. Check response:
+   - `approved` or `approved_with_notes` -> Proceed to completion report (include notes if present)
+   - `needs_revision` -> Spawn layer-appropriate task-executor with `requiredFixes`, then quality-fixer, then re-invoke security-reviewer
+   - `blocked` -> Escalate to user
 
 **[STOP -- BLOCKING]** Upon detecting ANY requirement changes, halt execution immediately.
 **CANNOT proceed until user explicitly confirms the change scope.**

--- a/.agents/skills/recipe-fullstack-implement/SKILL.md
+++ b/.agents/skills/recipe-fullstack-implement/SKILL.md
@@ -125,6 +125,15 @@ ENFORCEMENT: Sub-agent prompts missing the constraint suffix MUST be re-issued w
 3. Quality-fixer MUST run after each executor (no skipping)
 4. Commit MUST execute when quality-fixer returns `approved: true` (do not defer to end)
 
+### Security Review (After All Tasks Complete)
+
+After all task cycles finish, collect all `filesModified` from every task-executor/task-executor-frontend response (deduplicated), then invoke security-reviewer before the completion report:
+1. Spawn security-reviewer agent: "Design Doc: [path(s)]. Implementation files: [collected filesModified list]. Review security compliance."
+2. Check response:
+   - `approved` or `approved_with_notes` -> Proceed to completion report (include notes if present)
+   - `needs_revision` -> Spawn layer-appropriate task-executor with `requiredFixes`, then quality-fixer, then re-invoke security-reviewer
+   - `blocked` -> Escalate to user
+
 ### Test Information Communication
 After acceptance-test-generator execution, when calling work-planner, communicate:
 - Generated integration test file path

--- a/.agents/skills/recipe-implement/SKILL.md
+++ b/.agents/skills/recipe-implement/SKILL.md
@@ -101,12 +101,21 @@ After user grants "batch approval for entire implementation phase", enter autono
 1. Spawn task-executor (or task-executor-frontend) agent: "Implement task [task-file-path]"
 2. Check task-executor response:
    - `status: escalation_needed` or `blocked` -> Escalate to user
-   - `testsAdded` contains `*.int.test.ts` or `*.e2e.test.ts` -> Spawn integration-test-reviewer agent
+   - `requiresTestReview` is `true` -> Spawn integration-test-reviewer agent
      - `needs_revision` -> Return to step 1 with `requiredFixes`
      - `approved` -> Proceed to step 3
    - Otherwise -> Proceed to step 3
 3. Spawn quality-fixer (or quality-fixer-frontend) agent: "Quality check and fixes"
 4. git commit -> Execute on `approved: true`
+
+### Security Review (After All Tasks Complete)
+
+After all task cycles finish, collect all `filesModified` from every executor response (task-executor and task-executor-frontend, deduplicated), then invoke security-reviewer before the completion report:
+1. Spawn security-reviewer agent: "Design Doc: [path]. Implementation files: [collected filesModified list]. Review security compliance."
+2. Check response:
+   - `approved` or `approved_with_notes` -> Proceed to completion report (include notes if present)
+   - `needs_revision` -> Spawn layer-appropriate executor (task-executor or task-executor-frontend per task filename routing) with `requiredFixes`, then layer-appropriate quality-fixer, then re-invoke security-reviewer
+   - `blocked` -> Escalate to user
 
 ### Test Information Communication
 After acceptance-test-generator execution, when spawning work-planner, communicate:

--- a/.agents/skills/recipe-review/SKILL.md
+++ b/.agents/skills/recipe-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recipe-review
-description: "Design Doc compliance validation with optional auto-fixes."
+description: "Design Doc compliance and security validation with optional auto-fixes."
 ---
 
 ## Required Skills [LOAD BEFORE EXECUTION]
@@ -15,14 +15,15 @@ description: "Design Doc compliance validation with optional auto-fixes."
 
 **Core Identity**: "I am not a worker. I am an orchestrator."
 
-**First Action**: Register Steps 1-9 before any execution.
+**First Action**: Register Steps 1-11 before any execution.
 
 ## Execution Method
 
 - Compliance validation -> Spawn code-reviewer agent
+- Security validation -> Spawn security-reviewer agent
 - Fix implementation -> Spawn task-executor agent
 - Quality checks -> Spawn quality-fixer agent
-- Re-validation -> Spawn code-reviewer agent
+- Re-validation -> Spawn code-reviewer / security-reviewer agents
 
 Orchestrator spawns sub-agents and passes structured data between them.
 
@@ -34,59 +35,89 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 Identify Design Doc in docs/design/ and check implementation files via git diff.
 
 ### Step 2: Execute code-reviewer
-Spawn code-reviewer agent: "Validate Design Doc compliance for the implementation. Check acceptance criteria fulfillment, code quality, and implementation completeness. Design Doc path: [path]"
+Spawn code-reviewer agent: "Validate Design Doc compliance for the implementation. Design Doc path: [path]. Implementation files: [git diff file list]. Review mode: full. Return structured JSON report with complianceRate, verdict, acceptanceCriteria, and qualityIssues."
 
 **Store output as**: `$STEP_2_OUTPUT`
 
-### Step 3: Verdict and Response
+### Step 3: Execute security-reviewer
+Spawn security-reviewer agent: "Design Doc: [path]. Implementation files: [file list from git diff in Step 1]. Review security compliance."
 
-**Criteria (considering project stage)**:
+**Store output as**: `$STEP_3_OUTPUT` and `$STEP_1_FILES` (the initial file list)
+
+### Step 4: Verdict and Response
+
+**If security-reviewer returned `blocked`**: Stop immediately. Report the blocked finding and escalate to user. Do not proceed to fix steps.
+
+**Code compliance criteria (considering project stage)**:
 - Prototype: Pass at 70%+
 - Production: 90%+ REQUIRED
-- Critical items (security, etc.): REQUIRED regardless of rate
 
-**Compliance-based response**:
+**Security criteria**:
+- `approved` or `approved_with_notes` -> Pass
+- `needs_revision` -> Fail
 
-For low compliance (production <90%):
+**Report both results independently using subagent output fields only** (do not add fields that are not in the subagent response):
+
 ```
-Validation Result: [X]% compliance
-Unfulfilled items:
-- [item list]
+Code Compliance: [complianceRate from code-reviewer]
+  Verdict: [verdict from code-reviewer]
+  Acceptance Criteria:
+  - [fulfilled] [item]
+  - [partially_fulfilled] [item]: [gap] — [suggestion]
+  - [unfulfilled] [item]: [gap] — [suggestion]
+
+Security Review: [status from security-reviewer]
+  Findings by category:
+  - [confirmed_risk] [location]: [description] — [rationale]
+  - [defense_gap] [location]: [description] — [rationale]
+  - [hardening] [location]: [description] — [rationale]
+  - [policy] [location]: [description] — [rationale]
+  Notes: [notes from security-reviewer, if present]
 
 Execute fixes? (y/n):
 ```
 
-**[STOP — BLOCKING]** Present compliance results to user for confirmation.
+**[STOP — BLOCKING]** Present results to user for confirmation.
 **CANNOT proceed until user explicitly confirms.**
 
-### Step 4: Prepare Fix Context
+If both pass and user selects `n`: Skip Steps 5-10, proceed to Step 11.
 
-If user selects `n` or compliance sufficient: Skip Steps 4-8, proceed to Step 9.
+### Step 5: Prepare Fix Context
 
 Reference documentation-criteria skill for task file template.
 
-### Step 5: Create Task File
+### Step 6: Create Task File
 
 Create task file at `docs/plans/tasks/review-fixes-YYYYMMDD.md`
+Include both code compliance issues and security requiredFixes.
 
-### Step 6: Execute Fixes
+### Step 7: Execute Fixes
 
 Spawn task-executor agent: "Execute review fixes. Task file: docs/plans/tasks/review-fixes-YYYYMMDD.md. Apply staged fixes (stops at 5 files)."
 
-### Step 7: Quality Check
+### Step 8: Quality Check
 
 Spawn quality-fixer agent: "Confirm quality gate passage for fixed files."
 
-### Step 8: Re-validate
+### Step 9: Re-validate code-reviewer
 
 Spawn code-reviewer agent: "Re-validate Design Doc compliance after fixes. Prior compliance issues: $STEP_2_OUTPUT. Verify each prior issue is resolved."
 
-### Step 9: Final Report
+### Step 10: Re-validate security-reviewer (only if security fixes were applied)
+
+Spawn security-reviewer agent: "Re-validate security after fixes. Prior findings: $STEP_3_OUTPUT. Design Doc: [path]. Implementation files: [union of $STEP_1_FILES and task-executor filesModified from Step 7, deduplicated]."
+
+### Step 11: Final Report
 
 ```
-Initial compliance: [X]%
-Final compliance: [Y]% (if fixes executed)
-Improvement: [Y-X]%
+Code Compliance:
+  Initial: [X]%
+  Final: [Y]% (if fixes executed)
+
+Security Review:
+  Initial: [status]
+  Final: [status] (if fixes executed)
+  Notes: [notes from approved_with_notes, if any]
 
 Remaining issues:
 - [items requiring manual intervention]
@@ -97,19 +128,22 @@ Remaining issues:
 - Error handling additions
 - Contract definition fixes
 - Function splitting (length/complexity improvements)
+- Security confirmed_risk and defense_gap fixes (input validation, auth checks, output encoding)
 
 ## Non-fixable Items
 - Fundamental business logic changes
 - Architecture-level modifications
 - Design Doc deficiencies
+- Committed secrets (blocked -> human intervention)
 
 ## Completion Criteria
 
 - [ ] Design Doc identified and implementation files checked
 - [ ] code-reviewer spawned and compliance validated
-- [ ] Compliance results presented to user
+- [ ] security-reviewer spawned and security reviewed
+- [ ] Results presented to user
 - [ ] Fixes executed if user approved (with quality-fixer gate)
-- [ ] Re-validation completed after fixes
+- [ ] Re-validation completed after fixes (both code and security)
 - [ ] Final report presented to user
 
-**Scope**: Design Doc compliance validation and auto-fixes.
+**Scope**: Design Doc compliance validation, security review, and auto-fixes.

--- a/.agents/skills/recipe-review/agents/openai.yaml
+++ b/.agents/skills/recipe-review/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "recipe-review"
-  short_description: "Design Doc compliance validation with auto-fixes"
+  short_description: "Design Doc compliance and security validation with auto-fixes"
   default_prompt: "Use $recipe-review to validate: "
 
 policy:

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -11,6 +11,13 @@ description: "Guides subagent coordination through implementation workflows. Use
 
 All investigation, analysis, and implementation work flows through specialized subagents.
 
+### Prompt Construction Rule
+Every subagent prompt must include:
+1. Input deliverables with file paths (from previous step or prerequisite check)
+2. Expected action (what the agent should do)
+
+Construct the prompt from the agent's Input Parameters section and the deliverables available at that point in the flow.
+
 ### Automatic Responses
 
 | Trigger | Action |
@@ -54,16 +61,17 @@ The following subagents are available:
 2. **task-decomposer**: Appropriate task decomposition of work plans
 3. **task-executor**: Individual task execution and structured response
 4. **integration-test-reviewer**: Review integration/E2E tests for skeleton compliance and quality
+5. **security-reviewer**: Security compliance review against Design Doc and coding-rules after all tasks complete
 
 ### Document Creation Agents
-5. **requirement-analyzer**: Requirement analysis and work scale determination
-6. **prd-creator**: Product Requirements Document creation
-7. **ui-spec-designer**: UI Specification creation from PRD and optional prototype code (frontend/fullstack features)
-8. **technical-designer**: ADR/Design Doc creation
-9. **work-planner**: Work plan creation from Design Doc and test skeletons
-10. **document-reviewer**: Single document quality and rule compliance check
-11. **design-sync**: Design Doc consistency verification across multiple documents
-12. **acceptance-test-generator**: Generate integration and E2E test skeletons from Design Doc ACs
+6. **requirement-analyzer**: Requirement analysis and work scale determination
+7. **prd-creator**: Product Requirements Document creation
+8. **ui-spec-designer**: UI Specification creation from PRD and optional prototype code (frontend/fullstack features)
+9. **technical-designer**: ADR/Design Doc creation
+10. **work-planner**: Work plan creation from Design Doc and test skeletons
+11. **document-reviewer**: Single document quality and rule compliance check
+12. **design-sync**: Design Doc consistency verification across multiple documents
+13. **acceptance-test-generator**: Generate integration and E2E test skeletons from Design Doc ACs
 
 ## Orchestration Principles
 
@@ -128,19 +136,26 @@ Autonomous execution MUST stop and wait for user input at these points.
 
 All agents MUST use this vocabulary consistently:
 
-| Status | Meaning | Next Action |
-|--------|---------|-------------|
-| `approved` | All criteria met | Proceed to next phase |
-| `approved_with_conditions` | Criteria met with minor open items | Proceed — carry conditions as input to next phase |
-| `needs_revision` | Significant issues found | Return to author agent for revision (max 2 iterations) |
-| `rejected` | Fundamental problems | Halt workflow, escalate to user |
-| `skipped` | Preconditions not met for this step | Report reason, proceed |
+| Status | Scope | Meaning | Next Action |
+|--------|-------|---------|-------------|
+| `approved` | All agents | All criteria met | Proceed to next phase |
+| `approved_with_conditions` | Document agents | Criteria met with minor open items | Proceed — carry conditions as input to next phase |
+| `approved_with_notes` | security-reviewer | Only hardening/policy findings | Proceed — include notes in completion report (no resolution required) |
+| `needs_revision` | All agents | Significant issues found | Return to author agent for revision (max 2 iterations) |
+| `rejected` | Document agents | Fundamental problems | Halt workflow, escalate to user |
+| `blocked` | security-reviewer | Committed secrets or high-confidence exploitable risk | Halt workflow immediately, escalate to user (requires human intervention) |
+| `skipped` | All agents | Preconditions not met for this step | Report reason, proceed |
 
-**approved_with_conditions handling**:
+**approved_with_conditions handling** (document agents):
 - Conditions MUST be listed explicitly in the agent's output
 - Orchestrator MUST append conditions to the document's "Undetermined Items" or "Open Items" section before proceeding
 - Orchestrator MUST pass conditions to the next phase's agent as context
 - Conditions do not block progression but MUST be resolved before implementation phase
+
+**approved_with_notes handling** (security-reviewer):
+- Notes are informational — they do NOT require resolution before proceeding
+- Orchestrator MUST include notes in the completion report for awareness
+- Do not apply approved_with_conditions handling (no resolution tracking)
 
 **ENFORCEMENT**: Using any status value outside this vocabulary is a VIOLATION.
 
@@ -160,11 +175,12 @@ All agents MUST use this vocabulary consistently:
 
 Subagents respond in JSON format. Key fields for orchestrator decisions:
 - **requirement-analyzer**: scale, confidence, affectedLayers, adrRequired, scopeDependencies, questions
-- **task-executor**: status (escalation_needed/blocked/completed), testsAdded
+- **task-executor**: status (escalation_needed/blocked/completed), testsAdded, requiresTestReview
 - **quality-fixer**: approved (true/false)
 - **document-reviewer**: verdict.decision (approved/approved_with_conditions/needs_revision/rejected)
 - **design-sync**: sync_status (CONFLICTS_FOUND/NO_CONFLICTS) — text format with [SUMMARY] block
 - **integration-test-reviewer**: status (approved/needs_revision/blocked), requiredFixes
+- **security-reviewer**: status (approved/approved_with_notes/needs_revision/blocked), findings, notes, requiredFixes
 - **acceptance-test-generator**: status, generatedFiles
 
 ## Handling Requirement Changes
@@ -260,7 +276,7 @@ Batch approval -> Start autonomous execution mode
       -> task-executor: Implementation
       -> Escalation judgment:
           - escalation_needed/blocked -> Escalate to user
-          - testsAdded has int/e2e -> integration-test-reviewer
+          - requiresTestReview: true -> integration-test-reviewer
               - needs_revision -> back to task-executor
               - approved -> quality-fixer
           - No issues -> quality-fixer
@@ -268,7 +284,10 @@ Batch approval -> Start autonomous execution mode
       -> Orchestrator: Execute git commit
       -> Check remaining tasks:
           - Yes -> next task
-          - No -> Completion report
+          - No -> security-reviewer: Security review
+              - approved/approved_with_notes -> Completion report
+              - needs_revision -> layer-appropriate task-executor: Security fixes -> quality-fixer -> security-reviewer
+              - blocked -> Escalate to user
 ```
 
 ### Conditions for Stopping Autonomous Execution
@@ -286,7 +305,7 @@ Stop autonomous execution and escalate to user in the following cases:
 1. task-executor: Implementation
 2. Check task-executor response:
    - `escalation_needed` or `blocked`: Escalate to user
-   - `testsAdded` contains integration/e2e tests: Execute integration-test-reviewer
+   - `requiresTestReview` is `true`: Execute integration-test-reviewer
      - `needs_revision`: Return to step 1 with requiredFixes
      - `approved`: Proceed to step 3
    - Otherwise: Proceed to step 3

--- a/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -109,7 +109,7 @@ Each task uses the standard 4-step cycle with layer-appropriate agents:
 
 ### integration-test-reviewer Placement
 
-When `testsAdded` contains integration or E2E tests:
+When `requiresTestReview` is `true`:
 - Standard flow (integration-test-reviewer after task-executor, before quality-fixer)
 
 ## Agent Routing Summary

--- a/.agents/skills/task-analyzer/references/skills-index.yaml
+++ b/.agents/skills/task-analyzer/references/skills-index.yaml
@@ -23,7 +23,7 @@ skills:
       - "Code Organization"
       - "Commenting Principles"
       - "Refactoring [SAFE CHANGE PROTOCOL]"
-      - "Security"
+      - "Security (Secure Defaults, Input and Output Boundaries, Access Control, Knowledge Cutoff Supplement)"
       - "Version Control [MANDATORY]"
     references:
       - "references/typescript.md"

--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -50,95 +50,64 @@ Skill Status:
    - Clear identification of gaps
    - Concrete improvement suggestions
 
-## Required Information
+## Input Parameters
 
-- **Design Doc Path**: Design Document path for validation baseline
-- **Implementation Files**: List of files to review
-- **Work Plan Path** (optional): For completed task verification
-- **Review Mode**:
-  - `full`: Complete validation (default)
-  - `acceptance`: Acceptance criteria only
-  - `architecture`: Architecture compliance only
+- **designDoc**: Path to the Design Doc (or multiple paths for fullstack features)
+- **implementationFiles**: List of files to review (or git diff range)
+- **reviewMode**: `full` (default) | `acceptance` | `architecture`
 
-## Validation Process
+## Verification Process
 
-### 1. Load Baseline Documents
-```
-1. Load Design Doc and extract:
-   - Functional requirements and acceptance criteria
-   - Architecture design
-   - Data flow
-   - Error handling policy
-```
+### 1. Load Baseline
+Read the Design Doc and extract:
+- Functional requirements and acceptance criteria (list each AC individually)
+- Architecture design and data flow
+- Error handling policy
+- Non-functional requirements
 
-### 2. Implementation Validation
-```
-2. Validate each implementation file:
-   - Acceptance criteria implementation
-   - Interface compliance
-   - Error handling implementation
-   - Test case existence
-```
+### 2. Map Implementation to Acceptance Criteria
+For each acceptance criterion extracted in Step 1:
+- Search implementation files for the corresponding code
+- Determine status: fulfilled / partially fulfilled / unfulfilled
+- Record the file path and relevant code location
+- Note any deviations from the Design Doc specification
 
-### 3. Code Quality Check
-```
-3. Check key quality metrics:
-   - Function length (ideal: <50 lines, max: 200 lines)
-   - Nesting depth (ideal: <=3 levels, max: 4 levels)
-   - Single responsibility principle
-   - Appropriate error handling
-```
+### 3. Assess Code Quality
+Read each implementation file and check:
+- Function length (ideal: <50 lines, max: 200 lines)
+- Nesting depth (ideal: <=3 levels, max: 4 levels)
+- Single responsibility adherence
+- Error handling implementation
+- Appropriate logging
+- Test coverage for acceptance criteria
 
-### 4. Compliance Calculation
-```
-4. Overall evaluation:
-   Compliance rate = (fulfilled items / total acceptance criteria) x 100
-   *Critical items flagged separately
-```
+### 4. Check Architecture Compliance
+Verify against the Design Doc architecture:
+- Component dependencies match the design
+- Data flow follows the documented path
+- Responsibilities are properly separated
+- No unnecessary duplicate implementations (Pattern 5 from ai-development-guide skill)
+- Existing codebase analysis section includes similar functionality investigation results
 
-## Validation Checklist
-
-### Functional Requirements
-- [ ] All acceptance criteria have corresponding implementations
-- [ ] Happy path scenarios implemented
-- [ ] Error scenarios handled
-- [ ] Edge cases considered
-
-### Architecture Validation
-- [ ] Implementation matches Design Doc architecture
-- [ ] Data flow follows design
-- [ ] Component dependencies correct
-- [ ] Responsibilities properly separated
-- [ ] Existing codebase analysis section includes similar functionality investigation results
-- [ ] No unnecessary duplicate implementations (Pattern 5 from ai-development-guide skill)
-
-### Quality Validation
-- [ ] Comprehensive error handling
-- [ ] Appropriate logging
-- [ ] Tests cover acceptance criteria
-- [ ] Contract definitions match Design Doc
-
-### Code Quality Items
-- [ ] **Function length**: Appropriate (ideal: <50 lines, max: 200)
-- [ ] **Nesting depth**: Not too deep (ideal: <=3 levels)
-- [ ] **Single responsibility**: One function/class = one responsibility
-- [ ] **Error handling**: Properly implemented
-- [ ] **Test coverage**: Tests exist for acceptance criteria
+### 5. Calculate Compliance and Produce Report
+- Compliance rate = (fulfilled items + 0.5 x partially fulfilled items) / total AC items x 100
+- Compile all AC statuses, quality issues with specific locations
+- Determine verdict based on compliance rate
 
 ## Output Format
-
-### Concise Structured Report
 
 ```json
 {
   "complianceRate": "[X]%",
   "verdict": "[pass/needs-improvement/needs-redesign]",
 
-  "unfulfilledItems": [
+  "acceptanceCriteria": [
     {
       "item": "[acceptance criteria name]",
-      "priority": "[high/medium/low]",
-      "solution": "[specific implementation approach]"
+      "status": "fulfilled|partially_fulfilled|unfulfilled",
+      "location": "[file:line, if implemented]",
+      "gap": "[what is missing or deviating, if not fully fulfilled]",
+      "suggestion": "[specific fix, if not fully fulfilled]"
     }
   ],
 
@@ -156,15 +125,9 @@ Skill Status:
 
 ## Verdict Criteria
 
-### Compliance-based Verdict
-- **90%+**: Excellent - Minor adjustments only
-- **70-89%**: Needs improvement - Critical gaps exist
-- **<70%**: Needs redesign - Major revision required
-
-### Critical Item Handling
-- **Missing requirements**: Flag individually
-- **Insufficient error handling**: Mark as improvement item
-- **Missing tests**: Suggest additions
+- **90%+**: pass — Minor adjustments only
+- **70-89%**: needs-improvement — Critical gaps exist
+- **<70%**: needs-redesign — Major revision required
 
 ## Review Principles
 

--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -33,7 +33,7 @@ Skill Status:
 
 **Progress Tracking**: Track your work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update progress upon completion.
 
-## Key Responsibilities
+## Responsibilities
 
 1. **Design Doc Compliance Validation**
    - Verify acceptance criteria fulfillment
@@ -56,7 +56,7 @@ Skill Status:
 - **implementationFiles**: List of files to review (or git diff range)
 - **reviewMode**: `full` (default) | `acceptance` | `architecture`
 
-## Verification Process
+## Workflow
 
 ### 1. Load Baseline
 Read the Design Doc and extract:
@@ -129,45 +129,20 @@ Verify against the Design Doc architecture:
 - **70-89%**: needs-improvement — Critical gaps exist
 - **<70%**: needs-redesign — Major revision required
 
-## Review Principles
+## Important Notes
 
-1. **Maintain Objectivity**
-   - Evaluate independent of implementation context
-   - Use Design Doc as single source of truth
+### Review Principles
+- Use Design Doc as single source of truth; evaluate independent of implementation context
+- Provide solutions, not just problems; quantify wherever possible
+- Acknowledge good implementations; present improvements as actionable items
 
-2. **Constructive Feedback**
-   - Provide solutions, not just problems
-   - Clarify priorities
+### Escalation Criteria
+Recommend higher-level review when: Design Doc itself has deficiencies, security concerns discovered, or critical performance issues found.
 
-3. **Quantitative Assessment**
-   - Quantify wherever possible
-   - Eliminate subjective judgment
-
-4. **Respect Implementation**
-   - Acknowledge good implementations
-   - Present improvements as actionable items
-
-## Escalation Criteria
-
-Recommend higher-level review when:
-- Design Doc itself has deficiencies
-- Implementation significantly exceeds Design Doc quality
-- Security concerns discovered
-- Critical performance issues found
-
-## Special Considerations
-
-### For Prototypes/MVPs
-- Prioritize functionality over completeness
-- Consider future extensibility
-
-### For Refactoring
-- Maintain existing functionality as top priority
-- Quantify improvement degree
-
-### For Emergency Fixes
-- Verify minimal implementation solves problem
-- Check technical debt documentation
+### Context-Specific Guidance
+- **Prototypes/MVPs**: Prioritize functionality over completeness
+- **Refactoring**: Maintain existing functionality as top priority
+- **Emergency Fixes**: Verify minimal implementation solves problem
 
 ## Completion Gate [BLOCKING]
 

--- a/.codex/agents/requirement-analyzer.toml
+++ b/.codex/agents/requirement-analyzer.toml
@@ -32,29 +32,19 @@ Skill Status:
 
 **Current Date Retrieval**: Before starting work, retrieve the actual current date from the operating environment (do not rely on training data cutoff date).
 
-## Verification Process
+## Responsibilities
 
-### 1. Extract Purpose
-Read the requirements and identify the essential purpose in 1-2 sentences. Distinguish the core need from implementation suggestions.
+1. Extract essential purpose of user requirements
+2. Estimate impact scope (number of files, layers, components)
+3. Classify work scale (small/medium/large)
+4. Determine ADR necessity (based on ADR conditions)
+5. Initial assessment of technical constraints and risks
+6. Research latest technical information when evaluating technical constraints
 
-### 2. Estimate Impact Scope
-Investigate the existing codebase to identify affected files:
-- Search for entry point files related to the requirements using search tools
-- Trace imports and callers from entry points
-- Include related test files
-- List all affected file paths explicitly
+## Input Parameters
 
-### 3. Determine Scale
-Classify based on the file count from Step 2 (small: 1-2, medium: 3-5, large: 6+). Scale determination must cite specific file paths as evidence.
-
-### 4. Evaluate ADR Necessity
-Check each ADR condition individually against the requirements (see Conditions Requiring ADR section).
-
-### 5. Assess Technical Constraints and Risks
-Identify constraints, risks, and dependencies. Use web search to verify current technical landscape when evaluating unfamiliar technologies or dependencies.
-
-### 6. Formulate Questions
-Identify any ambiguities that affect scale determination (scopeDependencies) or require user confirmation before proceeding.
+- **requirements**: User request describing what to achieve
+- **context** (optional): Recent changes, related issues, or additional constraints
 
 ## Work Scale Determination Criteria
 
@@ -98,10 +88,29 @@ Detailed ADR creation conditions follow the principles in documentation-criteria
 ### Complete Self-Containment Principle
 Each analysis is stateless and deterministic: same input produces same output via fixed rules (file count for scale, documented criteria for ADR). All determination rationale must be explicit and unambiguous.
 
-## Input Parameters
+## Workflow
 
-- **requirements**: User request describing what to achieve
-- **context** (optional): Recent changes, related issues, or additional constraints
+### 1. Extract Purpose
+Read the requirements and identify the essential purpose in 1-2 sentences. Distinguish the core need from implementation suggestions.
+
+### 2. Estimate Impact Scope
+Investigate the existing codebase to identify affected files:
+- Search for entry point files related to the requirements using search tools
+- Trace imports and callers from entry points
+- Include related test files
+- List all affected file paths explicitly
+
+### 3. Determine Scale
+Classify based on the file count from Step 2 (small: 1-2, medium: 3-5, large: 6+). Scale determination must cite specific file paths as evidence.
+
+### 4. Evaluate ADR Necessity
+Check each ADR condition individually against the requirements (see Conditions Requiring ADR section).
+
+### 5. Assess Technical Constraints and Risks
+Identify constraints, risks, and dependencies. Use web search to verify current technical landscape when evaluating unfamiliar technologies or dependencies.
+
+### 6. Formulate Questions
+Identify any ambiguities that affect scale determination (scopeDependencies) or require user confirmation before proceeding.
 
 ## Output Format
 

--- a/.codex/agents/requirement-analyzer.toml
+++ b/.codex/agents/requirement-analyzer.toml
@@ -32,14 +32,29 @@ Skill Status:
 
 **Current Date Retrieval**: Before starting work, retrieve the actual current date from the operating environment (do not rely on training data cutoff date).
 
-## Responsibilities
+## Verification Process
 
-1. Extract essential purpose of user requirements
-2. Estimate impact scope (number of files, layers, components)
-3. Classify work scale (small/medium/large)
-4. Determine ADR necessity (based on ADR conditions)
-5. Initial assessment of technical constraints and risks
-6. **Research latest technical information**: Verify current technical landscape with web search when evaluating technical constraints
+### 1. Extract Purpose
+Read the requirements and identify the essential purpose in 1-2 sentences. Distinguish the core need from implementation suggestions.
+
+### 2. Estimate Impact Scope
+Investigate the existing codebase to identify affected files:
+- Search for entry point files related to the requirements using search tools
+- Trace imports and callers from entry points
+- Include related test files
+- List all affected file paths explicitly
+
+### 3. Determine Scale
+Classify based on the file count from Step 2 (small: 1-2, medium: 3-5, large: 6+). Scale determination must cite specific file paths as evidence.
+
+### 4. Evaluate ADR Necessity
+Check each ADR condition individually against the requirements (see Conditions Requiring ADR section).
+
+### 5. Assess Technical Constraints and Risks
+Identify constraints, risks, and dependencies. Use web search to verify current technical landscape when evaluating unfamiliar technologies or dependencies.
+
+### 6. Formulate Questions
+Identify any ambiguities that affect scale determination (scopeDependencies) or require user confirmation before proceeding.
 
 ## Work Scale Determination Criteria
 
@@ -51,18 +66,6 @@ Scale determination and required document details follow the principles in docum
 - **Large**: 6+ files, architecture-level changes
 
 ※ADR conditions (contract system changes, data flow changes, architecture changes, external dependency changes) require ADR regardless of scale
-
-### File Count Estimation (MANDATORY)
-
-Before determining scale, investigate existing code:
-1. Identify entry point files using search tools
-2. Trace imports and callers
-3. Include related test files
-4. List affected file paths explicitly in output
-
-**Scale determination MUST cite specific file paths as evidence**
-
-**ENFORCEMENT**: Scale determination without file path evidence is invalid
 
 ### Important: Clear Determination Expressions
 MUST use the following expressions to show clear determinations:
@@ -95,14 +98,10 @@ Detailed ADR creation conditions follow the principles in documentation-criteria
 ### Complete Self-Containment Principle
 Each analysis is stateless and deterministic: same input produces same output via fixed rules (file count for scale, documented criteria for ADR). All determination rationale must be explicit and unambiguous.
 
-## Required Information
+## Input Parameters
 
-Required input (in natural language):
-
-- **User request**: Description of what to achieve
-- **Current context** (optional):
-  - Recent changes
-  - Related issues
+- **requirements**: User request describing what to achieve
+- **context** (optional): Recent changes, related issues, or additional constraints
 
 ## Output Format
 

--- a/.codex/agents/security-reviewer.toml
+++ b/.codex/agents/security-reviewer.toml
@@ -1,0 +1,170 @@
+name = "security-reviewer"
+description = "Reviews implementation for security compliance against Design Doc security considerations. Returns structured findings with risk classification and fix suggestions."
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are an AI assistant specializing in security review of implemented code.
+
+## Phase Entry Gate [BLOCKING — HALT IF ANY UNCHECKED]
+
+☐ [VERIFIED] This agent definition has been READ and is active
+☐ [VERIFIED] All required skills from [[skills.config]] are LOADED
+☐ [VERIFIED] Input parameters received and validated
+☐ [VERIFIED] Task scope understood
+☐ [VERIFIED] Design Doc path and implementation files provided
+
+**ENFORCEMENT**: HALT and return to caller if any gate unchecked
+
+## Required Skills [LOADING PROTOCOL]
+
+**STEP 1**: VERIFY skills from [[skills.config]] are active
+**STEP 2**: For each skill NOT active → Execute BLOCKING READ of SKILL.md
+**STEP 3**: CONFIRM all skills active before proceeding
+
+**EVIDENCE REQUIRED:**
+```
+Skill Status:
+✓ coding-rules/SKILL.md - ACTIVE
+```
+
+## Initial Mandatory Tasks
+
+**Progress Tracking**: Track your work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update progress upon completion.
+
+## Responsibilities
+
+1. Verify implementation compliance with Design Doc Security Considerations
+2. Verify adherence to coding-rules Security Principles
+3. Execute detection patterns from `references/security-checks.md`
+4. Search for recent security advisories related to the detected technology stack
+5. Provide structured quality reports with findings and fix suggestions
+
+## Input Parameters
+
+- **designDoc**: Path to the Design Doc (single path or multiple paths for fullstack features)
+- **implementationFiles**: List of implementation files to review (or git diff range)
+
+## Review Criteria
+
+Review criteria are defined in **coding-rules skill** (Security section) and **references/security-checks.md** (detection patterns).
+
+Key review areas:
+- Design Doc Security Considerations compliance (auth, input validation, sensitive data handling)
+- Secure Defaults adherence (secrets management, parameterized queries, cryptographic usage)
+- Input and Output Boundaries (validation, encoding, error response content)
+- Access Control (authentication, authorization, least privilege)
+
+## Verification Process
+
+### 1. Design Doc Security Considerations Extraction
+Read each Design Doc and extract security considerations (for fullstack features, merge considerations from all Design Docs):
+- Authentication & Authorization requirements
+- Input Validation boundaries
+- Sensitive Data Handling policy
+- Any items marked N/A (skip those areas)
+
+### 2. Principles Compliance Check
+For each principle in coding-rules Security section, verify the implementation:
+- Secure Defaults: credentials management, query construction, cryptographic usage, random generation
+- Input and Output Boundaries: input validation at entry points, output encoding, error response content
+- Access Control: authentication on entry points, authorization on resource access, permission scope
+
+### 3. Pattern Detection
+Execute detection patterns from `references/security-checks.md`:
+- Search implementation files for each Stable Pattern
+- Search for each Trend-Sensitive Pattern
+- Record matches with file path and line number
+
+### 4. Trend Check
+Search for recent security advisories related to the detected technology stack (language, framework, major dependencies). Incorporate relevant findings into the review. If search returns no actionable results, proceed with the patterns from references/security-checks.md.
+
+### 5. Findings Consolidation and Classification
+Consolidate all findings, remove duplicates, and classify each finding into one of the following categories:
+
+| Category | Definition | Examples |
+|----------|-----------|----------|
+| **confirmed_risk** | An attack surface is present in the implementation as-is | Missing authentication on endpoint, arbitrary file access, SQL injection via string concatenation |
+| **defense_gap** | Not immediately exploitable, but a defensive layer is thin or absent | Runtime type validation missing (framework may catch it), unnecessary capability enabled |
+| **hardening** | Improvement to reduce attack surface or exposure | Reducing log verbosity, tightening error response content |
+| **policy** | Organizational or operational practice concern | Dependency version pinning strategy, CI security scanning coverage |
+
+For each finding, evaluate whether it represents an actual risk given the project's runtime environment, framework protections, and existing mitigations. Discard false positives.
+
+### Category-Specific Rationale (required per finding)
+
+Each finding must include a `rationale` field whose content depends on the category:
+
+| Category | Rationale must explain |
+|----------|----------------------|
+| **confirmed_risk** | Why the attack surface is exploitable as-is |
+| **defense_gap** | What defensive layer is being relied upon, and why it may be insufficient |
+| **hardening** | Why the current state is acceptable, and what improvement would add |
+| **policy** | Why this is not a technical vulnerability (what mitigates the technical risk) |
+
+## Output Format
+
+```json
+{
+  "status": "approved|approved_with_notes|needs_revision|blocked",
+  "summary": "[1-2 sentence summary]",
+  "filesReviewed": 5,
+  "findings": [
+    {
+      "category": "confirmed_risk|defense_gap|hardening|policy",
+      "confidence": "high|medium|low",
+      "location": "[file:line]",
+      "description": "[specific issue found]",
+      "rationale": "[category-specific, see Category-Specific Rationale]",
+      "suggestion": "[specific fix]"
+    }
+  ],
+  "notes": "[summary of hardening/policy findings for completion report, present when status is approved_with_notes]",
+  "requiredFixes": [
+    "[specific fix 1 — only confirmed_risk and qualifying defense_gap items]"
+  ]
+}
+```
+
+## Status Determination
+
+### blocked
+- Credentials, API keys, or tokens found in committed code
+- High-confidence confirmed_risk that enables direct exploitation (missing authentication on public endpoint, arbitrary file access)
+- Escalate immediately with finding details — requires human intervention
+
+### needs_revision
+- One or more confirmed_risk findings
+- Multiple defense_gap findings that affect primary input boundaries
+- `requiredFixes` lists only confirmed_risk and qualifying defense_gap items
+
+### approved_with_notes
+- Findings are limited to hardening and/or policy categories
+- Or defense_gap findings exist but are isolated and do not affect primary input boundaries
+- Notes are included in the completion report for awareness
+
+### approved
+- No meaningful findings after consolidation
+
+## Quality Checklist
+
+- [ ] Design Doc Security Considerations extracted and each item verified
+- [ ] Each Security section subsection checked against implementation
+- [ ] All Stable Patterns from security-checks.md searched
+- [ ] All Trend-Sensitive Patterns from security-checks.md searched
+- [ ] Technology stack trend check performed
+- [ ] Each finding classified into confirmed_risk / defense_gap / hardening / policy
+- [ ] False positives excluded considering runtime environment and existing mitigations
+- [ ] Committed secrets checked (blocked status if found)
+
+## Completion Gate [BLOCKING]
+
+☐ All completion criteria met with evidence
+☐ Output format validated (JSON with status and findings)
+☐ Quality standards satisfied (quality checklist fully checked)
+
+**ENFORCEMENT**: HALT if any gate unchecked. Return incomplete status to caller.
+"""
+
+[[skills.config]]
+path = ".agents/skills/coding-rules/SKILL.md"
+enabled = true

--- a/.codex/agents/task-executor-frontend.toml
+++ b/.codex/agents/task-executor-frontend.toml
@@ -191,6 +191,10 @@ Examples: `docs/plans/analysis/component-research.md`, `docs/plans/analysis/api-
 
 ## Structured Response Specification
 
+### Field Specifications
+
+**requiresTestReview**: Set to `true` when the task added or updated integration tests or E2E tests. Set to `false` for unit-test-only tasks or tasks with no tests.
+
 ### 1. Task Completion Response
 Report in the following JSON format upon task completion (**without executing quality checks or commits**, delegating to quality assurance process):
 
@@ -201,6 +205,7 @@ Report in the following JSON format upon task completion (**without executing qu
   "changeSummary": "[Specific summary of React component implementation/changes]",
   "filesModified": ["src/components/Button/Button.tsx", "src/components/Button/index.ts"],
   "testsAdded": ["src/components/Button/Button.test.tsx"],
+  "requiresTestReview": false,
   "newTestsPassed": true,
   "progressUpdated": {
     "taskFile": "5/8 items completed",

--- a/.codex/agents/task-executor.toml
+++ b/.codex/agents/task-executor.toml
@@ -192,6 +192,10 @@ Examples: `docs/plans/analysis/research-results.md`, `docs/plans/analysis/api-sp
 
 ## Structured Response Specification
 
+### Field Specifications
+
+**requiresTestReview**: Set to `true` when the task added or updated integration tests or E2E tests. Set to `false` for unit-test-only tasks or tasks with no tests.
+
 ### 1. Task Completion Response
 Report in the following JSON format upon task completion (**without executing quality checks or commits**, delegating to quality assurance process):
 
@@ -202,6 +206,7 @@ Report in the following JSON format upon task completion (**without executing qu
   "changeSummary": "[Specific summary of implementation content/changes]",
   "filesModified": ["specific/file/path1", "specific/file/path2"],
   "testsAdded": ["created/test/file/path"],
+  "requiresTestReview": true,
   "newTestsPassed": true,
   "progressUpdated": {
     "taskFile": "5/8 items completed",

--- a/.codex/agents/work-planner.toml
+++ b/.codex/agents/work-planner.toml
@@ -34,41 +34,41 @@ Skill Status:
 
 **Progress Tracking**: Track your work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update progress upon completion.
 
-## Main Responsibilities
+## Planning Process
 
-1. Identify and structure implementation tasks
-2. Clarify task dependencies
-3. Phase division and prioritization
-4. Define completion criteria for each task (derived from Design Doc acceptance criteria)
-5. **Define operational verification procedures for each phase**
-6. Concretize risks and countermeasures
-7. Document in progress-trackable format
+### 1. Load Input Documents
+Read the Design Doc(s), UI Spec, PRD, and ADR (if provided). Extract:
+- Acceptance criteria and implementation approach
+- Technical dependencies and implementation order
+- Integration points requiring E2E verification
 
-## Required Information
+### 2. Process Test Design Information (when provided)
+Read test skeleton files and extract meta information (see Test Design Information Processing section).
 
-Required input (in natural language):
+### 3. Select Implementation Strategy
+Choose Strategy A (TDD) if test skeletons are provided, Strategy B (implementation-first) otherwise. See Implementation Strategy Selection section.
 
-- **Operation Mode**:
-  - `create`: New creation (default)
-  - `update`: Update existing plan
+### 4. Compose Phases
+Structure phases based on technical dependencies from Design Doc:
+- Place tasks with lowest dependencies in earlier phases
+- Include operational verification at integration points
+- Include quality assurance in final phase
 
-- **Requirements Analysis Results**: Requirements analysis results (scale determination, technical requirements, etc.)
-- **PRD**: PRD document (if created)
-- **ADR**: ADR document (if created)
-- **Design Doc(s)**: Design Doc document(s) (if created, may be multiple for cross-layer features)
-- **Test Design Information** (reflect in plan if provided from previous process):
-  - Test definition file path
-  - Test case descriptions (it.todo format, etc.)
-  - Meta information (@category, @dependency, @complexity, etc.)
-- **Current Codebase Information**:
-  - List of affected files
-  - Current test coverage
-  - Dependencies
+### 5. Define Tasks with Completion Criteria
+For each task, derive completion criteria from Design Doc acceptance criteria. Apply the 3-element completion definition (Implementation Complete, Quality Complete, Integration Complete).
 
-- **Update Context** (update mode only):
-  - Path to existing plan
-  - Reason for changes
-  - Tasks needing addition/modification
+### 6. Produce Work Plan Document
+Write the work plan following the plan template from documentation-criteria skill. Include Phase Structure Diagram and Task Dependency Diagram (mermaid).
+
+## Input Parameters
+
+- **mode**: `create` (default) | `update`
+- **designDoc**: Path to Design Doc(s) (may be multiple for cross-layer features)
+- **uiSpec** (optional): Path to UI Specification (frontend/fullstack features)
+- **prd** (optional): Path to PRD document
+- **adr** (optional): Path to ADR document
+- **testSkeletons** (optional): Paths to integration/E2E test skeleton files from acceptance-test-generator
+- **updateContext** (update mode only): Path to existing plan, reason for changes
 
 ## Work Plan Output Format
 

--- a/.codex/agents/work-planner.toml
+++ b/.codex/agents/work-planner.toml
@@ -34,7 +34,27 @@ Skill Status:
 
 **Progress Tracking**: Track your work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update progress upon completion.
 
-## Planning Process
+## Main Responsibilities
+
+1. Identify and structure implementation tasks
+2. Clarify task dependencies
+3. Phase division and prioritization
+4. Define completion criteria for each task (derived from Design Doc acceptance criteria)
+5. Define operational verification procedures for each phase
+6. Concretize risks and countermeasures
+7. Document in progress-trackable format
+
+## Input Parameters
+
+- **mode**: `create` (default) | `update`
+- **designDoc**: Path to Design Doc(s) (may be multiple for cross-layer features)
+- **uiSpec** (optional): Path to UI Specification (frontend/fullstack features)
+- **prd** (optional): Path to PRD document
+- **adr** (optional): Path to ADR document
+- **testSkeletons** (optional): Paths to integration/E2E test skeleton files from acceptance-test-generator
+- **updateContext** (update mode only): Path to existing plan, reason for changes
+
+## Workflow
 
 ### 1. Load Input Documents
 Read the Design Doc(s), UI Spec, PRD, and ADR (if provided). Extract:
@@ -59,16 +79,6 @@ For each task, derive completion criteria from Design Doc acceptance criteria. A
 
 ### 6. Produce Work Plan Document
 Write the work plan following the plan template from documentation-criteria skill. Include Phase Structure Diagram and Task Dependency Diagram (mermaid).
-
-## Input Parameters
-
-- **mode**: `create` (default) | `update`
-- **designDoc**: Path to Design Doc(s) (may be multiple for cross-layer features)
-- **uiSpec** (optional): Path to UI Specification (frontend/fullstack features)
-- **prd** (optional): Path to PRD document
-- **adr** (optional): Path to ADR document
-- **testSkeletons** (optional): Paths to integration/E2E test skeleton files from acceptance-test-generator
-- **updateContext** (update mode only): Path to existing plan, reason for changes
 
 ## Work Plan Output Format
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Invoke recipes with `$recipe-name` in Codex. Type `$recipe-` and use tab complet
 | `$recipe-design` | Requirements → ADR/Design Doc | Architecture planning |
 | `$recipe-plan` | Design Doc → test skeletons → work plan | Planning phase |
 | `$recipe-build` | Execute backend tasks autonomously | Resume backend implementation |
-| `$recipe-review` | Design Doc compliance validation with auto-fixes | Post-implementation check |
+| `$recipe-review` | Design Doc compliance and security validation with auto-fixes | Post-implementation check |
 | `$recipe-diagnose` | Problem investigation → verification → solution | Bug investigation |
 | `$recipe-reverse-engineer` | Generate PRD + Design Docs from existing code | Legacy system documentation |
 | `$recipe-add-integration-tests` | Add integration/E2E tests from Design Doc | Test coverage for existing code |
@@ -157,7 +157,7 @@ Invoke recipes with `$recipe-name` in Codex. Type `$recipe-` and use tab complet
 | `$recipe-front-design` | Requirements → UI Spec → frontend Design Doc | Frontend architecture planning |
 | `$recipe-front-plan` | Frontend Design Doc → test skeletons → work plan | Frontend planning phase |
 | `$recipe-front-build` | Execute frontend tasks with RTL + quality checks | Resume frontend implementation |
-| `$recipe-front-review` | Frontend compliance validation with React-specific fixes | Frontend post-implementation check |
+| `$recipe-front-review` | Frontend compliance and security validation with React-specific fixes | Frontend post-implementation check |
 
 ### Fullstack (Cross-Layer)
 
@@ -244,6 +244,7 @@ Codex spawns these as needed during recipe execution. Each agent runs in its own
 |-------|------|
 | `code-reviewer` | Design Doc compliance validation |
 | `code-verifier` | Document-code consistency verification |
+| `security-reviewer` | Security compliance review after implementation |
 | `rule-advisor` | Skill selection via metacognitive analysis |
 | `scope-discoverer` | Codebase scope discovery for reverse docs |
 
@@ -316,7 +317,7 @@ your-project/
 │   ├── requirement-analyzer.toml
 │   ├── technical-designer.toml
 │   ├── task-executor.toml
-│   └── ... (22 agents total)
+│   └── ... (23 agents total)
 └── docs/                     # Created as you use the recipes
     ├── prd/
     ├── design/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

- Add **security-reviewer** agent with 4-category finding classification (`confirmed_risk`, `defense_gap`, `hardening`, `policy`) and structured rationale to reduce false positives
- Expand **coding-rules** Security section with positive, actionable instructions (Secure Defaults, Input/Output Boundaries, Access Control) and knowledge cutoff supplement
- Add **security-checks.md** reference with stable detection patterns (hardcoded secrets, SQL injection, path traversal, etc.) and trend-sensitive patterns (OWASP 2025, AI-generated code gaps)
- Integrate security review into **all implementation recipes** (recipe-build, recipe-front-build, recipe-fullstack-build, recipe-fullstack-implement, recipe-implement) — runs after all tasks complete, before completion report
- Integrate security review into **all review recipes** (recipe-review, recipe-front-review) — runs alongside code compliance validation
- Extend **orchestration vocabulary** with `approved_with_notes` and `blocked` statuses scoped to security-reviewer, with explicit handling rules
- Add **requiresTestReview** field to task-executor structured responses, replacing filename-pattern matching for integration-test-reviewer triggering
- Rewrite **code-reviewer**, **requirement-analyzer**, **work-planner** from checklist format to actionable verification pipelines with Input Parameters sections
- Specify **filesModified collection** strategy for security-reviewer input across all recipes (build: collect from executor responses; review: union of git diff + fix filesModified)

## Test plan

- [ ] Verify security-reviewer agent loads skills correctly via `[[skills.config]]`
- [ ] Run recipe-review against a project with Design Doc — confirm both code-reviewer and security-reviewer are invoked
- [ ] Verify `requiresTestReview` field appears in task-executor structured response
- [ ] Confirm orchestration vocabulary table includes all 7 statuses with Scope column
- [ ] Verify recipe-front-build Structured Response Specification lists `requiresTestReview`
- [ ] Check README and openai.yaml descriptions reflect security review capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)