### PR TITLE
Refine orchestration and recipe instructions

### DIFF
--- a/.agents/skills/recipe-build/SKILL.md
+++ b/.agents/skills/recipe-build/SKILL.md
@@ -90,7 +90,7 @@ ENFORCEMENT: Proceeding past a failed quality gate invalidates all subsequent wo
 **MANDATORY suffix for ALL sub-agent prompts**:
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within build skill scope. Use orchestrator-provided rules only.
+This agent operates within build skill scope. Use the task file as the primary instruction source. Use the active Design Doc or work plan only as supporting context when the task file references them. Constraints explicitly passed in this prompt by the orchestrator take precedence over supporting context. The agent's own role contract and required quality rules remain in force.
 ```
 
 Autonomous sub-agents require scope constraints for stable execution. MUST append this constraint to every sub-agent prompt.

--- a/.agents/skills/recipe-design/SKILL.md
+++ b/.agents/skills/recipe-design/SKILL.md
@@ -17,8 +17,9 @@ description: "Execute from requirement analysis to design document creation."
 
 **Execution Protocol**:
 1. **Spawn agents for all work** -- your role is to invoke sub-agents, pass data between them, and report results
-2. **Follow subagents-orchestration-guide skill design flow exactly**:
-   - Execute: requirement-analyzer -> technical-designer -> document-reviewer -> design-sync
+2. **Follow the design flow defined in subagents-orchestration-guide**:
+   - Apply the scale-specific and layer-specific branches defined there, including PRD, ADR, and UI Spec steps when required
+   - Use `requirement-analyzer -> codebase-analyzer -> technical-designer -> code-verifier -> document-reviewer -> design-sync` as the core design-document path after prerequisite branches are resolved
    - **[STOP — BLOCKING]** At every `[Stop: ...]` marker -> Present status to user for confirmation. **CANNOT proceed until user explicitly confirms.**
 3. **Scope**: Complete when design documents receive approval
 
@@ -27,10 +28,14 @@ ENFORCEMENT: Skipping any quality gate invalidates the design output.
 
 ## Workflow Overview
 
+Core design-document path after prerequisite branches such as PRD, ADR, or UI Spec are resolved:
+
 ```
 Requirements -> requirement-analyzer -> [Stop: Scale determination]
                                              |
-                                     technical-designer -> document-reviewer
+                                     codebase-analyzer
+                                             |
+                                     technical-designer -> code-verifier -> document-reviewer
                                              |
                                         design-sync -> [Stop: Design approval]
 ```
@@ -48,12 +53,7 @@ Requirements -> requirement-analyzer -> [Stop: Scale determination]
 
 Requirements: $ARGUMENTS
 
-Considering the deep impact on design, first engage in dialogue to understand the background and purpose of requirements:
-- What problems do you want to solve?
-- Expected outcomes and success criteria
-- Relationship with existing systems
-
-Once requirements are moderately clarified, analyze with requirement-analyzer and create appropriate design documents according to scale.
+Pass the user requirements directly to requirement-analyzer as the first action. If clarification is needed, handle it at the requirement-analysis stop point before proceeding.
 
 MUST clearly present design alternatives and trade-offs.
 
@@ -64,13 +64,19 @@ Execute the process below within design scope.
 ### Step 1: Requirement Analysis
 Spawn requirement-analyzer agent: "Analyze the following requirements and determine scale: $ARGUMENTS"
 
-### Step 2: Design Document Creation
-Spawn technical-designer agent: "Create design document based on requirement analysis output. Include architecture decisions, component design, and acceptance criteria."
+### Step 2: Codebase Analysis
+Spawn codebase-analyzer agent: "Analyze the existing codebase to provide evidence for Design Doc creation. requirement_analysis: [output from Step 1]. requirements: $ARGUMENTS"
 
-### Step 3: Document Review
-Spawn document-reviewer agent: "Review the design document created in the previous step. Verify completeness, consistency, and quality."
+### Step 3: Design Document Creation
+Spawn technical-designer agent: "Create design document based on requirement analysis output and codebase analysis output. Include architecture decisions, component design, and acceptance criteria."
 
-### Step 4: Consistency Verification
+### Step 4: Code Verification
+Spawn code-verifier agent: "Verify the design document against the current codebase. document_path: [output from Step 3]. doc_type: design-doc."
+
+### Step 5: Document Review
+Spawn document-reviewer agent: "Review the design document created in the previous step. Verify completeness, consistency, and quality. code_verification: [output from Step 4]"
+
+### Step 6: Consistency Verification
 Spawn design-sync agent: "Verify consistency of the design document with other existing design documents and project constraints."
 
 **Note**: design-sync returns `sync_status: "SKIPPED"` when only 1 Design Doc exists. This is distinct from `NO_CONFLICTS` and MUST be reported as such to the user.
@@ -78,7 +84,9 @@ Spawn design-sync agent: "Verify consistency of the design document with other e
 ## Completion Criteria
 
 - [ ] Spawned requirement-analyzer and determined scale
+- [ ] Spawned codebase-analyzer and passed its findings into design creation
 - [ ] Created appropriate design document (ADR or Design Doc) via technical-designer
+- [ ] Spawned code-verifier and passed its findings into document review
 - [ ] Spawned document-reviewer and addressed feedback
 - [ ] Spawned design-sync for consistency verification
 - [ ] Obtained user approval for design document

--- a/.agents/skills/recipe-front-build/SKILL.md
+++ b/.agents/skills/recipe-front-build/SKILL.md
@@ -98,7 +98,7 @@ ENFORCEMENT: Proceeding past a failed quality gate invalidates all subsequent wo
 **MANDATORY suffix for ALL sub-agent prompts**:
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within build skill scope. Use orchestrator-provided rules only.
+This agent operates within build skill scope. Use the task file as the primary instruction source. Use the active Design Doc or work plan only as supporting context when the task file references them. Constraints explicitly passed in this prompt by the orchestrator take precedence over supporting context. The agent's own role contract and required quality rules remain in force.
 ```
 
 Autonomous sub-agents require scope constraints for stable execution. MUST append this constraint to every sub-agent prompt.

