### PR TITLE
Generalize language-specific terminology

### DIFF
--- a/.agents/skills/coding-rules/references/security-checks.md
+++ b/.agents/skills/coding-rules/references/security-checks.md
@@ -14,17 +14,17 @@ These patterns have low false-positive rates and are detectable through grep or 
 
 ### SQL String Concatenation
 - SQL statements constructed through string concatenation or interpolation with variables
-- Detection approach: search for SQL keywords (`SELECT`, `INSERT`, `UPDATE`, `DELETE`) combined with string concatenation operators or template literals containing variable references
+- Detection approach: search for SQL keywords (`SELECT`, `INSERT`, `UPDATE`, `DELETE`) combined with string concatenation operators or string interpolation containing variable references
 
 ### Dynamic Code Execution
-- Use of `eval()`, `Function()`, `exec()`, `compile()` with dynamic input
-- Dynamic import or require with variable paths
-- Detection approach: search for these function calls where the argument is not a static literal
+- Use of dynamic code execution functions (e.g., `eval`, `exec`) with non-static input
+- Dynamic module loading with variable paths
+- Detection approach: search for dynamic code execution or module loading calls where the argument is not a static literal
 
 ### Insecure Deserialization
-- `pickle.loads()`, `yaml.load()` without SafeLoader, `marshal.loads()` with untrusted input
-- `JSON.parse()` followed by direct use in `eval()` or `Function()`
-- Detection approach: search for deserialization calls that accept external input without safe loader configuration
+- Deserialization of untrusted input using unsafe loaders or formats that allow arbitrary object construction (e.g., native serialization, YAML without safe loader)
+- Parsed data passed directly into dynamic code execution
+- Detection approach: search for deserialization calls that accept external input without safe loader or type-restricted configuration
 
 ### Path Traversal
 - File system paths constructed from user-supplied input without sanitization

--- a/.agents/skills/documentation-criteria/references/design-template.md
+++ b/.agents/skills/documentation-criteria/references/design-template.md
@@ -179,12 +179,12 @@ No Ripple Effect:
 
 ```yaml
 Input:
-  Type: [Type/interface definition]
+  Type: [Data shape, contract, or schema]
   Preconditions: [Required items, format constraints]
   Validation: [Validation method]
 
 Output:
-  Type: [Type/interface definition]
+  Type: [Data shape, contract, or schema]
   Guarantees: [Conditions that must always be met]
   On Error: [Exception/null/default value]
 

--- a/.codex/agents/code-verifier.toml
+++ b/.codex/agents/code-verifier.toml
@@ -78,7 +78,7 @@ Document modification and solution proposals are out of scope for this agent.
 | Implementation | 1 | Direct code implementing the claim |
 | Tests | 2 | Test cases verifying expected behavior |
 | Config | 3 | Configuration files, environment variables |
-| Types | 4 | Type definitions, interfaces, schemas |
+| Types & Contracts | 4 | Type definitions, schemas, API contracts |
 
 MUST collect from at least 2 sources before classifying. Single-source findings MUST be marked with lower confidence.
 

--- a/.codex/agents/design-sync.toml
+++ b/.codex/agents/design-sync.toml
@@ -185,19 +185,17 @@ ENFORCEMENT: sync_status MUST be one of: CONFLICTS_FOUND | NO_CONFLICTS | SKIPPE
 
 ### Type Definition Mismatch
 ```
-// Source Design Doc
-interface User {
+Source Design Doc:
+User
   id: string
   email: string
-  role: 'admin' | 'user'
-}
+  role: admin | user
 
-// Other Design Doc (conflict)
-interface User {
-  id: number        // different type
+Other Design Doc (conflict):
+User
+  id: number        # different type
   email: string
-  userRole: string  // different property name and type
-}
+  userRole: string  # different property name and type
 ```
 
 ### Numeric Parameter Mismatch

--- a/.codex/agents/quality-fixer.toml
+++ b/.codex/agents/quality-fixer.toml
@@ -221,7 +221,7 @@ MUST follow these principles to maintain high-quality code:
 
 **Required Fix Approaches**:
 - Test failures → Fix implementation or test logic to pass genuinely
-- Type errors → Add proper types or type guards with explicit typing
+- Type/contract errors → Fix type mismatches or interface/contract violations at their source
 - Errors → Log with context or propagate with error chain
 - Safety warnings → Address root cause directly
 

--- a/.codex/agents/scope-discoverer.toml
+++ b/.codex/agents/scope-discoverer.toml
@@ -87,7 +87,7 @@ Explore the codebase from both user-value and technical perspectives simultaneou
 | Test Files | 2 | User-value | E2E tests, integration tests (often named by feature) |
 | User-facing Components | 3 | User-value | Pages, screens, major UI components |
 | Module Structure | 4 | Technical | Service classes, controllers, repositories |
-| Interface Definitions | 5 | Technical | Public APIs, exported functions, type definitions |
+| Public Interfaces | 5 | Technical | Public APIs, exported functions, data shapes/schemas |
 | Dependency Graph | 6 | Technical | Import/export relationships, DI configurations |
 | Directory Structure | 7 | Both | Feature-based directories, domain directories |
 | Data Flow | 8 | Technical | Data transformations, state management |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- generalize language-specific wording in language-agnostic agent and skill files
- replace TypeScript-oriented examples and terms with broader contract or data-shape language where appropriate
- make security check guidance less tied to specific languages or runtime APIs

## Testing
- not run (documentation-only changes)