### PR TITLE
Align README Node.js requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Existing code → scope-discoverer (discoveredUnits + prdUnits) → prd-creator 
 ### Requirements
 
 - [Codex CLI](https://developers.openai.com/codex/cli) (latest)
-- Node.js >= 20
+- Node.js >= 22
 
 ### Install
 


### PR DESCRIPTION
## Summary
- update the README installation requirements to match the actual Node.js engine constraint

## Details
- change the documented Node.js requirement from `>= 20` to `>= 22`
- keep the installation instructions aligned with `package.json`

## Validation
- `git diff --check`