--- a/.agents/skills/recipe-fullstack-build/SKILL.md
+++ b/.agents/skills/recipe-fullstack-build/SKILL.md
@@ -108,7 +108,7 @@ ENFORCEMENT: Proceeding past a failed quality gate invalidates all subsequent wo
 **MANDATORY suffix for ALL sub-agent prompts**:
 ```
 [SYSTEM CONSTRAINT]
-This agent operates within build skill scope. Use orchestrator-provided rules only.
+This agent operates within build skill scope. Use the task file as the primary instruction source. Use the active Design Docs or work plan only as supporting context when the task file references them. Constraints explicitly passed in this prompt by the orchestrator take precedence over supporting context. The agent's own role contract and required quality rules remain in force.
 ```
 
 Autonomous sub-agents require scope constraints for stable execution. MUST append this constraint to every sub-agent prompt.

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -7,9 +7,7 @@ description: "Guides subagent coordination through implementation workflows. Use
 
 ## Role: The Orchestrator
 
-**The orchestrator coordinates subagents like a conductor -- directing the musicians without playing the instruments.**
-
-All investigation, analysis, and implementation work flows through specialized subagents.
+The orchestrator coordinates subagents. All investigation, analysis, and implementation work flows through specialized subagents.
 
 ### Prompt Construction Rule
 Every subagent prompt must include:
@@ -317,18 +315,11 @@ Stop autonomous execution and escalate to user in the following cases:
 3. **Work-planner update restriction violated**: Requirement changes after task-decomposer starts require overall redesign
 4. **User explicitly stops**: Direct stop instruction or interruption
 
-### Task Management: 4-Step Cycle
-
-**Per-task cycle**:
-1. task-executor: Implementation
-2. Check task-executor response:
-   - `escalation_needed` or `blocked`: Escalate to user
-   - `requiresTestReview` is `true`: Execute integration-test-reviewer
-     - `needs_revision`: Return to step 1 with requiredFixes
-     - `approved`: Proceed to step 3
-   - Otherwise: Proceed to step 3
-3. quality-fixer: Quality check and fixes
-4. git commit (on `status: "approved"`)
+Use the task loop defined in the autonomous execution diagram above. The canonical per-task cycle is:
+1. task-executor implementation
+2. escalation or integration-test-reviewer decision
+3. quality-fixer quality gate
+4. git commit on approval
 
 ## Main Orchestrator Roles
 
@@ -379,7 +370,7 @@ The resulting work plan must include this summary in its header so the plan rema
 - **Structured response REQUIRED**: Information transmission between subagents MUST use JSON format
 - **Approval management**: Document creation -> Execute document-reviewer -> Get user approval before proceeding
 - **Flow confirmation**: After getting approval, MUST check next step with work planning flow (large/medium/small scale)
-- **Consistency verification**: If subagent determinations contradict, MUST prioritize guidelines
+- **Consistency verification**: If subagent determinations contradict, MUST prioritize the constraints and decision rules defined in this orchestration guide
 
 **ENFORCEMENT**: Violating ANY constraint requires immediate correction
 
@@ -394,9 +385,9 @@ The resulting work plan must include this summary in its header so the plan rema
 
 When receiving a task, check the following:
 
-- [ ] Confirmed if there is an orchestrator instruction
+- [ ] Confirmed whether the user provided a specific workflow recipe or explicit execution constraint
 - [ ] Determined task type (new feature/fix/research, etc.)
-- [ ] Considered appropriate subagent utilization
+- [ ] Selected the next subagent according to the decision flow and current phase
 - [ ] Decided next action according to decision flow
 - [ ] Monitored requirement changes and errors during autonomous execution mode
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
This change tightens orchestration and recipe guidance to reduce ambiguity during multi-agent execution.

The focus is to make workflow routing, task-cycle interpretation, and recipe-specific execution boundaries more explicit without introducing new workflow concepts.

## What changed
- clarifies ambiguous orchestration language in `subagents-orchestration-guide`
- removes a redundant per-task-cycle restatement and keeps a single canonical task-loop definition
- makes action checklist items more concrete and evaluable
- aligns `recipe-design` with the canonical design flow by including codebase analysis and code verification
- updates build recipe prompt constraints to define instruction priority more clearly
- bumps the package patch version to `0.4.1`

## Why
Several orchestration and recipe instructions were valid in intent but still left room for conflicting interpretations, especially around:
- when a recipe should follow the orchestration flow versus a local shorthand
- which inputs a build-oriented subagent should treat as primary versus supporting context
- how to interpret the per-task cycle consistently across orchestration and execution recipes

This PR narrows those gaps so the instructions are easier to execute consistently.

## Testing
- `git diff --check`