### PR TITLE
fix: isolate subagent context in orchestration skills

### DIFF
--- a/.agents/skills/recipe-add-integration-tests/SKILL.md
+++ b/.agents/skills/recipe-add-integration-tests/SKILL.md
@@ -9,6 +9,8 @@ description: "Add integration/E2E tests to existing codebase using Design Docs."
 2. [LOAD IF NOT ACTIVE] `integration-e2e-testing` — integration and E2E test patterns
 3. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 **Context**: Test addition workflow for existing implementations
 
 ## Orchestrator Definition

--- a/.agents/skills/recipe-build/SKILL.md
+++ b/.agents/skills/recipe-build/SKILL.md
@@ -10,6 +10,8 @@ description: "Execute decomposed backend tasks in autonomous execution mode usin
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` — AI development patterns
 4. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 ## Orchestrator Definition
 
 **Core Identity**: "I am not a worker. I am an orchestrator." (see subagents-orchestration-guide skill)

--- a/.agents/skills/recipe-design/SKILL.md
+++ b/.agents/skills/recipe-design/SKILL.md
@@ -9,6 +9,8 @@ description: "Execute from requirement analysis to design document creation."
 2. [LOAD IF NOT ACTIVE] `implementation-approach` — implementation strategy
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 **Context**: Dedicated to the design phase.
 
 ## Orchestrator Definition

--- a/.agents/skills/recipe-diagnose/SKILL.md
+++ b/.agents/skills/recipe-diagnose/SKILL.md
@@ -8,6 +8,8 @@ description: "Investigate problem, verify findings, and derive solutions through
 1. [LOAD IF NOT ACTIVE] `ai-development-guide` — AI development patterns
 2. [LOAD IF NOT ACTIVE] `coding-rules` — coding standards
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 **Context**: Diagnosis flow to identify concrete failure points and present solutions
 
 Target problem: $ARGUMENTS

--- a/.agents/skills/recipe-front-build/SKILL.md
+++ b/.agents/skills/recipe-front-build/SKILL.md
@@ -10,6 +10,8 @@ description: "Execute frontend tasks in autonomous execution mode using task-exe
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` -- AI development patterns
 4. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 ## Orchestrator Definition
 
 **Core Identity**: "I am not a worker. I am an orchestrator." (see subagents-orchestration-guide skill)

--- a/.agents/skills/recipe-front-design/SKILL.md
+++ b/.agents/skills/recipe-front-design/SKILL.md
@@ -11,6 +11,8 @@ description: "Execute from requirement analysis to frontend design document crea
 2. [LOAD IF NOT ACTIVE] `implementation-approach` -- implementation methodology
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 ## Orchestrator Definition
 
 **Core Identity**: "I am not a worker. I am an orchestrator."

--- a/.agents/skills/recipe-front-plan/SKILL.md
+++ b/.agents/skills/recipe-front-plan/SKILL.md
@@ -11,6 +11,8 @@ description: "Create frontend work plan from design document with test skeleton 
 2. [LOAD IF NOT ACTIVE] `implementation-approach` -- implementation methodology
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 ## Orchestrator Definition
 
 **Core Identity**: "I am not a worker. I am an orchestrator."

--- a/.agents/skills/recipe-front-review/SKILL.md
+++ b/.agents/skills/recipe-front-review/SKILL.md
@@ -11,6 +11,8 @@ description: "Frontend Design Doc compliance and security validation with option
 2. [LOAD IF NOT ACTIVE] `testing` -- test strategy and quality gates
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` -- AI development patterns
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 ## Execution Method
 
 - Compliance validation -> performed by code-reviewer

--- a/.agents/skills/recipe-fullstack-build/SKILL.md
+++ b/.agents/skills/recipe-fullstack-build/SKILL.md
@@ -10,6 +10,8 @@ description: "Execute decomposed fullstack tasks with layer-aware agent routing 
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` -- AI development patterns
 4. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 ## Orchestrator Definition
 
 **Core Identity**: "I am not a worker. I am an orchestrator." (see subagents-orchestration-guide skill)

--- a/.agents/skills/recipe-fullstack-implement/SKILL.md
+++ b/.agents/skills/recipe-fullstack-implement/SKILL.md
@@ -14,6 +14,8 @@ description: "Orchestrate full-cycle implementation across backend and frontend 
 5. [LOAD IF NOT ACTIVE] `implementation-approach` -- implementation methodology
 6. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 ## Orchestrator Definition
 
 **Core Identity**: "I am not a worker. I am an orchestrator." (see subagents-orchestration-guide skill)

--- a/.agents/skills/recipe-implement/SKILL.md
+++ b/.agents/skills/recipe-implement/SKILL.md
@@ -8,6 +8,8 @@ description: "Orchestrate the complete implementation lifecycle from requirement
 1. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 2. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 # Full-Cycle Implementation
 
 $ARGUMENTS

