### PR TITLE
Add QA mechanism propagation to workflow instructions

### DIFF
--- a/.agents/skills/ai-development-guide/SKILL.md
+++ b/.agents/skills/ai-development-guide/SKILL.md
@@ -131,13 +131,14 @@ How to handle duplicate code based on Martin Fowler's "Refactoring":
 - For low certainty cases, create minimal verification code first
 
 ### Pattern 5: Insufficient Existing Code Investigation
-**Symptom**: Duplicate implementations, architecture inconsistency, integration failures
-**Cause**: Insufficient understanding of existing code before implementation
+**Symptom**: Duplicate implementations, architecture inconsistency, integration failures, adopting outdated patterns
+**Cause**: Insufficient understanding of existing code before implementation; referencing only nearby files without checking representativeness
 **Avoidance**:
 - Before implementation, always search for similar functionality
 - Similar functionality found: Use that implementation (do not create new)
 - Similar functionality is technical debt: Create ADR improvement proposal
 - No similar functionality: Implement following existing design philosophy
+- When adopting a pattern or dependency from nearby code, verify it is representative across the repository before adopting it
 
 ## Debugging Techniques
 
@@ -174,6 +175,15 @@ Pattern: Structured logging with context
   timestamp: current_time_ISO8601
 }
 ```
+
+## Quality Assurance Mechanism Awareness
+
+Before executing quality checks, discover applicable quality tools and constraints by inspecting the affected files' types, project manifests, CI pipelines, and configuration:
+- Primary detection: inspect affected file types, manifests, configuration, and CI pipelines to identify applicable quality tools
+- Check for domain-specific linters or validators such as schema validators, API spec validators, or configuration-file checkers
+- Check for domain-specific constraints in project configuration such as naming rules, length limits, or format requirements
+- When a task file lists `Quality Assurance Mechanisms`, use that section as supplementary guidance for what to verify
+- Include discovered domain-specific checks alongside the standard quality phases below
 
 ## Quality Check Workflow [MANDATORY]
 

--- a/.agents/skills/coding-rules/SKILL.md
+++ b/.agents/skills/coding-rules/SKILL.md
@@ -51,6 +51,21 @@ For language-specific rules, also read:
 - Depend on abstractions, not concrete implementations
 - Minimize inter-module dependencies
 
+## Reference Representativeness
+
+### Verifying References Before Adoption
+
+When adopting patterns, APIs, or dependencies from existing code:
+- If referencing only nearby files, verify the pattern is representative across the repository before adopting it
+- If multiple approaches coexist, identify the majority pattern and make a deliberate choice
+- If adopting an external dependency, verify repository-wide usage distribution for that dependency and its version
+- If repository evidence is insufficient to choose an appropriate dependency version, escalate instead of guessing
+- If following an existing pattern when alternatives exist, state the reason for following it
+
+### Principle
+
+Nearby code is a starting point for investigation, not a sufficient basis for adoption. Confirm that the reference is representative of repository conventions before using it as the model.
+
 ## Performance
 
 - **Measure first**: Profile before optimizing — no premature optimization

--- a/.agents/skills/documentation-criteria/references/design-template.md
+++ b/.agents/skills/documentation-criteria/references/design-template.md
@@ -52,6 +52,12 @@ unknowns:
 - [ ] [Standard/convention] `[explicit]` - Source: [config / rule file / documentation path]
 - [ ] [Observed pattern] `[implicit]` - Evidence: [file paths] - Confirmed: [Yes/No]
 
+#### Quality Assurance Mechanisms
+How quality is enforced in the change area. Each item is either adopted for this change or noted with a reason.
+
+- [ ] [Tool/check name] — Enforces: [what] — Config: [path] — Covers: [file paths/patterns or "project-wide"] — Status: `adopted` / `noted (reason)`
+- [ ] [Domain-specific constraint] — Enforces: [what] — Source: [path] — Covers: [file paths/patterns or "project-wide"] — Status: `adopted` / `noted (reason)`
+
 ### Problem to Solve
 
 [Specific problems or challenges this feature aims to address]

--- a/.agents/skills/documentation-criteria/references/plan-template.md
+++ b/.agents/skills/documentation-criteria/references/plan-template.md
@@ -32,6 +32,15 @@ Repeat this block for each Design Doc when multiple Design Docs exist. Preserve 
 - **Success criteria**: [extracted from Design Doc]
 - **Failure response**: [extracted from Design Doc]
 
+## Quality Assurance Mechanisms (from Design Docs)
+
+Adopted quality gates for the change area. Each task in this plan must satisfy the applicable mechanisms.
+
+| Mechanism | Enforces | Config Location | Covered Files |
+|-----------|----------|-----------------|---------------|
+| [Tool/check name] | [What quality aspect it enforces] | [path/to/config] | [file paths or patterns covered, or "project-wide"] |
+| [Domain constraint] | [What it enforces] | [path/to/source] | [file paths or patterns covered, or "project-wide"] |
+
 ## Design-to-Plan Traceability
 
 Map each Design Doc technical requirement to the task or phase that covers it. Use one row per extracted requirement item. Every row must have at least one covering task, or an explicit justified gap.

--- a/.agents/skills/documentation-criteria/references/task-template.md
+++ b/.agents/skills/documentation-criteria/references/task-template.md
@@ -37,6 +37,10 @@ Brief observations recorded after reading Investigation Targets:
 - [ ] Improve code (maintain passing tests)
 - [ ] Confirm added tests still pass
 
+## Quality Assurance Mechanisms
+(From the work plan header — include only mechanisms relevant to this task's target files)
+- [Tool/check name] — Enforces: [what] — Config: [path]
+
 ## Operation Verification Methods
 (Derived from Verification Strategy in the work plan)
 - **Verification method**: [What to verify and how]

--- a/.agents/skills/recipe-build/SKILL.md
+++ b/.agents/skills/recipe-build/SKILL.md
@@ -79,7 +79,7 @@ For EACH task, YOU MUST:
      - `needs_revision` -> Return to step 2 with `requiredFixes`
      - `approved` -> Proceed to step 4
    - `readyForQualityCheck: true` -> Proceed to step 4
-4. **Spawn quality-fixer agent**: "Execute all quality checks and fixes. Task file: [task-file-path]. filesModified: [task-executor response filesModified]. Use these files as the stub-detection scope."
+4. **Spawn quality-fixer agent**: "Execute all quality checks and fixes. Task file: [task-file-path]. The task file path above is also the `task_file` input. Read its `Quality Assurance Mechanisms` section as supplementary quality-check hints. filesModified: [task-executor response filesModified]. Use these files as the stub-detection scope."
 5. **CHECK quality-fixer response**:
    - `status: "stub_detected"` -> Return to step 2 with `stubFindings`
    - `status: "blocked"` -> STOP and escalate to user

--- a/.agents/skills/recipe-front-build/SKILL.md
+++ b/.agents/skills/recipe-front-build/SKILL.md
@@ -87,7 +87,7 @@ For EACH task, YOU MUST:
      - `needs_revision` -> Return to step 2 with `requiredFixes`
      - `approved` -> Proceed to step 4
    - `readyForQualityCheck: true` -> Proceed to step 4
-4. **Spawn quality-fixer-frontend agent**: "Execute all frontend quality checks and fixes. Task file: docs/plans/tasks/[filename].md. filesModified: [task-executor-frontend response filesModified]. Use these files as the stub-detection scope."
+4. **Spawn quality-fixer-frontend agent**: "Execute all frontend quality checks and fixes. Task file: docs/plans/tasks/[filename].md. The task file path above is also the `task_file` input. Read its `Quality Assurance Mechanisms` section as supplementary quality-check hints. filesModified: [task-executor-frontend response filesModified]. Use these files as the stub-detection scope."
 5. **CHECK quality-fixer-frontend response**:
    - `status: "stub_detected"` -> Return to step 2 with `stubFindings`
    - `status: "blocked"` -> STOP and escalate to user

--- a/.agents/skills/recipe-fullstack-build/SKILL.md
+++ b/.agents/skills/recipe-fullstack-build/SKILL.md
@@ -97,7 +97,7 @@ For EACH task, YOU MUST:
      - `needs_revision` -> Return to step 2 with `requiredFixes`
      - `approved` -> Proceed to step 4
    - `readyForQualityCheck: true` -> Proceed to step 4
-4. **Spawn quality-fixer agent** (layer-appropriate per routing table): "Execute all quality checks and fixes. Task file: [task-file-path]. filesModified: [executor response filesModified]. Use these files as the stub-detection scope."
+4. **Spawn quality-fixer agent** (layer-appropriate per routing table): "Execute all quality checks and fixes. Task file: [task-file-path]. The task file path above is also the `task_file` input. Read its `Quality Assurance Mechanisms` section as supplementary quality-check hints. filesModified: [executor response filesModified]. Use these files as the stub-detection scope."
 5. **CHECK quality-fixer response**:
    - `status: "stub_detected"` -> Return to step 2 with `stubFindings`
    - `status: "blocked"` -> STOP and escalate to user

--- a/.agents/skills/recipe-fullstack-implement/SKILL.md
+++ b/.agents/skills/recipe-fullstack-implement/SKILL.md
@@ -124,7 +124,7 @@ ENFORCEMENT: Sub-agent prompts missing the constraint suffix MUST be re-issued w
 **Rules**:
 1. Execute ONE task completely before starting next (each task goes through the full 4-step cycle individually, using the correct executor per filename pattern)
 2. Check executor status before quality-fixer (escalation check)
-3. Quality-fixer MUST run after each executor (no skipping) and MUST receive the executor `filesModified` list as stub-detection scope
+3. Quality-fixer MUST run after each executor (no skipping), MUST receive the executor `filesModified` list as stub-detection scope, and MUST receive the current task file as the `task_file` input so it reads the task file's `Quality Assurance Mechanisms` section as supplementary quality-check hints
 4. If quality-fixer returns `status: "stub_detected"`, route the task back to the same executor with `stubFindings`
 5. Commit MUST execute only when quality-fixer returns `status: "approved"` (do not defer to end)
 

--- a/.agents/skills/recipe-implement/SKILL.md
+++ b/.agents/skills/recipe-implement/SKILL.md
@@ -105,7 +105,7 @@ After user grants "batch approval for entire implementation phase", enter autono
      - `needs_revision` -> Return to step 1 with `requiredFixes`
      - `approved` -> Proceed to step 3
    - Otherwise -> Proceed to step 3
-3. Spawn quality-fixer (or quality-fixer-frontend) agent: "Quality check and fixes. Task file: [task-file-path]. filesModified: [executor response filesModified]. Use these files as the stub-detection scope."
+3. Spawn quality-fixer (or quality-fixer-frontend) agent: "Quality check and fixes. Task file: [task-file-path]. The task file path above is also the `task_file` input. Read its `Quality Assurance Mechanisms` section as supplementary quality-check hints. filesModified: [executor response filesModified]. Use these files as the stub-detection scope."
 4. Check quality-fixer response:
    - `status: "stub_detected"` -> Return to step 1 with `stubFindings`
    - `status: "blocked"` -> Escalate to user

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -178,9 +178,9 @@ All agents MUST use this vocabulary consistently:
 
 Subagents respond in JSON format. The final response from each JSON-returning subagent must be the JSON payload itself, with no trailing prose. Key fields for orchestrator decisions:
 - **requirement-analyzer**: scale, confidence, affectedLayers, adrRequired, scopeDependencies, questions
-- **codebase-analyzer**: analysisScope, existingElements, dataModel, focusAreas, limitations
-- **task-executor**: status (escalation_needed/completed), escalation_type (design_compliance_violation/similar_function_found/similar_component_found/investigation_target_not_found/out_of_scope_file/test_environment_not_ready), testsAdded, requiresTestReview
-- **quality-fixer**: status (`stub_detected`/approved/blocked). `stub_detected` returns `stubFindings[]` and routes back to the task executor. For blocked responses, discriminate by `reason`: specification conflicts use `blockingIssues[]`; execution prerequisites use `missingPrerequisites[]`, and each item provides its own `resolutionSteps`
+- **codebase-analyzer**: analysisScope, existingElements, dataModel, qualityAssurance, focusAreas, limitations
+- **task-executor**: status (escalation_needed/completed), escalation_type (design_compliance_violation/similar_function_found/similar_component_found/investigation_target_not_found/out_of_scope_file/test_environment_not_ready/dependency_version_uncertain), testsAdded, requiresTestReview
+- **quality-fixer**: Input: `task_file` (always pass the current task file path in orchestrated flows). Status (`stub_detected`/approved/blocked). `stub_detected` returns `stubFindings[]` and routes back to the task executor. For blocked responses, discriminate by `reason`: specification conflicts use `blockingIssues[]`; execution prerequisites use `missingPrerequisites[]`, and each item provides its own `resolutionSteps`
 - **document-reviewer**: verdict.decision (approved/approved_with_conditions/needs_revision/rejected)
 - **code-verifier**: summary.status, summary.consistencyScore, discrepancies, reverseCoverage
 - **design-sync**: sync_status (CONFLICTS_FOUND/NO_CONFLICTS) — text format with [SUMMARY] block
@@ -252,7 +252,7 @@ When receiving new features or change requests, start with requirement-analyzer.
 ### Design Flow Data Passing
 
 - Pass requirement-analyzer output and original requirements to codebase-analyzer
-- Pass codebase-analyzer JSON to technical-designer or technical-designer-frontend as `Codebase Analysis`, including `dataTransformationPipelines` when present
+- Pass codebase-analyzer JSON to technical-designer or technical-designer-frontend as `Codebase Analysis`, including `dataTransformationPipelines` and `qualityAssurance` when present
 - Pass Design Doc path to code-verifier
 - Pass code-verifier JSON to document-reviewer as `code_verification`
 

--- a/.codex/agents/codebase-analyzer.toml
+++ b/.codex/agents/codebase-analyzer.toml
@@ -110,7 +110,13 @@ When data access patterns appear in the analysis scope:
 
 1. Extract validation rules, business rules, configuration dependencies, and assumptions explicitly observable from code, comments, or configuration references
 2. Search for existing tests covering discovered elements
-3. Identify focus areas where design work should be careful, especially around:
+3. Identify quality assurance mechanisms that apply to the analyzed scope:
+   - inspect CI workflow definitions, linter configurations, static analysis settings, and pre-commit hooks that cover the affected files
+   - check whether domain-specific validators or checkers apply, such as schema validators, API spec validators, or configuration linters
+   - extract domain-specific constraints such as naming conventions, length limits, and file-format requirements from configuration, CI, or repository standards
+   - record each mechanism with tool/check name, enforced quality aspect, configuration location, covered files, and mechanism type
+   - if the coverage scope is ambiguous, record the broadest reasonable covered scope and note the ambiguity in `limitations`
+4. Identify focus areas where design work should be careful, especially around:
    - shared dependencies
    - boundary contracts
    - data integrity or persistence behavior
@@ -197,6 +203,24 @@ Return the JSON result as the final response.
       "impact": "Why design should respect it"
     }
   ],
+  "qualityAssurance": {
+    "mechanisms": [
+      {
+        "tool": "Tool or check name",
+        "enforces": "What quality aspect it enforces",
+        "configLocation": "path/to/config:line",
+        "coveredFiles": ["affected files or directories covered by this mechanism"],
+        "type": "linter|static_analysis|schema_validator|domain_specific|ci_check"
+      }
+    ],
+    "domainConstraints": [
+      {
+        "constraint": "Description of the domain-specific constraint",
+        "source": "path/to/config-or-ci:line",
+        "affectedFiles": ["files subject to this constraint"]
+      }
+    ]
+  },
   "focusAreas": [
     {
       "area": "Area name",
@@ -225,6 +249,7 @@ Return the JSON result as the final response.
 - [ ] Recorded external lookups that modify output values, including configuration, constants, and mapping data
 - [ ] Performed data model discovery when data access patterns were present
 - [ ] Extracted constraints and focus areas with concrete risks
+- [ ] Identified quality assurance mechanisms and domain-specific constraints for the affected scope when applicable
 - [ ] Checked existing tests for coverage signals
 - [ ] Populated `dataTransformationPipelines` for all traced pipelines
 - [ ] Populated `entryPointInventory` for all discovered entry points in the traced scope

--- a/.codex/agents/quality-fixer-frontend.toml
+++ b/.codex/agents/quality-fixer-frontend.toml
@@ -37,6 +37,10 @@ Skill Status:
    - Analyze error root causes and execute both auto-fixes and manual fixes autonomously
    - Continue fixing until all phases pass with zero errors, then return approved status
 
+## Input Parameters
+
+- **task_file** (optional): Path to the task file being verified. When provided, read the task file's `Quality Assurance Mechanisms` section and use the listed mechanisms as supplementary hints for quality-check discovery. Primary detection remains code, manifest, and configuration based.
+
 ## Initial Required Tasks
 
 **Progress Tracking**: Track your work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update progress upon completion.
@@ -73,6 +77,7 @@ Treat the following as allowed patterns:
 If incomplete implementation is detected, stop immediately and return `status: "stub_detected"` with the affected files and reasons. Proceed to lint, type-check, build, and tests only after this check passes.
 
 **Step 2: Detect Quality Check Commands**
+**Primary detection** (always execute):
 ```bash
 # Auto-detect from project manifest files
 # Identify project structure and extract quality commands:
