### PR TITLE
Improve UI spec template clarity and AC traceability

### DIFF
--- a/.agents/skills/documentation-criteria/SKILL.md
+++ b/.agents/skills/documentation-criteria/SKILL.md
@@ -53,7 +53,7 @@ description: "Documentation creation criteria for PRD, ADR, Design Doc, UI Spec,
 
 ### PRD (Product Requirements Document)
 **Purpose**: Define business requirements and user value
-**Scope**: Business requirements, user value, success metrics, user stories, MoSCoW prioritization, MVP/Future phase separation, user journey diagram, and scope boundary diagram only. Technical implementation details belong in Design Doc, technical decision rationale in ADR, and implementation phases or task breakdown belong in Work Plan.
+**Scope**: Business requirements, user value, success metrics, user stories, MoSCoW prioritization, MVP/Future phase separation, user journey diagram, scope boundary diagram, and acceptance criteria with sequential IDs (for example `AC-001`, `AC-002`, continuing across all requirements in the document) only. Technical implementation details belong in Design Doc, technical decision rationale in ADR, and implementation phases or task breakdown belong in Work Plan.
 
 ### ADR (Architecture Decision Record)
 **Purpose**: Record technical decision rationale and background

--- a/.agents/skills/documentation-criteria/references/prd-template.md
+++ b/.agents/skills/documentation-criteria/references/prd-template.md
@@ -29,15 +29,18 @@ So that [expected value/benefit]
 
 ### Must Have (MVP)
 - [ ] Requirement 1: [Detailed description]
-  - AC: [Acceptance criteria - Given/When/Then format or measurable standard]
+  - AC-001: [Acceptance criteria - Given/When/Then format or measurable standard]
+  - AC-002: [Acceptance criteria]
 - [ ] Requirement 2: [Detailed description]
-  - AC: [Acceptance criteria]
+  - AC-003: [Acceptance criteria]
 - [ ] Requirement 3: [Detailed description]
-  - AC: [Acceptance criteria]
+  - AC-004: [Acceptance criteria]
 
 ### Nice to Have
 - [ ] Requirement 1: [Detailed description]
+  - AC-005: [Acceptance criteria - continue numbering across all requirements]
 - [ ] Requirement 2: [Detailed description]
+  - AC-006: [Acceptance criteria]
 
 ### Out of Scope
 - Item 1: [Description and reason]

--- a/.agents/skills/documentation-criteria/references/ui-spec-template.md
+++ b/.agents/skills/documentation-criteria/references/ui-spec-template.md
@@ -28,7 +28,7 @@ Map PRD acceptance criteria to prototype references. Skip this section if no pro
 
 | AC ID | AC Summary | Screen / State | Prototype Reference (element ID / path) | Adoption Decision |
 |-------|-----------|----------------|----------------------------------------|-------------------|
-| AC-01 | [EARS AC summary] | [Screen / state name] | [element or file reference] | Adopted / Not adopted / On hold |
+| AC-001 | [EARS AC summary] | [Screen / state name] | [element or file reference] | Adopted / Not adopted / On hold |
 
 ## Screen List and Transitions
 
@@ -61,15 +61,19 @@ Map PRD acceptance criteria to prototype references. Skip this section if no pro
 
 #### State x Display Matrix
 
-| State | Default | Loading | Empty | Error | Partial |
-|-------|---------|---------|-------|-------|---------|
-| Display | [Normal display] | [Skeleton / spinner] | [Empty state + CTA] | [Error message + recovery action] | [Cached / partial display] |
+List only states that actually exist for this component. Remove unused rows. Include fallback or degraded states only when explicitly required by the PRD or existing behavior.
+
+| State | Trigger / Condition | Display | Recovery / Notes |
+|-------|---------------------|---------|------------------|
+| Default | [Initial or ready condition] | [Normal display] | [Notes if needed] |
+| Loading | [Data or action in progress] | [e.g., skeleton matching final layout] | [Cancellation, timeout, or transition notes if relevant] |
+| Error | [Failure condition] | [e.g., inline `Alert` + "Retry"] | [Recovery action required by product behavior] |
 
 #### Interaction Definition
 
 | AC ID | EARS Condition | User Action | System Response | State Transition | Error Handling |
 |-------|---------------|-------------|-----------------|-----------------|----------------|