--- a/.agents/skills/recipe-plan/SKILL.md
+++ b/.agents/skills/recipe-plan/SKILL.md
@@ -9,6 +9,8 @@ description: "Create work plan from design document with optional test skeleton 
 2. [LOAD IF NOT ACTIVE] `implementation-approach` — implementation strategy
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 **Context**: Dedicated to the planning phase.
 
 ## Orchestrator Definition

--- a/.agents/skills/recipe-reverse-engineer/SKILL.md
+++ b/.agents/skills/recipe-reverse-engineer/SKILL.md
@@ -9,6 +9,8 @@ description: "Generate PRD and Design Docs from existing codebase through discov
 2. [LOAD IF NOT ACTIVE] `ai-development-guide` — AI development patterns
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 **Context**: Reverse engineering workflow to create documentation from existing code
 
 Target: $ARGUMENTS

--- a/.agents/skills/recipe-review/SKILL.md
+++ b/.agents/skills/recipe-review/SKILL.md
@@ -9,6 +9,8 @@ description: "Design Doc compliance and security validation with optional auto-f
 2. [LOAD IF NOT ACTIVE] `testing` — test strategy and quality gates
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` — AI development patterns
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 **Context**: Post-implementation quality assurance
 
 ## Orchestrator Definition

--- a/.agents/skills/recipe-task/SKILL.md
+++ b/.agents/skills/recipe-task/SKILL.md
@@ -7,6 +7,8 @@ description: "Execute tasks with metacognitive analysis and appropriate rule sel
 
 1. [LOAD IF NOT ACTIVE] `task-analyzer` — task analysis and skill selection (rule-advisor handles remaining skill selection)
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 # Task Execution with Metacognitive Analysis
 
 Task: $ARGUMENTS

--- a/.agents/skills/recipe-update-doc/SKILL.md
+++ b/.agents/skills/recipe-update-doc/SKILL.md
@@ -8,6 +8,8 @@ description: "Update existing design documents (Design Doc / PRD / ADR) with rev
 1. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
 2. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 **Context**: Dedicated to updating existing design documents.
 
 ## Orchestrator Definition

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -5,6 +5,8 @@ description: "Guides subagent coordination through implementation workflows. Use
 
 # Subagents Orchestration Guide
 
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
 ## Role: The Orchestrator
 
 The orchestrator coordinates subagents. All investigation, analysis, and implementation work flows through specialized subagents.
@@ -119,26 +121,28 @@ Close a running subagent only when the user redirects the workflow, the orchestr
 
 ## How to Spawn Agents
 
-Spawn agents using natural language prompts. Provide clear context about what the agent should accomplish.
+Spawn agents using natural language prompts. Provide clear context about what the agent should accomplish. Every `spawn_agent` call MUST include `fork_turns="none"` or `fork_context=false` (see Spawn rule at top of this skill).
 
 ### Spawn Examples
 
-**requirement-analyzer**:
+Each example below is a spawn with `fork_turns="none"` or `fork_context=false` plus the quoted prompt.
+
+**requirement-analyzer** (`fork_turns="none"` or `fork_context=false`):
 > "Analyze the following requirements and determine the work scale: [user requirements]. Perform requirement analysis and scale determination."
 
-**codebase-analyzer**:
+**codebase-analyzer** (`fork_turns="none"` or `fork_context=false`):
 > "Analyze the existing codebase to provide evidence for Design Doc creation. Focus on existing implementations, data model elements, and constraints the design should respect. requirement_analysis: [JSON]. prd_path: [path if available]. requirements: [original user requirements]. layer: [target layer if applicable]. target_paths: [paths if narrowed]. Return codebase facts and focus areas."
 
-**task-executor**:
+**task-executor** (`fork_turns="none"` or `fork_context=false`):
 > "Execute the implementation task defined in docs/plans/tasks/[filename].md. Complete the implementation following TDD Red-Green-Refactor."
 
-**quality-fixer**:
+**quality-fixer** (`fork_turns="none"` or `fork_context=false`):
 > "Run quality checks on the codebase: static analysis, style check, all test execution. Fix any issues found and report when all checks pass."
 
-**document-reviewer**:
+**document-reviewer** (`fork_turns="none"` or `fork_context=false`):
 > "Review the document at [path] for quality and rule compliance. Check against documentation-criteria standards."
 
-**design-sync**:
+**design-sync** (`fork_turns="none"` or `fork_context=false`):
 > "Verify consistency between Design Docs in docs/design/. Use [path] as the source document for comparison."
 
 ## Explicit Stop Points [MANDATORY]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- bump the package version from 0.4.10 to 0.4.11
- add a shared spawn rule requiring context-isolated subagent launches across orchestration recipes
- update subagent spawn examples to include the context-isolation requirement

## Testing
- not run (skill documentation updates only)