### PR TITLE
Add a README note for linear-prism integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,14 @@ your-project/
 
 ---
 
+## Works With
+
+If your requirements already live in Linear or an existing PRD, [linear-prism](https://github.com/shinpr/linear-prism) can decompose them into implementation-ready tasks by reading the codebase, making dependencies explicit, and preserving Design Doc boundaries.
+
+Those tasks can then be passed into `$recipe-design` to enter the design phase with clearer scope and better task visibility.
+
+---
+
 ## FAQ
 
 **Q: What models does this work with?**


### PR DESCRIPTION
## Summary
- add a small "Works With" section to the README
- mention `linear-prism` as an upstream tool for decomposing requirements from Linear or an existing PRD
- clarify that its output can feed into `$recipe-design` for the design phase

## Why
`linear-prism` is not a core part of `codex-workflows`, but it connects naturally to the workflow described here. A brief note makes that integration path visible without changing the main positioning of the project.

## Testing
- not run (README-only change)
