### PR TITLE
Bump minimum Node.js to 22 and release 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",
@@ -30,6 +30,6 @@
   ],
   "homepage": "https://github.com/shinpr/codex-workflows#readme",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Raise `engines.node` from `>=20.0.0` to `>=22.0.0` — Node 20 EOL is April 2026
- Bump version `0.2.5` → `0.3.0` (breaking environment change under 0.x semver)

## Test plan
- [x] Verified `node bin/cli.js --help` runs without errors on Node 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)