-| AC-01 | When [trigger] | [Click / input / etc.] | [Expected behavior] | [From state -> To state] | [Retry / Reset / Fallback] |
+| AC-001 | When [trigger] | [Click / input / etc.] | [Expected behavior] | [From state -> To state] | [Retry / Reset / Explicitly defined degraded behavior if any] |
 
 ### Component: [ComponentName2]
 
@@ -79,8 +83,15 @@ Map PRD acceptance criteria to prototype references. Skip this section if no pro
 
 ### Environment Constraints
 - Target browsers: [e.g., Chrome 120+, Safari 17+]
-- Responsive breakpoints: [e.g., 768px, 1024px, 1280px]
 - Theme support: [e.g., light/dark, system preference]
+
+#### Responsive Behavior
+
+| Breakpoint | Width | Key Changes |
+|-----------|-------|-------------|
+| Mobile | [e.g., < 768px] | [e.g., single-column layout, compact navigation, reduced non-critical detail] |
+| Tablet | [e.g., 768px - 1023px] | [e.g., two-column layout, condensed sidebar, larger touch targets] |
+| Desktop | [e.g., >= 1024px] | [e.g., full layout, persistent navigation, expanded comparison views] |
 
 ### Existing Component Reuse Map
 
@@ -90,12 +101,42 @@ Map PRD acceptance criteria to prototype references. Skip this section if no pro
 | [DataTable] | Extend | [components/ui/Table] | [Add sorting support] |
 | [FeatureCard] | New | - | [No similar component exists] |
 
-### Design Tokens
+### Design Tokens (include only when existing tokens must be referenced or a new visual system must be defined)
+
+Prefer existing design-system tokens, theme variables, or component-library primitives. If the project does not define tokens at this level, replace this section with a short note such as `N/A - existing component library styles are used without new token definitions`. If the entire Design Tokens section is `N/A`, skip all subsections below.
+
+#### Color Roles
+
+Remove unused subsections and rows. Do not invent token names or values that are not supported by the codebase, design system, or approved design direction.
+
+| Role | Token | Value | Usage |
+|------|-------|-------|-------|
+| Background Surface | [existing token] | [actual value if defined] | [Page or container background] |
+| Brand / Accent | [existing token] | [actual value if defined] | [Primary actions and emphasis] |
+
+#### Typography Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing |
+|------|------|------|--------|-------------|----------------|
+| Body | [existing token or family] | [actual size if defined] | [actual weight if defined] | [actual line height if defined] | [actual letter spacing if defined] |
+
+#### Spacing Scale
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| [color-primary] | [value] | [Primary actions] |
-| [spacing-md] | [value] | [Component spacing] |
+| [existing token] | [actual value if defined] | [Relevant spacing usage] |
+
+#### Elevation
+
+| Level | Treatment | Usage |
+|-------|-----------|-------|
+| [Relevant level] | [actual token or shadow treatment if defined] | [Where it is used] |
+
+#### Border Radius Scale
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| [existing token] | [actual value if defined] | [Relevant usage] |
 
 ## Visual Acceptance
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- improve PRD acceptance-criteria traceability with sequential AC IDs across the document
- refine the UI Spec template so state definitions only capture real states and degraded behavior is explicitly requirement-driven
- make design token documentation conditional and grounded in existing design-system tokens instead of invented values
- add responsive behavior guidance and bump the package version to `0.4.6`

## Why
The current templates leave too much room for ambiguous output in design-related documents. This change makes UI planning artifacts more concrete where structure helps, while reducing pressure to invent states or token values that do not exist in the product.

## Testing
- Not run (template and version updates only)