@@ -80,6 +85,12 @@ If incomplete implementation is detected, stop immediately and return `status: "
 # - Dependency manifest → identify language toolchain (TypeScript, ESLint, Biome, etc.)
 # - Build configuration → extract build/check commands
 ```
+
+**Supplementary detection** (when `task_file` is provided):
+- Read the task file's `Quality Assurance Mechanisms` section
+- For executable mechanisms, verify the tool exists and is runnable in the current project, then add it to the quality-check command set
+- For non-executable domain constraints, keep them as explicit verification targets and check the changed files against the stated constraint during review
+- Record skipped mechanisms only when neither executable verification nor direct constraint checking is possible
 
 **Step 3: Execute Quality Checks**
 Follow the principles in ai-development-guide skill "Quality Check Workflow" section:
@@ -226,6 +237,16 @@ Before setting status to blocked, confirm specifications in this order:
       "filesCount": 3
     }
   ],
+  "taskFileMechanisms": {
+    "provided": true,
+    "executed": ["mechanism names that were found and executed"],
+    "skipped": [
+      {
+        "mechanism": "mechanism name",
+        "reason": "tool not found / config not found / not executable"
+      }
+    ]
+  },
   "metrics": {
     "totalErrors": 0,
     "totalWarnings": 0,
@@ -252,6 +273,16 @@ Before setting status to blocked, confirm specifications in this order:
     "Fix attempt 2: Tried aligning implementation to test",
     "Fix attempt 3: Tried inferring specification from Design Doc"
   ],
+  "taskFileMechanisms": {
+    "provided": true,
+    "executed": ["mechanisms executed before blocking"],
+    "skipped": [
+      {
+        "mechanism": "mechanism name",
+        "reason": "tool not found / config not found / not executable"
+      }
+    ]
+  },
   "needsUserDecision": "Please confirm the correct button disabled behavior"
 }
 ```
@@ -269,6 +300,16 @@ Before setting status to blocked, confirm specifications in this order:
       "resolutionSteps": ["Install the required browser runtime", "Re-run the E2E check command"]
     }
   ],
+  "taskFileMechanisms": {
+    "provided": true,
+    "executed": ["mechanisms executed before blocking"],
+    "skipped": [
+      {
+        "mechanism": "mechanism name",
+        "reason": "tool not found / config not found / not executable"
+      }
+    ]
+  },
   "checksSkipped": 1,
   "checksPassedWithoutPrerequisites": 2
 }

--- a/.codex/agents/quality-fixer.toml
+++ b/.codex/agents/quality-fixer.toml
@@ -37,6 +37,10 @@ Skill Status:
    - Analyze error root causes and execute both auto-fixes and manual fixes autonomously
    - Continue fixing until all phases pass with zero errors, then return approved status
 
+## Input Parameters
+
+- **task_file** (optional): Path to the task file being verified. When provided, read the task file's `Quality Assurance Mechanisms` section and use the listed mechanisms as supplementary hints for quality-check discovery. Primary detection remains code, manifest, and configuration based.
+
 ## Initial Required Tasks
 
 **Progress Tracking**: Track your work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Update progress upon completion.
@@ -71,6 +75,7 @@ Treat the following as allowed patterns:
 If incomplete implementation is detected, stop immediately and return `status: "stub_detected"` with the affected files and reasons. Proceed to lint, build, and tests only after this check passes.
 
 **Step 2: Detect Quality Check Commands**
+**Primary detection** (always execute):
 ```bash
 # Auto-detect from project manifest files
 # Identify project structure and extract quality commands:
@@ -78,6 +83,12 @@ If incomplete implementation is detected, stop immediately and return `status: "
 # - Dependency manifest → identify language toolchain
 # - Build configuration → extract build/check commands
 ```
+
+**Supplementary detection** (when `task_file` is provided):
+- Read the task file's `Quality Assurance Mechanisms` section
+- For executable mechanisms, verify the tool exists and is runnable in the current project, then add it to the quality-check command set
+- For non-executable domain constraints, keep them as explicit verification targets and check the changed files against the stated constraint during review
+- Record skipped mechanisms only when neither executable verification nor direct constraint checking is possible
 
 **Step 3: Execute Quality Checks**
 Follow the principles in ai-development-guide skill "Quality Check Workflow" section:
@@ -197,6 +208,16 @@ Return one of the following as the final response (see Output Format for schemas
       "filesCount": 2
     }
   ],
+  "taskFileMechanisms": {
+    "provided": true,
+    "executed": ["mechanism names that were found and executed"],
+    "skipped": [
+      {
+        "mechanism": "mechanism name",
+        "reason": "tool not found / config not found / not executable"
+      }
+    ]
+  },
   "metrics": {
     "totalErrors": 0,
     "totalWarnings": 0,
@@ -223,6 +244,16 @@ Return one of the following as the final response (see Output Format for schemas
     "Fix attempt 2: Tried aligning implementation to test",
     "Fix attempt 3: Tried inferring specification from related documentation"
   ],
+  "taskFileMechanisms": {
+    "provided": true,
+    "executed": ["mechanisms executed before blocking"],
+    "skipped": [
+      {
+        "mechanism": "mechanism name",
+        "reason": "tool not found / config not found / not executable"
+      }
+    ]
+  },
   "needsUserDecision": "Please confirm the correct error code"
 }
 ```
@@ -240,6 +271,16 @@ Return one of the following as the final response (see Output Format for schemas
       "resolutionSteps": ["Run the project seed script for E2E fixtures", "Start the dependent local services"]
     }
   ],
+  "taskFileMechanisms": {
+    "provided": true,
+    "executed": ["mechanisms executed before blocking"],
+    "skipped": [
+      {
+        "mechanism": "mechanism name",
+        "reason": "tool not found / config not found / not executable"
+      }
+    ]
+  },
   "checksSkipped": 1,
   "checksPassedWithoutPrerequisites": 3
 }

--- a/.codex/agents/task-decomposer.toml
+++ b/.codex/agents/task-decomposer.toml
@@ -65,6 +65,7 @@ Decompose tasks based on implementation strategy patterns determined in implemen
 3. **Task File Generation**
    - Create individual task files in `docs/plans/tasks/`
    - Document concrete executable procedures
+   - Include task-level Quality Assurance Mechanisms when the work plan defines them
    - **Always include operation verification methods**
    - Define clear completion criteria (within executor's scope of responsibility)
 
@@ -160,6 +161,18 @@ When the work plan includes one or more Verification Strategy blocks:
 3. **Per-task verification**: Each task's Operation Verification Methods MUST instantiate the relevant plan-level verification method for that task's specific files, interfaces, or behavior.
 4. **Failure handling**: Copy or adapt the relevant plan-level failure response so the executor knows whether to reassess, stop, or escalate.
 5. **Investigation coverage**: Include every resource required for verification, such as existing implementations for comparison, schema definitions, fixtures, contracts, or seed data.
+
+## Quality Assurance Mechanism Propagation
+
+When the work plan includes a `Quality Assurance Mechanisms` table:
+
+1. **Normalize coverage entries**: Treat each `Covered Files` entry as one of: exact file path, ancestor directory path, glob-like pattern, or `project-wide`
+2. **Exact file match**: Include the mechanism when a `Covered Files` entry exactly matches a task Target File
+3. **Ancestor directory match**: Include the mechanism when a `Covered Files` entry is an ancestor directory of a task Target File, for example `src/api/` covers `src/api/handlers/auth.ts` but not `src/api-utils/auth.ts`
+4. **Pattern match**: When a `Covered Files` entry uses a glob-like pattern such as `src/**/*.ts` or `**/*.schema.json`, include the mechanism when the task Target File reasonably matches that pattern
+5. **Include project-wide mechanisms**: If the mechanism is `project-wide` or has no file-specific coverage, include it in every task
+6. **Include matching mechanisms**: Add all matching mechanisms to the task file's `Quality Assurance Mechanisms` section
+7. **Omit empty sections**: If no mechanisms apply to the task, omit that section from the task file
 
 ## Design-to-Plan Traceability Propagation
 
@@ -271,6 +284,7 @@ Please execute decomposed tasks according to the order.
 - [ ] Impact scope and boundaries definition for each task
 - [ ] Appropriate granularity (1-5 files/task)
 - [ ] Investigation Targets specified for every task
+- [ ] Quality Assurance Mechanisms propagated to relevant tasks when present in the plan header
 - [ ] Operation Verification Methods specified for every task
 - [ ] Clear completion criteria setting
 - [ ] Overall design document creation

--- a/.codex/agents/task-executor-frontend.toml
+++ b/.codex/agents/task-executor-frontend.toml
@@ -167,6 +167,19 @@ Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have u
 3. **Cross-check against Investigation Notes**: Ensure planned implementation is consistent with the observations recorded in the task file
 4. **Execute determination**: Determine continue/escalation per "Mandatory Judgment Criteria" above
 
+#### Reference Representativeness (Applied During Implementation)
+
+When adopting a pattern, UI composition, or dependency from existing code, apply repository-wide representativeness checks at the point of adoption:
+
+□ **Repository-wide verification**: Confirm the referenced pattern is representative across the repository, not just the nearest 2-3 files
+□ **Dependency version verification** (when adopting external dependencies):
+  - verify repository-wide usage distribution for the same dependency
+  - if following one existing version when alternatives exist, state the reason
+  - if repository-wide verification is insufficient to determine the appropriate version, escalate with `reason: "Dependency version uncertain"`
+□ **Coexistence resolution**: When multiple patterns or versions coexist, identify the majority before choosing
+
+This is a repeated self-check during implementation, not a one-time pre-implementation gate.
+
 #### Implementation Flow (TDD Compliant)
 **Completion Confirmation**: If all checkboxes are `[x]`, report "already completed" and end
 
@@ -322,6 +335,30 @@ When an Investigation Target file does not exist or the path is stale, escalate 
     "Update the task file with current paths"
   ],
   "recommendation": "[Recommended next step based on what was found]"
+}
+```
+
+#### 2-4. Dependency Version Uncertain Escalation
+When repository-wide verification is insufficient to determine the appropriate dependency version, escalate in following JSON format:
+
+```json
+{
+  "status": "escalation_needed",
+  "reason": "Dependency version uncertain",
+  "taskName": "[Task name being executed]",
+  "escalation_type": "dependency_version_uncertain",
+  "dependency": {
+    "name": "[dependency name]",
+    "versionsFound": ["list of versions found in repository"],
+    "filesChecked": ["file paths where the dependency usage was found"],
+    "ambiguityReason": "[why repository state alone is insufficient]"
+  },
+  "user_decision_required": true,
+  "suggested_options": [
+    "Use the majority version already in the repository",
+    "Use a different version with explicit rationale",
+    "Research the latest stable version and decide after review"
+  ]
 }
 ```
 

--- a/.codex/agents/task-executor.toml
+++ b/.codex/agents/task-executor.toml
@@ -167,6 +167,19 @@ Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have u
 3. **Cross-check against Investigation Notes**: Ensure planned implementation is consistent with the observations recorded in the task file
 4. **Execute determination**: Determine continue/escalation per "Mandatory Judgment Criteria" above
 
+#### Reference Representativeness (Applied During Implementation)
+
+When adopting a pattern, API usage, or dependency from existing code, apply repository-wide representativeness checks at the point of adoption:
+
+□ **Repository-wide verification**: Confirm the referenced pattern is representative across the repository, not just the nearest 2-3 files
+□ **Dependency version verification** (when adopting external dependencies):
+  - verify repository-wide usage distribution for the same dependency
+  - if following one existing version when alternatives exist, state the reason
+  - if repository-wide verification is insufficient to determine the appropriate version, escalate with `reason: "Dependency version uncertain"`
+□ **Coexistence resolution**: When multiple versions or patterns coexist, identify the majority before choosing
+
+This is a repeated self-check during implementation, not a one-time pre-implementation gate.
+
 #### Implementation Flow (TDD Compliant)
 
 **If all checkboxes already `[x]`**: Report "already completed" and end
@@ -326,11 +339,36 @@ When an Investigation Target file does not exist or the path is stale, escalate 
 }
 ```
 
+#### 2-4. Dependency Version Uncertain Escalation
+When repository-wide verification is insufficient to determine the appropriate dependency version, escalate in following JSON format:
+
+```json
+{
+  "status": "escalation_needed",
+  "reason": "Dependency version uncertain",
+  "taskName": "[Task name being executed]",
+  "escalation_type": "dependency_version_uncertain",
+  "dependency": {
+    "name": "[dependency name]",
+    "versionsFound": ["list of versions found in repository"],
+    "filesChecked": ["file paths where the dependency usage was found"],
+    "ambiguityReason": "[why repository state alone is insufficient]"
+  },
+  "user_decision_required": true,
+  "suggested_options": [
+    "Use the majority version already in the repository",
+    "Use a different version with explicit rationale",
+    "Research the latest stable version and decide after review"
+  ]
+}
+```
+
 ## Execution Principles
 
 - Follow RED-GREEN-REFACTOR (see the principles in testing skill)
 - Update progress checkboxes per step
 - Escalate when: design deviation, similar functions found, investigation target not found, test environment missing
+- Escalate when dependency version or representative pattern choice cannot be determined from repository evidence
 - Stop after implementation and test creation — quality checks and commits are handled separately
 
 ## Completion Gate [BLOCKING]

--- a/.codex/agents/technical-designer.toml
+++ b/.codex/agents/technical-designer.toml
@@ -52,11 +52,18 @@ Must be performed before any investigation:
    - Scan project configuration, rule files, and existing code patterns
    - Classify each: **Explicit** (documented) or **Implicit** (observed pattern only)
 
-2. **Record in Design Doc**
-   - List in "Applicable Standards" section with `[explicit]`/`[implicit]` tags
+2. **Identify Quality Assurance Mechanisms**
+   - When Codebase Analysis is provided, use `qualityAssurance` as the primary source
+   - Otherwise inspect CI pipelines, linter configs, pre-commit hooks, and project configuration for checks that cover the change area
+   - Identify domain-specific constraints from configuration or CI
+   - For each mechanism, decide whether it is `adopted` for this change or `noted` with a reason
+
+3. **Record in Design Doc**
+   - List standards in "Applicable Standards" section with `[explicit]`/`[implicit]` tags
+   - List quality assurance mechanisms in "Quality Assurance Mechanisms" section with `adopted` / `noted (reason)` status
    - Implicit standards require user confirmation before design proceeds
 
-3. **Alignment Rule**
+4. **Alignment Rule**
    - Design decisions MUST reference applicable standards
    - Deviations MUST have documented rationale
 
@@ -309,6 +316,7 @@ Implementation sample creation checklist:
 ### Design Doc Checklist
 **All modes**:
 - [ ] **Standards identification gate completed** (required)
+- [ ] **Quality assurance mechanisms identified with adoption status** (required)
 - [ ] **Code inspection evidence recorded** (required)
 - [ ] **Integration points enumerated with contracts** (required)
 - [ ] **Data contracts clarified** (required)

--- a/.codex/agents/work-planner.toml
+++ b/.codex/agents/work-planner.toml
@@ -65,6 +65,7 @@ Read the Design Doc(s), UI Spec, PRD, and ADR (if provided). Extract:
 - Technical dependencies and implementation order
 - Integration points and their contracts
 - Verification Strategy from each Design Doc: correctness definition, target comparison, verification method, observable success indicator, normalized verification timing, and early verification point
+- Quality Assurance Mechanisms from each Design Doc: all items marked `adopted`, including mechanism name, enforced quality aspect, configuration path, and covered files or project-wide scope
 - Implementation-relevant technical requirements from each Design Doc section using the category values defined in the plan template's `Design-to-Plan Traceability` section
 
 Focus on implementation-relevant items only: items that directly inform task creation, dependency ordering, verification design, or protected no-change boundaries.
@@ -81,6 +82,7 @@ Choose Strategy A (TDD) if test skeletons are provided, Strategy B (implementati
 **Common rules (all approaches)**:
 - Preserve Verification Strategies per Design Doc in the work plan header and keep each source document path. Merge strategies only when the Design Docs explicitly define a shared one
 - Include Verification Strategy summaries in the work plan header so the plan is self-sufficient for downstream task generation
+- Include adopted Quality Assurance Mechanisms in the work plan header so downstream task generation and quality checks inherit the intended quality gates
 - Place tasks with the lowest dependencies in earlier phases
 - Map normalized verification timing to phases as follows: `phase_1` -> earliest implementation phase, `per_phase` -> each relevant phase, `integration_phase` -> integration phase, `final_phase` -> final Quality Assurance phase
 - Include verification tasks in the phase corresponding to the Verification Strategy timing
@@ -286,6 +288,7 @@ When creating work plans, **Phase Structure Diagrams** and **Task Dependency Dia
 
 - [ ] Design Doc(s) consistency verification
 - [ ] Verification Strategies extracted from each Design Doc and included in the plan header without unintended merging
+- [ ] Adopted Quality Assurance Mechanisms extracted from the Design Doc(s) and included in the plan header
 - [ ] Design-to-Plan Traceability table completed for all extracted implementation-relevant DD items
   - [ ] Every row mapped to covering task(s) or justified `gap`
   - [ ] Interface change and propagation items mapped explicitly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- add quality assurance mechanism discovery to codebase analysis and design/planning templates
- propagate adopted quality gates through plans, task decomposition, and quality-fixer inputs
- add repository-wide reference representativeness checks for executor agents
- bump the package patch version to `0.4.9`

## What changed
- `codebase-analyzer` now records `qualityAssurance` findings, including mechanisms and domain constraints
- `technical-designer`, `work-planner`, and the documentation templates now carry Quality Assurance Mechanisms explicitly through the workflow
- `task-decomposer` now propagates matching quality mechanisms into task files using exact paths, ancestor directories, glob-like patterns, and project-wide scope
- `quality-fixer` and `quality-fixer-frontend` now accept `task_file` as structured input and treat task-level quality mechanisms as supplementary verification hints
- `task-executor` and `task-executor-frontend` now enforce repository-wide reference representativeness and can escalate with `dependency_version_uncertain`
- orchestration recipes now pass the task file explicitly as `task_file` input when invoking quality-fixer

## Verification
- `git diff --check`

## Notes
- This change updates workflow instructions and templates only; it does not change runtime application code.