### PR TITLE
Add implementation readiness workflow

### DIFF
--- a/.agents/skills/coding-rules/references/typescript.md
+++ b/.agents/skills/coding-rules/references/typescript.md
@@ -59,7 +59,7 @@ function isUser(value: unknown): value is User {
 - **Function Components (Mandatory)**: Official React recommendation, optimizable by modern tooling
 - **Classes Prohibited**: Class components completely deprecated (Exception: Error Boundary)
 - **Custom Hooks**: Standard pattern for logic reuse and dependency injection
-- **Component Hierarchy**: Atoms > Molecules > Organisms > Templates > Pages
+- **Component Hierarchy**: Follow the project's existing component architecture. Use Atoms > Molecules > Organisms > Templates > Pages only when the project adopts Atomic Design.
 - **Co-location**: Place tests, styles, and related files alongside components
 
 **State Management Patterns**

--- a/.agents/skills/documentation-criteria/references/plan-template.md
+++ b/.agents/skills/documentation-criteria/references/plan-template.md
@@ -5,6 +5,7 @@ Type: feature|fix|refactor
 Estimated Duration: X days
 Estimated Impact: X files
 Related Issue/PR: #XXX (if any)
+Implementation Readiness: pending
 
 ## Related Documents
 - Design Doc(s):
@@ -65,6 +66,24 @@ Map each Design Doc technical requirement to the task or phase that covers it. U
 - Normalize same-boundary field propagation into one row when the fields must move together through the same boundary for the same reason
 - Merge duplicate restatements of the same obligation from multiple DD sections into one row and cite the primary section in `DD Section`
 - Keep `scope-boundary` rows concrete: name the protected file group, component boundary, contract, or workflow that must remain unchanged
+
+## UI Spec Component -> Task Mapping
+
+Include this section when a UI Spec is among the inputs. Map each UI component section to the task(s) that implement it so task-decomposer can pass the exact UI Spec context to executor tasks. Omit this section when no UI Spec exists.
+
+| UI Spec Component (section heading) | States to Cover | Covered By Task(s) | Gap Status | Notes |
+|-------------------------------------|-----------------|--------------------|------------|-------|
+| [Use the UI Spec heading exactly as written, e.g. "Component: AlertCard"] | [default / loading / empty / error / partial] | [P1-T1, P2-T1] | covered | |
+
+**Reference key rule**: The component identifier is the UI Spec section heading verbatim. Component headings must be unique within a UI Spec.
+
+## Connection Map
+
+Include this section when implementation crosses runtime, process, deployment, or service boundaries. Omit it when the change stays inside one runtime or only uses in-process package imports.
+
+| Boundary | Owner (left side) | Owner (right side) | Expected Signal | Covered By Task(s) |
+|----------|-------------------|--------------------|-----------------|--------------------|
+| [e.g. "web client -> API"] | [module/package on request side] | [module/package on response side] | [Observable evidence, e.g. HTTP 200 matching schema X] | [P1-T1, P1-T2] |
 
 ## Objective
 [Why this change is necessary, what problem it solves]

--- a/.agents/skills/documentation-criteria/references/plan-template.md
+++ b/.agents/skills/documentation-criteria/references/plan-template.md
@@ -81,9 +81,9 @@ Include this section when a UI Spec is among the inputs. Map each UI component s
 
 Include this section when implementation crosses runtime, process, deployment, or service boundaries. Omit it when the change stays inside one runtime or only uses in-process package imports.
 
-| Boundary | Owner (left side) | Owner (right side) | Expected Signal | Covered By Task(s) |
-|----------|-------------------|--------------------|-----------------|--------------------|
-| [e.g. "web client -> API"] | [module/package on request side] | [module/package on response side] | [Observable evidence, e.g. HTTP 200 matching schema X] | [P1-T1, P1-T2] |
+| Boundary | Caller / Producer | Callee / Consumer | Expected Signal | Covered By Task(s) |
+|----------|-------------------|-------------------|-----------------|--------------------|
+| [e.g. "web client -> API"] | [module/package initiating request or message] | [module/package receiving request or message] | [Observable evidence, e.g. HTTP 200 matching schema X] | [P1-T1, P1-T2] |
 
 ## Objective
 [Why this change is necessary, what problem it solves]

--- a/.agents/skills/documentation-criteria/references/ui-spec-template.md
+++ b/.agents/skills/documentation-criteria/references/ui-spec-template.md
@@ -59,6 +59,8 @@ Map PRD acceptance criteria to prototype references. Skip this section if no pro
 
 ### Component: [ComponentName]
 
+> Component heading uniqueness: every `Component: [ComponentName]` heading must be unique within this UI Spec. Work plans and task decomposition reference components by exact heading text.
+
 #### State x Display Matrix
 
 List only states that actually exist for this component. Remove unused rows. Include fallback or degraded states only when explicitly required by the PRD or existing behavior.

--- a/.agents/skills/integration-e2e-testing/SKILL.md
+++ b/.agents/skills/integration-e2e-testing/SKILL.md
@@ -49,6 +49,8 @@ Use `Value Score` for ranking candidates of the same test type. Handle E2E cost 
 - `service-integration-e2e threshold = Value Score > 50` for non-reserved candidates
 - Reserved-slot eligibility overrides the threshold when the candidate is the highest-value user-facing multi-step journey
 
+The fixture-e2e threshold is lower because this lane uses mocked backend or fixture-driven state, avoids live-stack setup, and has a higher per-feature budget. The service-integration-e2e threshold stays higher because live-stack tests are slower, more brittle, and more expensive to maintain.
+
 ### Selection Rules
 
 | Test Type | Ranking Basis | Selection Rule |

--- a/.agents/skills/integration-e2e-testing/SKILL.md
+++ b/.agents/skills/integration-e2e-testing/SKILL.md
@@ -7,14 +7,15 @@ description: "Integration and E2E test design principles, value-based selection,
 
 ## References
 
-**E2E test design with Playwright**: See [references/e2e-design.md](references/e2e-design.md) for UI Spec-driven E2E test candidate selection and Playwright test architecture.
+**E2E test design**: See [references/e2e-design.md](references/e2e-design.md) for UI Spec-driven E2E test candidate selection and browser test architecture. Playwright is the default browser harness example; use the project's standard when different.
 
 ## Test Type Definition and Limits [MANDATORY]
 
-| Test Type | Purpose | Scope | Limit per Feature | Implementation Timing |
-|-----------|---------|-------|-------------------|----------------------|
-| Integration | Verify component interactions | Partial system integration | MAX 3 | Created alongside implementation |
-| E2E | Verify critical user journeys | Full system | MAX 1-2 | Executed in final phase only |
+| Test Type | Purpose | Scope | External Deps | Limit per Feature | Implementation Timing |
+|-----------|---------|-------|---------------|-------------------|----------------------|
+| Integration | Verify component interactions in-process | Partial system integration | Project-local dependencies | MAX 3 | Created alongside implementation |
+| fixture-e2e | Verify browser/user journey with controlled state | Browser UI + mocked backend or fixtures | No live stack required | MAX 3 | Created alongside UI implementation |
+| service-integration-e2e | Verify live-stack cross-service correctness | Full local stack | Local services, DB, queues, stubs | MAX 1-2 | Executed in final phase only |
 
 **ENFORCEMENT**: Exceeding test limits requires explicit justification
 
@@ -42,10 +43,10 @@ Value Score = (Business Value x User Frequency) + (Legal Requirement x 10) + Def
 
 Use `Value Score` for ranking candidates of the same test type. Handle E2E cost through budget limits and reserved-slot rules instead of cost-division scoring.
 
-### E2E Threshold
+### E2E Lane Thresholds
 
-- `E2E threshold = Value Score >= 50`
-- Use this threshold for non-reserved E2E selection only
+- `fixture-e2e threshold = Value Score >= 20` for non-reserved candidates
+- `service-integration-e2e threshold = Value Score > 50` for non-reserved candidates
 - Reserved-slot eligibility overrides the threshold when the candidate is the highest-value user-facing multi-step journey
 
 ### Selection Rules
@@ -53,33 +54,40 @@ Use `Value Score` for ranking candidates of the same test type. Handle E2E cost 
 | Test Type | Ranking Basis | Selection Rule |
 |-----------|---------------|----------------|
 | Integration | Highest `Value Score` among integration candidates | Select up to budget |
-| E2E | Highest `Value Score` among E2E candidates | Select when `reservedSlotEligible = true`, or when `Value Score >= 50` |
+| fixture-e2e | Highest `Value Score` among fixture-e2e candidates | Select reserved user-facing journey or candidates with `Value Score >= 20` |
+| service-integration-e2e | Highest `Value Score` among service-integration-e2e candidates | Select reserved cross-service journey or candidates with `Value Score > 50` |
 
 ### E2E Candidate Rules
 
 - Treat integration and E2E as complementary coverage layers
+- Default browser-level user journeys to `fixture-e2e` when mocked backend or fixture-driven state can verify the behavior
+- Promote to `service-integration-e2e` only when correctness depends on real cross-service behavior such as DB persistence, queue/event delivery, transactional consistency, or external service contract payloads
 - Retain an E2E candidate when it validates a user-facing multi-step journey, even if integration tests partially cover the behavior
-- Preserve E2E candidates for user-facing multi-step journeys that validate cross-screen or cross-boundary continuity
-- Distinguish user-facing journeys from service-internal chains; reserved E2E coverage applies only to user-facing journeys
+- Distinguish user-facing journeys from service-internal chains; reserved fixture-e2e coverage applies only to user-facing journeys
 
 ### Reserved E2E Slot
 
-Reserve 1 E2E slot for the highest-value user-facing multi-step journey when such a journey exists, even if it does not satisfy `Value Score >= 50`.
+Reserve 1 fixture-e2e slot for the highest-value user-facing multi-step journey when such a journey exists, even if it does not satisfy `Value Score >= 20`.
+
+Reserve 1 service-integration-e2e slot only when that journey requires real cross-service verification that fixture-e2e cannot prove.
 
 ### E2E Absence Contract
 
 When no E2E test is generated, downstream artifacts must treat that as an explicit decision, not an error. Carry:
-- `generatedFiles.e2e: null`
-- `e2eAbsenceReason`: one of `no_user_facing_multi_step_journey`, `all_e2e_candidates_below_threshold`, `covered_by_existing_e2e`, `budget_not_justified`
+- `generatedFiles.fixtureE2e: null`
+- `generatedFiles.serviceE2e: null`
+- `e2eAbsenceReason.fixtureE2e`: one of `no_user_facing_multi_step_journey`, `all_e2e_candidates_below_threshold`, `covered_by_existing_e2e`, `budget_not_justified`
+- `e2eAbsenceReason.serviceE2e`: one of the fixture reasons plus `no_real_service_dependency`
 
 ### E2E Selection Decision Table
 
 | Condition | Result |
 |-----------|--------|
-| At least one user-facing multi-step journey exists | Reserve 1 E2E slot for the highest-value such journey |
-| Remaining E2E candidate has `Value Score >= 50` | Eligible for non-reserved E2E selection |
-| Remaining E2E candidate has `Value Score < 50` | Exclude and use `all_e2e_candidates_below_threshold` if no E2E remains |
-| Existing E2E already covers the same journey | Exclude and use `covered_by_existing_e2e` if no E2E remains |
+| At least one user-facing multi-step journey exists | Reserve 1 fixture-e2e slot for the highest-value such journey |
+| Journey correctness requires live cross-service behavior | Reserve or consider service-integration-e2e |
+| Remaining fixture-e2e candidate has `Value Score >= 20` | Eligible for non-reserved fixture-e2e selection |
+| Remaining service-integration-e2e candidate has `Value Score > 50` | Eligible for non-reserved service-integration-e2e selection |
+| Existing E2E already covers the same journey | Exclude and use `covered_by_existing_e2e` if no lane remains |
 
 ## Test Skeleton Specification [MANDATORY]
 
@@ -90,8 +98,9 @@ Each test MUST include the following annotations:
 ```
 // AC: [Original acceptance criteria text]
 // Behavior: [Trigger] -> [Process] -> [Observable Result]
-// @category: core-functionality | integration | edge-case | e2e
-// @dependency: none | [component names] | full-system
+// @category: core-functionality | integration | edge-case | fixture-e2e | service-integration-e2e
+// @lane: integration | fixture-e2e | service-integration-e2e
+// @dependency: none | [component names] | full-ui (mocked backend) | full-system
 // @real-dependency: [component names] (optional)
 // @complexity: low | medium | high
 // Value Score: [score]
@@ -133,7 +142,9 @@ These annotations allow work-planner to create prerequisite tasks before E2E exe
 ## Test File Naming Convention
 
 - Integration tests: `*.int.test.*` or `*.integration.test.*`
-- E2E tests: `*.e2e.test.*`
+- fixture-e2e tests: `*.fixture.e2e.test.*`
+- service-integration-e2e tests: `*.service.e2e.test.*`
+- legacy E2E tests: `*.e2e.test.*`
 
 The test runner or framework in the project determines the appropriate file extension.
 

--- a/.agents/skills/integration-e2e-testing/references/e2e-design.md
+++ b/.agents/skills/integration-e2e-testing/references/e2e-design.md
@@ -1,10 +1,12 @@
-# E2E Test Design with Playwright
+# E2E Test Design
 
 ## When to Create E2E Tests
 
-E2E tests target **critical user journeys** that span multiple pages or require real browser interaction. Apply the parent skill rules exactly:
-- Reserve 1 E2E slot for the highest-value user-facing multi-step journey
-- Use `Value Score >= 50` for any additional non-reserved E2E candidate
+E2E tests target critical user journeys that span multiple interaction boundaries or require browser-level verification. Apply the parent skill rules exactly:
+- Reserve 1 fixture-e2e slot for the highest-value user-facing multi-step journey
+- Use `Value Score >= 20` for additional fixture-e2e candidates
+- Use service-integration-e2e only when correctness depends on real cross-service behavior
+- Use `Value Score > 50` for additional service-integration-e2e candidates
 
 ### Candidate Sources
 
@@ -22,6 +24,7 @@ E2E tests target **critical user journeys** that span multiple pages or require 
 - Flows requiring real browser APIs (navigation, cookies, localStorage)
 - Accessibility verification requiring actual DOM rendering
 - Responsive behavior across viewports
+- Live-stack verification where DB persistence, queue/event delivery, transaction consistency, or external service payloads are the behavior under test
 
 **Exclude** (use integration tests instead):
 - Single-component state changes (use RTL)
@@ -47,20 +50,22 @@ Preconditions: [Auth state, data state]
 Verification Points:
   - [What to assert at each step]
 E2E Value Score: [calculated score]
+Lane: fixture-e2e | service-integration-e2e
 ```
 
-## Playwright Test Architecture
+## Browser Test Architecture
 
 ### Page Object Pattern
 
-Organize browser interactions through page objects for maintainability:
+Organize browser interactions through page objects or the project's equivalent harness pattern for maintainability:
 
 ```
 tests/
 ├── e2e/
 │   ├── pages/           # Page objects
 │   ├── fixtures/        # Test fixtures and helpers
-│   └── *.e2e.test.ts    # Test files
+│   ├── *.fixture.e2e.test.ts
+│   └── *.service.e2e.test.ts
 ```
 
 ### Test Isolation
@@ -83,7 +88,8 @@ When UI Spec defines responsive behavior, test critical breakpoints:
 ## Budget Enforcement
 
 Hard limits per feature (same as parent skill):
-- **E2E Tests**: MAX 1-2 tests
-- Generate the reserved user-journey E2E when eligible
-- Generate any additional E2E only when `Value Score >= 50`
+- **fixture-e2e**: MAX 3 tests
+- **service-integration-e2e**: MAX 1-2 tests
+- Generate the reserved fixture-e2e user journey when eligible
+- Generate service-integration-e2e only when live cross-service behavior must be verified
 - Prefer fewer, comprehensive journey tests over many granular tests

--- a/.agents/skills/recipe-add-integration-tests/SKILL.md
+++ b/.agents/skills/recipe-add-integration-tests/SKILL.md
@@ -171,3 +171,10 @@ ENFORCEMENT: Commits without quality-fixer approval are invalid.
 - [ ] Tests reviewed via integration-test-reviewer (approved or fixes applied)
 - [ ] Quality check passed via quality-fixer
 - [ ] Test files committed
+- [ ] Task files created by this recipe deleted from `docs/plans/tasks/`
+
+## Final Cleanup
+
+Before the completion report, delete only the integration-test task files this recipe created for the current run. Their work is committed; `docs/plans/` is ephemeral working state.
+
+If cleanup fails, report the failed path but do not invalidate completed test work.

--- a/.agents/skills/recipe-build/SKILL.md
+++ b/.agents/skills/recipe-build/SKILL.md
@@ -29,8 +29,29 @@ Work plan: $ARGUMENTS
 
 ## Pre-execution Prerequisites
 
-### Task File Existence Check
-Check for work plans in docs/plans/ and task files in docs/plans/tasks/.
+### Implementation Readiness Check
+
+Before task processing, locate the work plan to gate against.
+
+Resolution rule:
+1. List task files in `docs/plans/tasks/` matching the single-layer pattern `{plan-name}-task-*.md`.
+2. Exclude `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
+3. If matching task files exist, infer `{plan-name}` from the most recent matching task file and use `docs/plans/{plan-name}.md`.
+4. If no matching task files exist, use the most recent non-template work plan in `docs/plans/`.
+
+Read the work plan header and find `Implementation Readiness: <status>`.
+
+| Status | Action |
+|--------|--------|
+| `ready` | Proceed to Consumed Task Set computation |
+| `pending` or absent | Ask the user whether to continue without preflight. Recommended action is to run `$recipe-prepare-implementation [plan-path]` first. Continue only on explicit approval |
+| `escalated` | Read the work plan's Implementation Readiness Report, present remaining gaps, and continue only on explicit approval |
+
+### Consumed Task Set
+
+Compute the **Consumed Task Set** for this run: task files in `docs/plans/tasks/` matching `{plan-name}-task-*.md`, excluding `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
+
+Every subsequent reference to task files in this recipe uses this set, not an unrestricted `docs/plans/tasks/*.md` scan.
 
 ### Task Generation Decision Flow
 
@@ -38,8 +59,8 @@ Analyze task file existence state and determine the action required:
 
 | State | Criteria | Next Action |
 |-------|----------|-------------|
-| Tasks exist | .md files in tasks/ directory | User's execution instruction serves as batch approval -> Enter autonomous execution immediately |
-| No tasks + plan exists | Plan exists but no task files | Confirm with user -> spawn task-decomposer |
+| Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval -> Enter autonomous execution immediately |
+| No tasks + plan exists | Consumed Task Set is empty but plan exists | Confirm with user -> spawn task-decomposer |
 | Neither exists | No plan or task files | Error: Prerequisites not met |
 
 ## Task Decomposition Phase (Conditional)
@@ -58,7 +79,7 @@ Generate tasks from the work plan? (y/n):
 Spawn task-decomposer agent: "Read work plan at docs/plans/[plan-name].md and decompose into atomic tasks. Output: Individual task files in docs/plans/tasks/. Granularity: 1 task = 1 commit = independently executable."
 
 ### 3. Verify Generation
-Verify generated task files exist in docs/plans/tasks/.
+Recompute the Consumed Task Set and verify it is non-empty.
 
 ## Pre-execution Checklist
 
@@ -122,6 +143,12 @@ After all task cycles finish, collect all `filesModified` from every task-execut
    - Re-run only the verifier(s) that failed
    - Maximum retry count is 1 verification fix cycle; if any failed verifier still fails after re-run, escalate to the user
 5. If both verifiers pass -> Proceed to completion report
+
+## Final Cleanup
+
+Before the completion report, delete the implementation task files in the Consumed Task Set, matching phase-completion files for the same plan, and `_overview-{plan-name}.md` if present. Preserve the work plan itself.
+
+If cleanup fails, report the failed path but do not invalidate completed implementation work.
 
 **[STOP — BLOCKING]** Upon detecting ANY requirement changes, halt execution immediately.
 **CANNOT proceed until user explicitly confirms the change scope.**

--- a/.agents/skills/recipe-build/SKILL.md
+++ b/.agents/skills/recipe-build/SKILL.md
@@ -34,18 +34,13 @@ Work plan: $ARGUMENTS
 Before task processing, locate the work plan to gate against.
 
 Resolution rule:
-1. List task files in `docs/plans/tasks/` matching the single-layer pattern `{plan-name}-task-*.md`.
-2. Exclude `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
-3. If matching task files exist, infer `{plan-name}` from the most recent matching task file and use `docs/plans/{plan-name}.md`.
-4. If no matching task files exist, use the most recent non-template work plan in `docs/plans/`.
+1. If `$ARGUMENTS` contains a work plan path, use that exact file and derive `{plan-name}` from its basename. This takes precedence over task-file mtimes.
+2. If `$ARGUMENTS` is empty, list task files in `docs/plans/tasks/` matching the single-layer pattern `{plan-name}-task-*.md`.
+3. Exclude `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
+4. If matching task files exist, infer `{plan-name}` from the most recent matching task file and use `docs/plans/{plan-name}.md`.
+5. If no matching task files exist, use the most recent non-template work plan in `docs/plans/`.
 
-Read the work plan header and find `Implementation Readiness: <status>`.
-
-| Status | Action |
-|--------|--------|
-| `ready` | Proceed to Consumed Task Set computation |
-| `pending` or absent | Ask the user whether to continue without preflight. Recommended action is to run `$recipe-prepare-implementation [plan-path]` first. Continue only on explicit approval |
-| `escalated` | Read the work plan's Implementation Readiness Report, present remaining gaps, and continue only on explicit approval |
+Read the work plan header and apply the Implementation Readiness Marker Contract from `subagents-orchestration-guide`.
 
 ### Consumed Task Set
 
@@ -146,7 +141,12 @@ After all task cycles finish, collect all `filesModified` from every task-execut
 
 ## Final Cleanup
 
-Before the completion report, delete the implementation task files in the Consumed Task Set, matching phase-completion files for the same plan, and `_overview-{plan-name}.md` if present. Preserve the work plan itself.
+Before the completion report, delete only these files for the current `{plan-name}`:
+- Every file in the Consumed Task Set
+- `docs/plans/tasks/{plan-name}-phase*-completion.md`
+- `docs/plans/tasks/_overview-{plan-name}.md`
+
+Preserve the work plan itself.
 
 If cleanup fails, report the failed path but do not invalidate completed implementation work.
 

--- a/.agents/skills/recipe-front-build/SKILL.md
+++ b/.agents/skills/recipe-front-build/SKILL.md
@@ -34,18 +34,13 @@ Work plan: $ARGUMENTS
 Before task processing, locate the work plan to gate against.
 
 Resolution rule:
-1. List task files in `docs/plans/tasks/` matching `{plan-name}-frontend-task-*.md`.
-2. Exclude `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
-3. If matching task files exist, infer `{plan-name}` from the most recent matching task file and use `docs/plans/{plan-name}.md`.
-4. If no matching task files exist, use the most recent non-template work plan in `docs/plans/`.
+1. If `$ARGUMENTS` contains a work plan path, use that exact file and derive `{plan-name}` from its basename. This takes precedence over task-file mtimes.
+2. If `$ARGUMENTS` is empty, list task files in `docs/plans/tasks/` matching `{plan-name}-frontend-task-*.md`.
+3. Exclude `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
+4. If matching task files exist, infer `{plan-name}` from the most recent matching task file and use `docs/plans/{plan-name}.md`.
+5. If no matching task files exist, use the most recent non-template work plan in `docs/plans/`.
 
-Read the work plan header and find `Implementation Readiness: <status>`.
-
-| Status | Action |
-|--------|--------|
-| `ready` | Proceed to Consumed Task Set computation |
-| `pending` or absent | Ask the user whether to continue without preflight. Recommended action is to run `$recipe-prepare-implementation [plan-path]` first. Continue only on explicit approval |
-| `escalated` | Read the work plan's Implementation Readiness Report, present remaining gaps, and continue only on explicit approval |
+Read the work plan header and apply the Implementation Readiness Marker Contract from `subagents-orchestration-guide`.
 
 ### Consumed Task Set
 
@@ -154,7 +149,12 @@ After all task cycles finish, collect all `filesModified` from every task-execut
 
 ## Final Cleanup
 
-Before the completion report, delete the implementation task files in the Consumed Task Set, matching phase-completion files for the same plan, and `_overview-{plan-name}.md` if present. Preserve the work plan itself.
+Before the completion report, delete only these files for the current `{plan-name}`:
+- Every file in the Consumed Task Set
+- `docs/plans/tasks/{plan-name}-phase*-completion.md`
+- `docs/plans/tasks/_overview-{plan-name}.md`
+
+Preserve the work plan itself.
 
 If cleanup fails, report the failed path but do not invalidate completed implementation work.
 

--- a/.agents/skills/recipe-front-build/SKILL.md
+++ b/.agents/skills/recipe-front-build/SKILL.md
@@ -29,8 +29,29 @@ Work plan: $ARGUMENTS
 
 ## Pre-execution Prerequisites
 
-### Task File Existence Check
-Check for work plans in docs/plans/ and task files in docs/plans/tasks/.
+### Implementation Readiness Check
+
+Before task processing, locate the work plan to gate against.
+
+Resolution rule:
+1. List task files in `docs/plans/tasks/` matching `{plan-name}-frontend-task-*.md`.
+2. Exclude `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
+3. If matching task files exist, infer `{plan-name}` from the most recent matching task file and use `docs/plans/{plan-name}.md`.
+4. If no matching task files exist, use the most recent non-template work plan in `docs/plans/`.
+
+Read the work plan header and find `Implementation Readiness: <status>`.
+
+| Status | Action |
+|--------|--------|
+| `ready` | Proceed to Consumed Task Set computation |
+| `pending` or absent | Ask the user whether to continue without preflight. Recommended action is to run `$recipe-prepare-implementation [plan-path]` first. Continue only on explicit approval |
+| `escalated` | Read the work plan's Implementation Readiness Report, present remaining gaps, and continue only on explicit approval |
+
+### Consumed Task Set
+
+Compute the **Consumed Task Set** for this run: task files in `docs/plans/tasks/` matching `{plan-name}-frontend-task-*.md`, excluding `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
+
+Every subsequent reference to task files in this recipe uses this set, not an unrestricted `docs/plans/tasks/*.md` scan.
 
 ### Task Generation Decision Flow
 
@@ -38,8 +59,8 @@ Analyze task file existence state and determine the action required:
 
 | State | Criteria | Next Action |
 |-------|----------|-------------|
-| Tasks exist | .md files in tasks/ directory | User's execution instruction serves as batch approval -> Enter autonomous execution immediately |
-| No tasks + plan exists | Plan exists but no task files | Confirm with user -> spawn task-decomposer |
+| Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval -> Enter autonomous execution immediately |
+| No tasks + plan exists | Consumed Task Set is empty but plan exists | Confirm with user -> spawn task-decomposer |
 | Neither exists | No plan or task files | Error: Prerequisites not met |
 
 ## Task Decomposition Phase (Conditional)
@@ -58,7 +79,7 @@ Generate tasks from the work plan? (y/n):
 Spawn task-decomposer agent: "Read work plan at docs/plans/[plan-name].md and decompose into atomic tasks. Output: Individual task files in docs/plans/tasks/. Granularity: 1 task = 1 commit = independently executable"
 
 ### 3. Verify Generation
-Verify generated task files exist in docs/plans/tasks/.
+Recompute the Consumed Task Set and verify it is non-empty.
 
 ## Pre-execution Checklist
 
@@ -130,6 +151,12 @@ After all task cycles finish, collect all `filesModified` from every task-execut
    - Re-run only the verifier(s) that failed
    - Maximum retry count is 1 verification fix cycle; if any failed verifier still fails after re-run, escalate to the user
 5. If both verifiers pass -> Proceed to completion report
+
+## Final Cleanup
+
+Before the completion report, delete the implementation task files in the Consumed Task Set, matching phase-completion files for the same plan, and `_overview-{plan-name}.md` if present. Preserve the work plan itself.
+
+If cleanup fails, report the failed path but do not invalidate completed implementation work.
 
 **[STOP -- BLOCKING]** Upon detecting ANY requirement changes, halt execution immediately.
 **CANNOT proceed until user explicitly confirms the change scope.**

--- a/.agents/skills/recipe-front-plan/SKILL.md
+++ b/.agents/skills/recipe-front-plan/SKILL.md
@@ -48,7 +48,7 @@ Check for existence of design documents in docs/design/.
 Spawn acceptance-test-generator agent: "Generate test skeletons from Design Doc at [path]. [UI Spec at [ui-spec path] if exists.]"
 
 ### Step 3: Work Plan Creation
-Spawn work-planner agent: "Create work plan from Design Doc at [path]. Integration test file: [path from step 2]. E2E test file: [path from step 2 or null]. E2E absence reason: [value from step 2 when E2E file is null]. Integration tests are created simultaneously with each phase implementation, E2E tests are executed only in final phase when an E2E file exists."
+Spawn work-planner agent: "Create work plan from Design Doc at [path]. Integration test file: [path from step 2]. fixture-e2e test file: [path from step 2 or null]. service-integration-e2e test file: [path from step 2 or null]. E2E absence reasons by lane: [values from step 2 when an E2E lane is null]. Integration tests are created with each phase implementation, fixture-e2e runs alongside UI implementation, service-integration-e2e runs only in the final phase when a service E2E file exists. Include `Implementation Readiness: pending` in the work plan header."
 
 **[STOP -- BLOCKING]** Interact with user to complete plan and obtain approval for plan content. Clarify specific implementation steps and risks.
 **CANNOT proceed until user explicitly approves the work plan.**

--- a/.agents/skills/recipe-front-review/SKILL.md
+++ b/.agents/skills/recipe-front-review/SKILL.md
@@ -18,7 +18,8 @@ description: "Frontend Design Doc compliance and security validation with option
 - Compliance validation -> performed by code-reviewer
 - Security validation -> performed by security-reviewer
 - Rule analysis -> performed by rule-advisor
-- Fix implementation -> performed by task-executor-frontend
+- Code-side fix path -> performed by task-executor-frontend
+- Design-side update path -> performed by technical-designer-frontend in update mode, then document-reviewer, then design-sync when multiple Design Docs exist
 - Quality checks -> performed by quality-fixer-frontend
 - Re-validation -> performed by code-reviewer / security-reviewer
 
@@ -80,28 +81,39 @@ Security Review: [status from security-reviewer]
   - [policy] [location]: [description] — [rationale]
   Notes: [notes from security-reviewer, if present]
 
-Execute fixes? (y/n):
+Resolve discrepancies by route:
+  c) Code-side fix
+  d) Design-side update
+  s) Skip
+
+Default: accept all recommended routes.
 ```
 
-**[STOP -- BLOCKING]** Wait for user response on whether to execute fixes.
-**CANNOT proceed with auto-fixes without user approval.**
+Before presenting results, recommend a route for each finding:
+- Use `d` when implementation intent matches the requirement but the Design Doc is stale or too narrow.
+- Use `c` when code drifted from a still-correct Design Doc, or when the finding is reliability, security, or maintainability related.
+- Use `s` only when the user explicitly accepts the current state without changes.
 
-If both pass and user selects `n`: Skip fix steps, proceed to Final Report.
+**[STOP -- BLOCKING]** Wait for user response on routes.
+**CANNOT proceed with fixes or document updates without user approval.**
 
-If user selects `y`:
+If all findings are skipped: Skip fix steps, proceed to Final Report.
 
 ## Pre-fix Metacognition
 
 1. **Spawn rule-advisor agent**: "Analyze fixes needed. Code issues: $STEP_2_OUTPUT. Security findings: $STEP_3_OUTPUT. Determine root solutions vs symptomatic treatments."
-2. **Register tasks**: Register work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Create task file -> `docs/plans/tasks/review-fixes-YYYYMMDD.md`. Include both code compliance issues and security requiredFixes.
-3. **Spawn task-executor-frontend agent**: "Execute staged auto-fixes for [task-file-path]. Stop at 5 files."
-4. **Spawn quality-fixer-frontend agent**: "Execute all frontend quality checks and confirm quality gate passage"
-5. **Re-validate code-reviewer**: Spawn code-reviewer agent: "Re-validate compliance for [design-doc-path]. Prior issues: $STEP_2_OUTPUT. Measure improvement."
-6. **Re-validate security-reviewer** (only if security fixes were applied): Spawn security-reviewer agent: "Re-validate security after fixes. Prior findings: $STEP_3_OUTPUT. Design Doc: [path]. Implementation files: [union of $STEP_1_FILES and task-executor-frontend filesModified from step 3, deduplicated]."
+2. **Design-side update**: If any finding is routed to `d`, spawn technical-designer-frontend in update mode, then document-reviewer, then design-sync when multiple Design Docs exist. If both `d` and `c` routes exist, re-evaluate `c` findings against the updated Design Doc and drop any now satisfied.
+3. **Register tasks**: Register work steps. Always include: first "Confirm skill constraints", final "Verify skill fidelity". Create task file -> `docs/plans/tasks/review-fixes-YYYYMMDD.md`. Include only code compliance issues and security requiredFixes routed to `c`.
+4. **Spawn task-executor-frontend agent**: "Execute staged auto-fixes for [task-file-path]. Stop at 5 files."
+5. **Spawn quality-fixer-frontend agent**: "Execute all frontend quality checks and confirm quality gate passage"
+6. **Re-validate code-reviewer**: Spawn code-reviewer agent: "Re-validate compliance for [design-doc-path]. Prior issues: $STEP_2_OUTPUT. Measure improvement."
+7. **Re-validate security-reviewer** (only if security fixes were applied): Spawn security-reviewer agent: "Re-validate security after fixes. Prior findings: $STEP_3_OUTPUT. Design Doc: [path]. Implementation files: [union of $STEP_1_FILES and task-executor-frontend filesModified from step 4, deduplicated]."
 
 ENFORCEMENT: Auto-fixes MUST go through quality-fixer-frontend before re-validation. Skipping quality checks invalidates fixes.
 
 ### Final Report
+Delete the review-fix task file this recipe created, if present. Its work is committed; `docs/plans/` is ephemeral working state.
+
 ```
 Code Compliance:
   Initial: [X]%

--- a/.agents/skills/recipe-front-review/SKILL.md
+++ b/.agents/skills/recipe-front-review/SKILL.md
@@ -87,6 +87,12 @@ Resolve discrepancies by route:
   s) Skip
 
 Default: accept all recommended routes.
+
+Accepted response formats:
+- empty input -- accept every recommended route
+- `all-recommended` -- accept every recommended route
+- `all:c`, `all:d`, or `all:s` -- apply one route to every finding
+- Per-finding routes, e.g. `F1:c, F2:d, F3:s`
 ```
 
 Before presenting results, recommend a route for each finding:

--- a/.agents/skills/recipe-fullstack-build/SKILL.md
+++ b/.agents/skills/recipe-fullstack-build/SKILL.md
@@ -39,8 +39,29 @@ Work plan: $ARGUMENTS
 
 ## Pre-execution Prerequisites
 
-### Task File Existence Check
-Check for work plans in docs/plans/ and task files in docs/plans/tasks/.
+### Implementation Readiness Check
+
+Before task processing, locate the work plan to gate against.
+
+Resolution rule:
+1. List task files in `docs/plans/tasks/` matching `{plan-name}-backend-task-*.md` or `{plan-name}-frontend-task-*.md`.
+2. Exclude `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
+3. If matching task files exist, infer `{plan-name}` from the most recent matching task file and use `docs/plans/{plan-name}.md`.
+4. If no matching task files exist, use the most recent non-template work plan in `docs/plans/`.
+
+Read the work plan header and find `Implementation Readiness: <status>`.
+
+| Status | Action |
+|--------|--------|
+| `ready` | Proceed to Consumed Task Set computation |
+| `pending` or absent | Ask the user whether to continue without preflight. Recommended action is to run `$recipe-prepare-implementation [plan-path]` first. Continue only on explicit approval |
+| `escalated` | Read the work plan's Implementation Readiness Report, present remaining gaps, and continue only on explicit approval |
+
+### Consumed Task Set
+
+Compute the **Consumed Task Set** for this run: task files in `docs/plans/tasks/` matching `{plan-name}-backend-task-*.md` or `{plan-name}-frontend-task-*.md`, excluding `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
+
+Every subsequent reference to task files in this recipe uses this set, not an unrestricted `docs/plans/tasks/*.md` scan.
 
 ### Task Generation Decision Flow
 
@@ -48,8 +69,8 @@ Analyze task file existence state and determine the action required:
 
 | State | Criteria | Next Action |
 |-------|----------|-------------|
-| Tasks exist | .md files in tasks/ directory | User's execution instruction serves as batch approval -> Enter autonomous execution immediately |
-| No tasks + plan exists | Plan exists but no task files | Confirm with user -> spawn task-decomposer |
+| Tasks exist | Consumed Task Set is non-empty | User's execution instruction serves as batch approval -> Enter autonomous execution immediately |
+| No tasks + plan exists | Consumed Task Set is empty but plan exists | Confirm with user -> spawn task-decomposer |
 | Neither exists | No plan or task files | Error: Prerequisites not met |
 
 ## Task Decomposition Phase (Conditional)
@@ -68,7 +89,7 @@ Generate tasks from the work plan? (y/n):
 Spawn task-decomposer agent: "Read work plan at docs/plans/[plan-name].md and decompose into atomic tasks. Output: Individual task files in docs/plans/tasks/. Granularity: 1 task = 1 commit = independently executable. Use layer-aware naming: {plan}-backend-task-{n}.md, {plan}-frontend-task-{n}.md based on target file paths."
 
 ### 3. Verify Generation
-Verify generated task files exist in docs/plans/tasks/.
+Recompute the Consumed Task Set and verify it is non-empty.
 
 ## Pre-execution Checklist
 
@@ -140,6 +161,12 @@ After all task cycles finish, collect all `filesModified` from every task-execut
    - Re-run only the verifier(s) that failed
    - Maximum retry count is 1 verification fix cycle; if any failed verifier still fails after re-run, escalate to the user
 5. If all verifiers pass -> Proceed to completion report
+
+## Final Cleanup
+
+Before the completion report, delete the implementation task files in the Consumed Task Set, matching phase-completion files for the same plan, and `_overview-{plan-name}.md` if present. Preserve the work plan itself.
+
+If cleanup fails, report the failed path but do not invalidate completed implementation work.
 
 **[STOP -- BLOCKING]** Upon detecting ANY requirement changes, halt execution immediately.
 **CANNOT proceed until user explicitly confirms the change scope.**

--- a/.agents/skills/recipe-fullstack-build/SKILL.md
+++ b/.agents/skills/recipe-fullstack-build/SKILL.md
@@ -44,18 +44,13 @@ Work plan: $ARGUMENTS
 Before task processing, locate the work plan to gate against.
 
 Resolution rule:
-1. List task files in `docs/plans/tasks/` matching `{plan-name}-backend-task-*.md` or `{plan-name}-frontend-task-*.md`.
-2. Exclude `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
-3. If matching task files exist, infer `{plan-name}` from the most recent matching task file and use `docs/plans/{plan-name}.md`.
-4. If no matching task files exist, use the most recent non-template work plan in `docs/plans/`.
+1. If `$ARGUMENTS` contains a work plan path, use that exact file and derive `{plan-name}` from its basename. This takes precedence over task-file mtimes.
+2. If `$ARGUMENTS` is empty, list task files in `docs/plans/tasks/` matching `{plan-name}-backend-task-*.md` or `{plan-name}-frontend-task-*.md`.
+3. Exclude `*-task-prep-*.md`, `_overview-*.md`, `*-phase*-completion.md`, `review-fixes-*.md`, and `integration-tests-*-task-*.md`.
+4. If matching task files exist, infer `{plan-name}` from the most recent matching task file and use `docs/plans/{plan-name}.md`.
+5. If no matching task files exist, use the most recent non-template work plan in `docs/plans/`.
 
-Read the work plan header and find `Implementation Readiness: <status>`.
-
-| Status | Action |
-|--------|--------|
-| `ready` | Proceed to Consumed Task Set computation |
-| `pending` or absent | Ask the user whether to continue without preflight. Recommended action is to run `$recipe-prepare-implementation [plan-path]` first. Continue only on explicit approval |
-| `escalated` | Read the work plan's Implementation Readiness Report, present remaining gaps, and continue only on explicit approval |
+Read the work plan header and apply the Implementation Readiness Marker Contract from `subagents-orchestration-guide`.
 
 ### Consumed Task Set
 
@@ -164,7 +159,12 @@ After all task cycles finish, collect all `filesModified` from every task-execut
 
 ## Final Cleanup
 
-Before the completion report, delete the implementation task files in the Consumed Task Set, matching phase-completion files for the same plan, and `_overview-{plan-name}.md` if present. Preserve the work plan itself.
+Before the completion report, delete only these files for the current `{plan-name}`:
+- Every file in the Consumed Task Set
+- `docs/plans/tasks/{plan-name}-phase*-completion.md`
+- `docs/plans/tasks/_overview-{plan-name}.md`
+
+Preserve the work plan itself.
 
 If cleanup fails, report the failed path but do not invalidate completed implementation work.
 

--- a/.agents/skills/recipe-fullstack-implement/SKILL.md
+++ b/.agents/skills/recipe-fullstack-implement/SKILL.md
@@ -120,13 +120,7 @@ ENFORCEMENT: Sub-agent prompts missing the constraint suffix MUST be re-issued w
 
 ### Implementation Readiness Gate
 
-Before executing task files, read the associated work plan header:
-
-| Status | Action |
-|--------|--------|
-| `ready` | Proceed |
-| `pending` or absent | Recommend running `$recipe-prepare-implementation [plan-path]`; continue only on explicit user approval |
-| `escalated` | Present the Implementation Readiness Report remaining gaps; continue only on explicit user approval |
+Before executing task files, execute the Implementation Readiness Preflight Procedure from `subagents-orchestration-guide` for the approved work plan exact path. This means loading the work plan, evaluating R1-R5, resolving approved prep gaps through exact prep task files when needed, persisting the Readiness Report, and setting `Implementation Readiness: ready` or `escalated`. Then apply the Implementation Readiness Marker Contract before entering autonomous execution.
 
 **Agent routing by task filename** (see monorepo-flow.md reference):
 ```

--- a/.agents/skills/recipe-fullstack-implement/SKILL.md
+++ b/.agents/skills/recipe-fullstack-implement/SKILL.md
@@ -101,6 +101,7 @@ When user responds to questions:
 **Required Flow Compliance**:
 - Run quality-fixer (layer-appropriate) before every commit
 - Obtain user approval before Edit/Write outside autonomous mode
+- Run implementation readiness preflight for the approved work plan before autonomous implementation, or continue without it only after explicit user approval
 
 ENFORCEMENT: Commits without quality-fixer approval are invalid and MUST be reverted.
 
@@ -116,6 +117,16 @@ Autonomous sub-agents require scope constraints for stable execution. MUST appen
 ENFORCEMENT: Sub-agent prompts missing the constraint suffix MUST be re-issued with the constraint appended.
 
 ## Task Execution Quality Cycle (Filename-Pattern-Based)
+
+### Implementation Readiness Gate
+
+Before executing task files, read the associated work plan header:
+
+| Status | Action |
+|--------|--------|
+| `ready` | Proceed |
+| `pending` or absent | Recommend running `$recipe-prepare-implementation [plan-path]`; continue only on explicit user approval |
+| `escalated` | Present the Implementation Readiness Report remaining gaps; continue only on explicit user approval |
 
 **Agent routing by task filename** (see monorepo-flow.md reference):
 ```
@@ -152,9 +163,10 @@ After all task cycles finish, collect all `filesModified` from every task-execut
 ### Test Information Communication
 After acceptance-test-generator execution, when calling work-planner, communicate:
 - Generated integration test file path
-- Generated E2E test file path or `null`
-- E2E absence reason when no E2E file is generated
-- Explicit note that integration tests are created simultaneously with implementation, E2E tests are executed after all implementations only when an E2E file exists
+- Generated fixture-e2e test file path or `null`
+- Generated service-integration-e2e test file path or `null`
+- E2E absence reason per lane when no E2E file is generated
+- Explicit note that integration tests are created simultaneously with implementation, fixture-e2e runs alongside UI implementation, and service-integration-e2e executes after all implementations only when a service E2E file exists
 
 **[STOP -- BLOCKING]** Upon detecting ANY requirement changes, halt execution immediately.
 **CANNOT proceed until user explicitly confirms the change scope.**

--- a/.agents/skills/recipe-implement/SKILL.md
+++ b/.agents/skills/recipe-implement/SKILL.md
@@ -73,7 +73,7 @@ Follow subagents-orchestration-guide skill Large/Medium/Small scale flow exactly
 **[STOP — BLOCKING]** Present Work Plan for user approval. **CANNOT proceed until user explicitly confirms.**
 
 **STEP 5**: Run implementation readiness preflight.
-Spawn recipe-prepare-implementation workflow for the approved work plan. If the work plan remains `pending` or becomes `escalated`, present the readiness report and continue only on explicit user approval.
+Execute the Implementation Readiness Preflight Procedure from `subagents-orchestration-guide` for the approved work plan exact path. This means loading the work plan, evaluating R1-R5, resolving approved prep gaps through exact prep task files when needed, persisting the Readiness Report, and setting `Implementation Readiness: ready` or `escalated`. Apply the Implementation Readiness Marker Contract before entering autonomous execution.
 
 **STEP 6**: Enter guided autonomous execution (see Autonomous Execution Mode below) using task-executor-frontend + quality-fixer-frontend agents.
 
@@ -95,13 +95,7 @@ After user grants "batch approval for entire implementation phase", enter autono
 
 ### Implementation Readiness Gate
 
-Before executing task files, read the associated work plan header:
-
-| Status | Action |
-|--------|--------|
-| `ready` | Proceed |
-| `pending` or absent | Recommend running `$recipe-prepare-implementation [plan-path]`; continue only on explicit user approval |
-| `escalated` | Present the Implementation Readiness Report remaining gaps; continue only on explicit user approval |
+Before executing task files, read the associated work plan header and apply the Implementation Readiness Marker Contract from `subagents-orchestration-guide`.
 
 ### Task Execution Quality Cycle (4-Step Cycle per Task)
 

--- a/.agents/skills/recipe-implement/SKILL.md
+++ b/.agents/skills/recipe-implement/SKILL.md
@@ -72,7 +72,10 @@ Follow subagents-orchestration-guide skill Large/Medium/Small scale flow exactly
 **STEP 4**: Spawn acceptance-test-generator agent → spawn work-planner agent.
 **[STOP — BLOCKING]** Present Work Plan for user approval. **CANNOT proceed until user explicitly confirms.**
 
-**STEP 5**: Enter guided autonomous execution (see Autonomous Execution Mode below) using task-executor-frontend + quality-fixer-frontend agents.
+**STEP 5**: Run implementation readiness preflight.
+Spawn recipe-prepare-implementation workflow for the approved work plan. If the work plan remains `pending` or becomes `escalated`, present the readiness report and continue only on explicit user approval.
+
+**STEP 6**: Enter guided autonomous execution (see Autonomous Execution Mode below) using task-executor-frontend + quality-fixer-frontend agents.
 
 ---
 
@@ -89,6 +92,16 @@ Follow subagents-orchestration-guide `references/monorepo-flow.md` for the compl
 ## Autonomous Execution Mode
 
 After user grants "batch approval for entire implementation phase", enter autonomous execution.
+
+### Implementation Readiness Gate
+
+Before executing task files, read the associated work plan header:
+
+| Status | Action |
+|--------|--------|
+| `ready` | Proceed |
+| `pending` or absent | Recommend running `$recipe-prepare-implementation [plan-path]`; continue only on explicit user approval |
+| `escalated` | Present the Implementation Readiness Report remaining gaps; continue only on explicit user approval |
 
 ### Task Execution Quality Cycle (4-Step Cycle per Task)
 
@@ -136,9 +149,10 @@ After all task cycles finish, collect all `filesModified` from every executor re
 ### Test Information Communication
 After acceptance-test-generator execution, when spawning work-planner, communicate:
 - Generated integration test file path
-- Generated E2E test file path or `null`
-- E2E absence reason when no E2E file is generated
-- Note: integration tests are created with implementation; E2E tests run after all implementations when an E2E file exists
+- Generated fixture-e2e test file path or `null`
+- Generated service-integration-e2e test file path or `null`
+- E2E absence reason per lane when no E2E file is generated
+- Note: integration tests are created with implementation; fixture-e2e runs alongside UI implementation; service-integration-e2e runs after all implementations when a service E2E file exists
 
 ## Completion Criteria
 

--- a/.agents/skills/recipe-plan/SKILL.md
+++ b/.agents/skills/recipe-plan/SKILL.md
@@ -45,14 +45,14 @@ Follow the planning process below:
 Check for existence of design documents in docs/design/, notify user if none exist.
 Present options if multiple exist (can be specified with $ARGUMENTS).
 
-### Step 2: E2E Test Skeleton Generation Confirmation
-- Confirm with user whether to generate E2E test skeleton first
+### Step 2: Integration/E2E Test Skeleton Generation Confirmation
+- Confirm with user whether to generate integration and E2E test skeletons first
 - If user wants generation: Spawn acceptance-test-generator agent: "Generate test skeletons from Design Doc at [design-doc-path]"
 - Pass generation results to next process according to subagents-orchestration-guide skill coordination specification
-- If no E2E file is generated, carry the explicit `e2eAbsenceReason` forward as a valid planning input
+- If no E2E file is generated for a lane, carry the explicit lane-specific `e2eAbsenceReason` forward as a valid planning input
 
 ### Step 3: Work Plan Creation
-- Spawn work-planner agent: "Create work plan from design document at [design-doc-path]. Include deliverables from previous process according to subagents-orchestration-guide skill coordination specification. If `generatedFiles.e2e` is null, use `e2eAbsenceReason` and accept the null E2E file as a valid planning input."
+- Spawn work-planner agent: "Create work plan from design document at [design-doc-path]. Include deliverables from previous process according to subagents-orchestration-guide skill coordination specification. If `generatedFiles.fixtureE2e` or `generatedFiles.serviceE2e` is null, use the corresponding `e2eAbsenceReason` and accept the null E2E lane as a valid planning input. Include `Implementation Readiness: pending` in the work plan header."
 - Interact with user to complete plan and obtain approval for plan content
 - Clarify specific implementation steps and risks
 
@@ -61,7 +61,7 @@ Present options if multiple exist (can be specified with $ARGUMENTS).
 ## Completion Criteria
 
 - [ ] Design document identified and selected
-- [ ] E2E test skeleton generation confirmed with user (generated if requested)
+- [ ] Integration/E2E test skeleton generation confirmed with user (generated if requested)
 - [ ] Work plan created via work-planner
 - [ ] Plan content approved by user
 - [ ] All stopping points honored with user confirmation

--- a/.agents/skills/recipe-prepare-implementation/SKILL.md
+++ b/.agents/skills/recipe-prepare-implementation/SKILL.md
@@ -23,15 +23,7 @@ Work plan: $ARGUMENTS
 
 ## Readiness Marker Contract
 
-Work plans use the header line `Implementation Readiness: <status>`.
-
-| Status | Meaning |
-|--------|---------|
-| `pending` | Initial state from work-planner; readiness has not been checked |
-| `ready` | Readiness scan completed and no applicable failures remain |
-| `escalated` | Readiness scan completed, but one or more failures remain |
-
-If the line is absent, treat the work plan as `pending` and insert the line after `Related Issue/PR:` when persisting the report.
+Use the Implementation Readiness Marker Contract defined in `subagents-orchestration-guide`. If the line is absent, treat the work plan as `pending` and insert it after `Related Issue/PR:` when persisting the report.
 
 ## Readiness Criteria
 
@@ -43,9 +35,9 @@ Each criterion produces `pass`, `fail`, or `not_applicable`, with file:line evid
 | R2 | E2E prerequisites are addressed | For each fixture-e2e or service-integration-e2e skeleton, every noted precondition is present in the codebase or covered by a Phase 0 task |
 | R3 | Phase 1 observability exists | The first implementation phase includes at least one operation verification method executable at task completion using existing files, prior Phase 0 deliverables, or the task's own output |
 | R4 | UI rendering surface exists | When the plan implements UI components, a fixture entry, dev route, Storybook story, preview harness, or equivalent render surface exists or is covered by a Phase 0 task |
-| R5 | Local lane procedure exists | The work plan or referenced docs record commands needed to run the relevant local lane, including startup commands, ports, seed steps, and required environment variables |
+| R5 | Local lane procedure exists | The work plan or referenced docs record commands needed to run the relevant local service stack or browser harness, including startup commands, ports, seed steps, and required environment variables |
 
-R4 applies only to UI work. R5 applies when the plan uses a local service stack, browser harness, or manual verification lane.
+R4 applies only to UI work. R5 applies when the plan uses a local service stack or browser harness.
 
 ## Execution Flow
 
@@ -91,7 +83,7 @@ When one or more criteria fail:
    - Backend prep: `{plan-name}-backend-task-prep-{NN}.md`
    - Frontend prep: `{plan-name}-frontend-task-prep-{NN}.md`
    - Single-layer prep: `{plan-name}-task-prep-{NN}.md`
-3. Insert the tasks into the work plan as Phase 0 before Phase 1.
+3. Insert the tasks into the work plan's existing Phase 0 when one exists. If no Phase 0 exists, create `Phase 0: Implementation Readiness Prep` before Phase 1. Keep existing Phase 0 task IDs stable; assign prep task IDs after existing Phase 0 tasks or use a clearly labeled `P0-PREP-N` identifier when the plan's numbering would otherwise require renumbering.
 4. Each prep task must include Investigation Targets, concrete implementation steps, and Operation Verification Methods.
 
 Layer selection:
@@ -103,7 +95,7 @@ Layer selection:
 ### Step 5: Execute Prep Tasks
 
 Run each prep task through the standard 4-step cycle:
-1. Spawn the layer-appropriate task executor.
+1. Spawn the layer-appropriate task executor with the exact prep task path in the prompt: "Execute implementation-readiness prep task. Task file: [exact prep task path]."
 2. Check for `blocked` or `escalation_needed`.
 3. Spawn the layer-appropriate quality fixer with the task file as `task_file`.
 4. Commit only when the quality fixer returns `approved`.
@@ -121,8 +113,13 @@ After prep tasks are complete:
 1. Re-run the readiness scan.
 2. Persist or replace `## Implementation Readiness Report` in the work plan.
 3. Set the header to `Implementation Readiness: ready` when all applicable criteria pass, otherwise `Implementation Readiness: escalated`.
-4. Delete only the prep task files created by this recipe for the current work plan and the Phase 0 completion file if generated.
-5. Report remaining gaps if any.
+4. Collapse completed prep tasks out of active plan execution: remove the Phase 0 readiness prep task entries from the work plan and record their committed evidence under `Resolution Tasks Executed` in the Readiness Report. If Phase 0 becomes empty and was created only by this recipe, remove that Phase 0 section. Preserve any pre-existing Phase 0 content.
+5. Delete only these files for the current `{plan-name}`:
+   - `docs/plans/tasks/{plan-name}-task-prep-*.md`
+   - `docs/plans/tasks/{plan-name}-backend-task-prep-*.md`
+   - `docs/plans/tasks/{plan-name}-frontend-task-prep-*.md`
+   - `docs/plans/tasks/{plan-name}-phase0-completion.md`
+6. Report remaining gaps if any.
 
 ## Readiness Report Format
 
@@ -132,6 +129,7 @@ After prep tasks are complete:
 Work plan: [path]
 Outcome: ready | escalated
 Gaps resolved: [N]
+phase0_created_by_recipe: true | false
 
 ### Readiness Criteria
 
@@ -160,5 +158,5 @@ Gaps resolved: [N]
 - [ ] Re-scan completed after prep tasks
 - [ ] Work plan readiness marker updated to `ready` or `escalated`
 - [ ] Readiness Report persisted in the work plan
+- [ ] Completed prep task references collapsed into the Readiness Report
 - [ ] Prep task files created by this recipe removed from `docs/plans/tasks/`
-

--- a/.agents/skills/recipe-prepare-implementation/SKILL.md
+++ b/.agents/skills/recipe-prepare-implementation/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: recipe-prepare-implementation
+description: "Verify that an approved work plan is implementable before build execution, resolving readiness gaps through Phase 0 prep tasks when needed."
+---
+
+## Required Skills [LOAD BEFORE EXECUTION]
+
+1. [LOAD IF NOT ACTIVE] `coding-rules` -- coding standards
+2. [LOAD IF NOT ACTIVE] `testing` -- test strategy and quality gates
+3. [LOAD IF NOT ACTIVE] `ai-development-guide` -- AI development patterns
+4. [LOAD IF NOT ACTIVE] `documentation-criteria` -- document templates
+5. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination
+
+**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+
+## Purpose
+
+Run this recipe after work-plan approval and before any build or implementation execution. It verifies that the plan can be executed from Phase 1 onward without missing verification references, test prerequisites, UI render surfaces, or local execution instructions.
+
+The recipe is safe to invoke unconditionally. If all readiness criteria pass, it only updates the work plan readiness marker and report.
+
+Work plan: $ARGUMENTS
+
+## Readiness Marker Contract
+
+Work plans use the header line `Implementation Readiness: <status>`.
+
+| Status | Meaning |
+|--------|---------|
+| `pending` | Initial state from work-planner; readiness has not been checked |
+| `ready` | Readiness scan completed and no applicable failures remain |
+| `escalated` | Readiness scan completed, but one or more failures remain |
+
+If the line is absent, treat the work plan as `pending` and insert the line after `Related Issue/PR:` when persisting the report.
+
+## Readiness Criteria
+
+Each criterion produces `pass`, `fail`, or `not_applicable`, with file:line evidence where possible.
+
+| ID | Criterion | Pass Evidence |
+|----|-----------|---------------|
+| R1 | Verification Strategy references resolve | Every command, file path, function, endpoint, fixture, seed, and test reference in the work plan's Verification Strategies either exists now or is the deliverable of a task in the plan |
+| R2 | E2E prerequisites are addressed | For each fixture-e2e or service-integration-e2e skeleton, every noted precondition is present in the codebase or covered by a Phase 0 task |
+| R3 | Phase 1 observability exists | The first implementation phase includes at least one operation verification method executable at task completion using existing files, prior Phase 0 deliverables, or the task's own output |
+| R4 | UI rendering surface exists | When the plan implements UI components, a fixture entry, dev route, Storybook story, preview harness, or equivalent render surface exists or is covered by a Phase 0 task |
+| R5 | Local lane procedure exists | The work plan or referenced docs record commands needed to run the relevant local lane, including startup commands, ports, seed steps, and required environment variables |
+
+R4 applies only to UI work. R5 applies when the plan uses a local service stack, browser harness, or manual verification lane.
+
+## Execution Flow
+
+### Step 1: Load Inputs
+
+Read the work plan passed in `$ARGUMENTS`; if absent, select the most recent non-template `docs/plans/*.md`. Extract:
+- Verification Strategies
+- Quality Assurance Mechanisms
+- Design-to-Plan Traceability
+- UI Spec Component -> Task Mapping
+- Connection Map
+- test skeleton references and E2E absence reasons
+- phase structure and task IDs
+- referenced Design Docs and UI Specs
+
+If no work plan exists, stop and report the missing prerequisite.
+
+### Step 2: Readiness Scan
+
+Evaluate R1-R5 using repository search and the work plan content. Build a `## Implementation Readiness Report` regardless of outcome.
+
+For each `fail`, identify the smallest concrete prep task that closes the gap. Examples:
+- Add fixture data for a UI state
+- Add an API mock handler for fixture-e2e
+- Add a seed script for service-integration-e2e
+- Add a Storybook story, dev route, or equivalent render surface
+- Document local startup commands and required environment variables
+- Add a missing verification helper or script referenced by the plan
+
+### Step 3: No-Op Success
+
+When all applicable criteria are `pass`:
+1. Persist `## Implementation Readiness Report` in the work plan immediately after the header block.
+2. Set `Implementation Readiness: ready`.
+3. Do not create task files.
+4. Report `outcome: ready`.
+
+### Step 4: Create Resolution Tasks
+
+When one or more criteria fail:
+1. Present the proposed prep tasks to the user and continue only after explicit approval.
+2. Create task files in `docs/plans/tasks/` using the task template:
+   - Backend prep: `{plan-name}-backend-task-prep-{NN}.md`
+   - Frontend prep: `{plan-name}-frontend-task-prep-{NN}.md`
+   - Single-layer prep: `{plan-name}-task-prep-{NN}.md`
+3. Insert the tasks into the work plan as Phase 0 before Phase 1.
+4. Each prep task must include Investigation Targets, concrete implementation steps, and Operation Verification Methods.
+
+Layer selection:
+- Use frontend prep when every target is UI, browser harness, component, page, or frontend fixture work.
+- Use backend prep when every target is API, server, service, repository, database, seed, or backend fixture work.
+- Use single-layer prep for non-layered repositories.
+- Escalate if the gap crosses layers and cannot be split into separate prep tasks.
+
+### Step 5: Execute Prep Tasks
+
+Run each prep task through the standard 4-step cycle:
+1. Spawn the layer-appropriate task executor.
+2. Check for `blocked` or `escalation_needed`.
+3. Spawn the layer-appropriate quality fixer with the task file as `task_file`.
+4. Commit only when the quality fixer returns `approved`.
+
+Append this scope boundary to every subagent prompt:
+
+```
+[SYSTEM CONSTRAINT]
+This agent operates within implementation-readiness prep scope. Use the task file as the primary instruction source. Do not implement feature behavior beyond the readiness gap described by the task.
+```
+
+### Step 6: Re-Scan and Persist
+
+After prep tasks are complete:
+1. Re-run the readiness scan.
+2. Persist or replace `## Implementation Readiness Report` in the work plan.
+3. Set the header to `Implementation Readiness: ready` when all applicable criteria pass, otherwise `Implementation Readiness: escalated`.
+4. Delete only the prep task files created by this recipe for the current work plan and the Phase 0 completion file if generated.
+5. Report remaining gaps if any.
+
+## Readiness Report Format
+
+```markdown
+## Implementation Readiness Report
+
+Work plan: [path]
+Outcome: ready | escalated
+Gaps resolved: [N]
+
+### Readiness Criteria
+
+| ID | Result | Evidence |
+|----|--------|----------|
+| R1 | pass / fail / not_applicable | [file:line or missing reference] |
+| R2 | ... | ... |
+| R3 | ... | ... |
+| R4 | ... | ... |
+| R5 | ... | ... |
+
+### Resolution Tasks Executed
+- [task file path] - [one-line summary] - committed
+
+### Remaining Gaps
+- [criterion ID]: [unresolved reference] - Next action: [recommendation]
+```
+
+## Completion Criteria
+
+- [ ] Work plan loaded and relevant sections extracted
+- [ ] Readiness scan completed with evidence per criterion
+- [ ] No-op success handled when all criteria pass
+- [ ] Failing criteria converted to approved prep tasks when needed
+- [ ] Prep tasks executed through executor -> quality-fixer -> commit
+- [ ] Re-scan completed after prep tasks
+- [ ] Work plan readiness marker updated to `ready` or `escalated`
+- [ ] Readiness Report persisted in the work plan
+- [ ] Prep task files created by this recipe removed from `docs/plans/tasks/`
+

--- a/.agents/skills/recipe-prepare-implementation/agents/openai.yaml
+++ b/.agents/skills/recipe-prepare-implementation/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "recipe-prepare-implementation"
+  short_description: "Preflight work plan readiness before implementation"
+  default_prompt: "Use $recipe-prepare-implementation to verify: "
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/recipe-review/SKILL.md
+++ b/.agents/skills/recipe-review/SKILL.md
@@ -89,6 +89,12 @@ Resolve discrepancies by route:
   s) Skip
 
 Default: accept all recommended routes.
+
+Accepted response formats:
+- empty input -- accept every recommended route
+- `all-recommended` -- accept every recommended route
+- `all:c`, `all:d`, or `all:s` -- apply one route to every finding
+- Per-finding routes, e.g. `F1:c, F2:d, F3:s`
 ```
 
 Before presenting results, recommend a route for each finding:

--- a/.agents/skills/recipe-review/SKILL.md
+++ b/.agents/skills/recipe-review/SKILL.md
@@ -23,7 +23,8 @@ description: "Design Doc compliance and security validation with optional auto-f
 
 - Compliance validation -> Spawn code-reviewer agent
 - Security validation -> Spawn security-reviewer agent
-- Fix implementation -> Spawn task-executor agent
+- Code-side fix path -> Spawn task-executor agent
+- Design-side update path -> Spawn technical-designer in update mode, then document-reviewer, then design-sync when multiple Design Docs exist
 - Quality checks -> Spawn quality-fixer agent
 - Re-validation -> Spawn code-reviewer / security-reviewer agents
 
@@ -82,22 +83,41 @@ Security Review: [status from security-reviewer]
   - [policy] [location]: [description] — [rationale]
   Notes: [notes from security-reviewer, if present]
 
-Execute fixes? (y/n):
+Resolve discrepancies by route:
+  c) Code-side fix
+  d) Design-side update
+  s) Skip
+
+Default: accept all recommended routes.
 ```
 
-**[STOP — BLOCKING]** Present results to user for confirmation.
-**CANNOT proceed until user explicitly confirms.**
+Before presenting results, recommend a route for each finding:
+- Use `d` when implementation intent matches the requirement but the Design Doc is stale or too narrow.
+- Use `c` when code drifted from a still-correct Design Doc, or when the finding is reliability, security, or maintainability related.
+- Use `s` only when the user explicitly accepts the current state without changes.
 
-If both pass and user selects `n`: Skip Steps 5-10, proceed to Step 11.
+**[STOP — BLOCKING]** Present results and recommended routes to user for confirmation.
+**CANNOT proceed until user explicitly confirms routes.**
+
+If all findings are skipped: Skip Steps 5-10, proceed to Step 11.
 
 ### Step 5: Prepare Fix Context
 
 Reference documentation-criteria skill for task file template.
 
+### Step 5d: Design-Side Update
+
+Run this step only when the user routes at least one finding to `d`.
+
+1. Spawn technical-designer agent in update mode: "Update Design Doc at [path]. The implementation is being accepted as correct for these findings: [d-routed findings with code locations and current Design Doc values]. Update the relevant sections and add change history."
+2. Spawn document-reviewer agent: "Review updated Design Doc at [path] for consistency and completeness."
+3. If multiple Design Docs exist in `docs/design/`, spawn design-sync agent: "Check cross-Design Doc consistency after updating [path]."
+4. If the user selected both `d` and `c` routes, re-evaluate the `c` findings against the updated Design Doc and drop any that are now satisfied.
+
 ### Step 6: Create Task File
 
 Create task file at `docs/plans/tasks/review-fixes-YYYYMMDD.md`
-Include both code compliance issues and security requiredFixes.
+Include only code-side compliance issues and security requiredFixes routed to `c`.
 
 ### Step 7: Execute Fixes
 
@@ -116,6 +136,8 @@ Spawn code-reviewer agent: "Re-validate Design Doc compliance after fixes. Prior
 Spawn security-reviewer agent: "Re-validate security after fixes. Prior findings: $STEP_3_OUTPUT. Design Doc: [path]. Implementation files: [union of $STEP_1_FILES and task-executor filesModified from Step 7, deduplicated]."
 
 ### Step 11: Final Report
+
+Delete the review-fix task file this recipe created, if present. Its work is committed; `docs/plans/` is ephemeral working state.
 
 ```
 Code Compliance:

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -123,27 +123,10 @@ Close a running subagent only when the user redirects the workflow, the orchestr
 
 Spawn agents using natural language prompts. Provide clear context about what the agent should accomplish. Every `spawn_agent` call MUST include `fork_turns="none"` or `fork_context=false` (see Spawn rule at top of this skill).
 
-### Spawn Examples
+### Spawn Prompt Requirements
 
-Each example below is a spawn with `fork_turns="none"` or `fork_context=false` plus the quoted prompt.
-
-**requirement-analyzer** (`fork_turns="none"` or `fork_context=false`):
-> "Analyze the following requirements and determine the work scale: [user requirements]. Perform requirement analysis and scale determination."
-
-**codebase-analyzer** (`fork_turns="none"` or `fork_context=false`):
-> "Analyze the existing codebase to provide evidence for Design Doc creation. Focus on existing implementations, data model elements, and constraints the design should respect. requirement_analysis: [JSON]. prd_path: [path if available]. requirements: [original user requirements]. layer: [target layer if applicable]. target_paths: [paths if narrowed]. Return codebase facts and focus areas."
-
-**task-executor** (`fork_turns="none"` or `fork_context=false`):
-> "Execute the implementation task defined in docs/plans/tasks/[filename].md. Complete the implementation following TDD Red-Green-Refactor."
-
-**quality-fixer** (`fork_turns="none"` or `fork_context=false`):
-> "Run quality checks on the codebase: static analysis, style check, all test execution. Fix any issues found and report when all checks pass."
-
-**document-reviewer** (`fork_turns="none"` or `fork_context=false`):
-> "Review the document at [path] for quality and rule compliance. Check against documentation-criteria standards."
-
-**design-sync** (`fork_turns="none"` or `fork_context=false`):
-> "Verify consistency between Design Docs in docs/design/. Use [path] as the source document for comparison."
+- Set `fork_context=false` or `fork_turns="none"` on every spawn for context isolation.
+- Each spawn prompt must name the target deliverable, input paths, and expected result. When invoking `task-executor*`, include the exact task file path, for example: `Execute the implementation task. Task file: docs/plans/tasks/[filename].md.`
 
 ## Explicit Stop Points [MANDATORY]
 
@@ -207,7 +190,34 @@ Subagents respond in JSON format. The final response from each JSON-returning su
 | `design-sync` | `sync_status` |
 | `integration-test-reviewer` | `status`, `requiredFixes` |
 | `security-reviewer` | `status`, `findings`, `notes`, `requiredFixes` |
-| `acceptance-test-generator` | `status`, `generatedFiles`, lane-specific `e2eAbsenceReason` |
+| `acceptance-test-generator` | `status`, `generatedFiles.integration`, `generatedFiles.fixtureE2e`, `generatedFiles.serviceE2e`, `e2eAbsenceReason.fixtureE2e`, `e2eAbsenceReason.serviceE2e` |
+
+## Implementation Readiness Marker Contract
+
+Work plans use the header line `Implementation Readiness: <status>`.
+
+| Status | Meaning | Consumer Action |
+|--------|---------|-----------------|
+| `pending` | Initial state from work-planner; readiness has not been checked | Present the unchecked state, recommend running implementation readiness preflight, and continue only on explicit user approval |
+| `ready` | Readiness scan completed and no applicable failures remain | Proceed with task execution |
+| `escalated` | Readiness scan completed, but one or more failures remain | Read the work plan's Implementation Readiness Report, present remaining gaps, and continue only on explicit user approval |
+| absent | Older work plan without the marker | Treat as `pending` |
+
+## Implementation Readiness Preflight Procedure
+
+Use this procedure after work-plan approval and before autonomous task execution when the flow needs to verify implementation readiness.
+
+1. Load the approved work plan exact path and extract Verification Strategies, Quality Assurance Mechanisms, Design-to-Plan Traceability, UI Spec Component -> Task Mapping, Connection Map, test skeleton references, E2E absence reasons, phase structure, referenced Design Docs, and UI Specs.
+2. Evaluate these criteria with evidence:
+   - R1 Verification Strategy references resolve
+   - R2 E2E prerequisites are addressed
+   - R3 Phase 1 observability exists
+   - R4 UI rendering surface exists when UI work is present
+   - R5 Local service stack or browser harness procedure exists when applicable
+3. If every applicable criterion passes, persist `## Implementation Readiness Report` in the work plan and set `Implementation Readiness: ready`.
+4. If any criterion fails, create the smallest approved prep tasks that close the gaps, execute each exact prep task file through the standard executor -> quality-fixer -> commit cycle, then re-run the scan.
+5. After re-scan, set `Implementation Readiness: ready` when all applicable criteria pass, otherwise `Implementation Readiness: escalated`, and persist remaining gaps in the Readiness Report.
+6. Collapse completed prep task references into the Readiness Report and delete only the prep task files created for the current work plan.
 
 ## Handling Requirement Changes
 
@@ -216,17 +226,7 @@ requirement-analyzer follows the "completely self-contained" principle and proce
 
 #### How to Integrate Requirements
 
-**Important**: To maximize accuracy, integrate requirements as complete sentences, including all contextual information communicated by the user.
-
-```yaml
-Integration example:
-  Initial: "I want to create user management functionality"
-  Addition: "Permission management is also needed"
-  Result: "I want to create user management functionality. Permission management is also needed.
-
-          Initial requirement: I want to create user management functionality
-          Additional requirement: Permission management is also needed"
-```
+Integrate initial requirements and later additions as complete sentences, preserving all contextual information communicated by the user. The updated input must remain self-contained without relying on prior conversation turns.
 
 ### Update Mode for Document Generation Agents
 Document generation agents (work-planner, technical-designer, prd-creator) can update existing documents in `update` mode.
@@ -350,7 +350,7 @@ Maximum retry count is 1 verification fix cycle. If any failed verifier still fa
 | `codebase-analyzer` | `technical-designer*` | `Codebase Analysis`, including `focusAreas`, `dataModel`, `qualityAssurance`, `dataTransformationPipelines`, `limitations` |
 | `technical-designer*` | `code-verifier` | Design Doc path |
 | `code-verifier` | `document-reviewer` | `code_verification` JSON |
-| `acceptance-test-generator` | `work-planner` | integration test path, fixture-e2e path or `null`, service-integration-e2e path or `null`, lane-specific `e2eAbsenceReason` when a lane is absent |
+| `acceptance-test-generator` | `work-planner` | `generatedFiles.integration`, `generatedFiles.fixtureE2e`, `generatedFiles.serviceE2e`, `e2eAbsenceReason: { fixtureE2e, serviceE2e }` |
 | Design Doc | `work-planner` | Verification Strategy summary, Output Comparison details, implementation-relevant technical requirements, protected no-change boundaries |
 
 Handoff rules:

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -207,7 +207,7 @@ Subagents respond in JSON format. The final response from each JSON-returning su
 | `design-sync` | `sync_status` |
 | `integration-test-reviewer` | `status`, `requiredFixes` |
 | `security-reviewer` | `status`, `findings`, `notes`, `requiredFixes` |
-| `acceptance-test-generator` | `status`, `generatedFiles`, `e2eAbsenceReason` |
+| `acceptance-test-generator` | `status`, `generatedFiles`, lane-specific `e2eAbsenceReason` |
 
 ## Handling Requirement Changes
 
@@ -350,11 +350,11 @@ Maximum retry count is 1 verification fix cycle. If any failed verifier still fa
 | `codebase-analyzer` | `technical-designer*` | `Codebase Analysis`, including `focusAreas`, `dataModel`, `qualityAssurance`, `dataTransformationPipelines`, `limitations` |
 | `technical-designer*` | `code-verifier` | Design Doc path |
 | `code-verifier` | `document-reviewer` | `code_verification` JSON |
-| `acceptance-test-generator` | `work-planner` | integration test path, E2E path or `null`, `e2eAbsenceReason` when E2E is absent |
+| `acceptance-test-generator` | `work-planner` | integration test path, fixture-e2e path or `null`, service-integration-e2e path or `null`, lane-specific `e2eAbsenceReason` when a lane is absent |
 | Design Doc | `work-planner` | Verification Strategy summary, Output Comparison details, implementation-relevant technical requirements, protected no-change boundaries |
 
 Handoff rules:
-- Verify generated integration and E2E file paths exist before passing them onward
+- Verify generated integration, fixture-e2e, and service-integration-e2e file paths exist before passing them onward
 - Escalate only when required outputs are missing without a valid absence reason
 - Require work-planner to map every carried-forward technical requirement to a covering task or a justified `gap`
 

--- a/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -100,7 +100,7 @@ Spawn acceptance-test-generator with all Design Docs and UI Spec:
 
 Spawn work-planner with all Design Docs:
 
-> "Create a work plan from the following documents: PRD: [path] (Large Scale only), Design Doc (backend): [path], Design Doc (frontend): [path]. Compose phases as vertical feature slices where possible -- each phase should contain both backend and frontend work for the same feature area, enabling early integration verification per phase."
+> "Create a work plan from the following documents: PRD: [path] (Large Scale only), Design Doc (backend): [path], Design Doc (frontend): [path], UI Spec: [path] (if exists). Test skeletons from acceptance-test-generator: integration: [path or null], fixtureE2e: [path or null], serviceE2e: [path or null], e2eAbsenceReason: { fixtureE2e: [value or null], serviceE2e: [value or null] }. Compose phases as vertical feature slices where possible -- each phase should contain both backend and frontend work for the same feature area, enabling early integration verification per phase. Include `Implementation Readiness: pending` in the work plan header."
 
 work-planner's existing Integration Complete criteria naturally covers cross-layer verification when given multiple Design Docs.
 

--- a/.agents/skills/task-analyzer/references/skills-index.yaml
+++ b/.agents/skills/task-analyzer/references/skills-index.yaml
@@ -4,7 +4,7 @@
 skills:
   coding-rules:
     skill: "coding-rules"
-    tags: [implementation, code-quality, refactoring, clean-code, maintainability, function-design, error-handling, parameterized-dependencies, performance, security]
+    tags: [implementation, code-quality, refactoring, clean-code, maintainability, function-design, error-handling, parameterized-dependencies, reference-representativeness, performance, security]
     typical-use: "Language-agnostic code creation, modification, and refactoring principles applicable to all programming languages"
     size: medium
     key-references:
@@ -14,23 +14,25 @@ skills:
       - "Refactoring - Martin Fowler"
       - "Single Responsibility Principle - SOLID"
     sections:
+      - "Language-Specific References"
       - "Core Philosophy [MANDATORY]"
       - "Code Quality [MANDATORY]"
       - "Function Design [MANDATORY]"
       - "Error Handling [MANDATORY]"
       - "Dependency Management"
+      - "Reference Representativeness"
       - "Performance"
       - "Code Organization"
       - "Commenting Principles"
       - "Refactoring [SAFE CHANGE PROTOCOL]"
-      - "Security (Secure Defaults, Input and Output Boundaries, Access Control, Knowledge Cutoff Supplement)"
+      - "Security"
       - "Version Control [MANDATORY]"
     references:
       - "references/typescript.md"
 
   testing:
     skill: "testing"
-    tags: [testing, tdd, quality, unit-testing, integration-testing, e2e-testing, test-design, coverage, mocking, test-independence, ci-cd, test-quality-criteria]
+    tags: [testing, tdd, quality, unit-testing, integration-testing, e2e-testing, data-layer-testing, test-design, coverage, mocking, test-independence, ci-cd, test-quality-criteria]
     typical-use: "Universal testing principles, TDD practice, test quality criteria, test creation and quality assurance for all programming languages"
     size: large
     key-references:
@@ -39,6 +41,7 @@ skills:
       - "AAA Pattern - Arrange-Act-Assert"
       - "Test Pyramid - Mike Cohn"
     sections:
+      - "Language-Specific References"
       - "Core Testing Philosophy"
       - "TDD Process [MANDATORY for all code changes]"
       - "Quality Requirements [MANDATORY]"
@@ -46,6 +49,7 @@ skills:
       - "Test Design Principles"
       - "Test Independence"
       - "Mocking and Test Doubles"
+      - "Data Layer Testing"
       - "Test Quality Practices [MANDATORY]"
       - "What to Test"
       - "Test Quality Criteria [MANDATORY]"
@@ -68,11 +72,13 @@ skills:
       - "DRY Principle - The Pragmatic Programmer"
       - "YAGNI Principle - Extreme Programming"
     sections:
+      - "Language-Specific References"
       - "Technical Anti-patterns (Red Flag Patterns) [MANDATORY]"
       - "Fail-Fast Fallback Design Principles"
       - "Rule of Three - Criteria for Code Duplication"
       - "Common Failure Patterns and Avoidance Methods"
       - "Debugging Techniques"
+      - "Quality Assurance Mechanism Awareness"
       - "Quality Check Workflow [MANDATORY]"
       - "Situations Requiring Technical Decisions"
       - "Implementation Completeness Assurance"
@@ -117,7 +123,7 @@ skills:
 
   integration-e2e-testing:
     skill: "integration-e2e-testing"
-    tags: [testing, integration-testing, e2e-testing, test-design, behavior-first, roi, test-skeleton, ears-format]
+    tags: [testing, integration-testing, e2e-testing, fixture-e2e, service-integration-e2e, e2e-absence-reason, test-design, behavior-first, roi, test-skeleton, ears-format]
     typical-use: "Integration and E2E test design principles, value-based test selection, behavior-first approach, test skeleton specification"
     size: medium
     key-references:
@@ -136,7 +142,7 @@ skills:
 
   subagents-orchestration-guide:
     skill: "subagents-orchestration-guide"
-    tags: [orchestration, workflow, subagents, autonomous-execution, planning, design-flow, implementation-flow]
+    tags: [orchestration, workflow, subagents, context-isolation, autonomous-execution, planning, design-flow, implementation-flow, implementation-readiness, readiness-gate]
     typical-use: "Orchestrating subagents through implementation workflows, scale determination, stop points, autonomous execution mode"
     size: large
     key-references:
@@ -152,6 +158,8 @@ skills:
       - "Explicit Stop Points [MANDATORY]"
       - "Scale Determination and Document Requirements"
       - "Structured Response Specification"
+      - "Implementation Readiness Marker Contract"
+      - "Implementation Readiness Preflight Procedure"
       - "Handling Requirement Changes"
       - "Basic Flow for Work Planning"
       - "Autonomous Execution Mode"

--- a/.agents/skills/testing/references/typescript.md
+++ b/.agents/skills/testing/references/typescript.md
@@ -13,9 +13,8 @@ import userEvent from '@testing-library/user-event'
 ### Coverage Requirements
 
 - **Overall minimum**: 60%
-- **Atoms (Button, Text)**: 70%+
-- **Molecules (FormField)**: 65%+
-- **Organisms (Header, Footer)**: 60%+
+- **Atomic Design projects**: Atoms 70%+, Molecules 65%+, Organisms 60%+
+- **Other component architectures**: Keep 60% as the baseline and raise foundational or highly reused components to 70%+
 - **Custom Hooks**: 65%+
 - **Utils**: 70%+
 

--- a/.codex/agents/acceptance-test-generator.toml
+++ b/.codex/agents/acceptance-test-generator.toml
@@ -58,7 +58,8 @@ Test type definitions, budgets, and value-based selection rules are specified in
 
 Key points:
 - **Integration Tests**: MAX 3 per feature, created alongside implementation
-- **E2E Tests**: MAX 1-2 per feature, executed in final phase only
+- **fixture-e2e**: MAX 3 per feature, created alongside UI implementation, mocked backend / fixture-driven state
+- **service-integration-e2e**: MAX 1-2 per feature, executed in final phase only, live local stack
 
 ## 4-Phase Generation Process
 
@@ -123,7 +124,7 @@ For each valid AC from Phase 1:
 
 **Output**: Candidate pool with value metadata
 
-### Phase 3: Value-Based Selection (Two-Pass #2)
+### Phase 3: Value-Based Selection and Lane Assignment (Two-Pass #2)
 
 Value score and E2E selection rules are defined in **integration-e2e-testing skill**.
 
@@ -138,14 +139,15 @@ Value score and E2E selection rules are defined in **integration-e2e-testing ski
 3. **Push-Down Analysis**:
    ```
    Can this be unit-tested? → Remove from integration/E2E pool
-   Already integration-tested? → Keep E2E candidate when it validates a user-facing multi-step journey
+   Already integration-tested AND verifiable in-process? → Remove from E2E pool
    ```
-4. **Journey Classification**:
+4. **Lane Assignment**:
    ```
-   User-facing multi-step journey? → Mark as reserved-slot eligible
-   Service-internal chain only? → Not reserved-slot eligible
+   UI journey verifiable with mocked backend / fixture-driven state → fixture-e2e
+   Journey correctness depends on real cross-service behavior → service-integration-e2e
+   Service-internal chain only → Not reserved-slot eligible
    ```
-5. **Sort by Value Score** (descending order)
+5. **Sort by Value Score within each lane** (descending order)
 
 **Output**: Ranked, deduplicated candidate list
 
@@ -153,16 +155,19 @@ Value score and E2E selection rules are defined in **integration-e2e-testing ski
 
 **Hard Limits per Feature**:
 - **Integration Tests**: MAX 3 tests
-- **E2E Tests**: MAX 1-2 tests
+- **fixture-e2e**: MAX 3 tests
+- **service-integration-e2e**: MAX 1-2 tests
 
 **Selection Algorithm**:
 
 ```
 1. Sort integration candidates by Value Score (descending)
 2. Select up to 3 integration candidates
-3. Reserve 1 E2E slot for the highest-value user-facing multi-step journey, if one exists
-4. Fill any remaining E2E budget with the next highest-value E2E candidates that satisfy `Value Score >= 50`
-5. If no E2E is selected, return `generatedFiles.e2e: null` with a concrete `e2eAbsenceReason`
+3. Reserve 1 fixture-e2e slot for the highest-value user-facing multi-step journey, if one exists
+4. Reserve 1 service-integration-e2e slot only when the journey needs real cross-service verification
+5. Fill remaining fixture-e2e budget with candidates that satisfy `Value Score >= 20`
+6. Fill remaining service-integration-e2e budget with candidates that satisfy `Value Score > 50`
+7. If a lane emits no tests, return its generated file as `null` with a concrete lane-specific absence reason
 ```
 
 **Output**: Final test set
@@ -198,24 +203,46 @@ Adapt comment syntax to the project's language when generating annotations.
   [Test: 'AC1: Failed payment displays error without creating order']
 ```
 
-### E2E Test File
+### fixture-e2e Test File
 
 ```
-// [Feature Name] E2E Test - Design Doc: [filename]
-// Generated: [date] | Budget Used: 1/2 E2E
-// Test Type: End-to-End Test
-// Implementation Timing: After all feature implementations complete
+// [Feature Name] fixture-e2e Test - Design Doc: [filename]
+// Generated: [date] | Budget Used: 1/3 fixture-e2e
+// Test Type: Browser UI with mocked backend / fixture-driven state
+// Implementation Timing: Alongside UI implementation
 
 [Import statement using detected test framework]
 
 [Test suite using detected framework syntax]
-  // User Journey: Complete purchase flow (browse → add to cart → checkout → payment → confirmation)
-  // Value Score: 120 | Business Value: 10 (business-critical) | Frequency: 10 (core flow) | Legal: true (PCI compliance)
-  // Verification: End-to-end user experience from product selection to order confirmation
-  // @category: e2e
+  // User Journey: Dismiss card -> Undo banner appears -> Undo restores card
+  // Value Score: 60 | Business Value: 6 | Frequency: 7 | Defect Detection: 8
+  // Verification: Browser-visible state transitions with mocked backend state
+  // @category: fixture-e2e
+  // @lane: fixture-e2e
+  // @dependency: full-ui (mocked backend)
+  // @complexity: medium
+  [Test: 'User Journey: Dismiss and undo restores the card']
+```
+
+### service-integration-e2e Test File
+
+```
+// [Feature Name] service-integration-e2e Test - Design Doc: [filename]
+// Generated: [date] | Budget Used: 1/2 service-integration-e2e
+// Test Type: End-to-end against running local stack
+// Implementation Timing: Final phase only
+
+[Import statement using detected test framework]
+
+[Test suite using detected framework syntax]
+  // User Journey: Complete purchase flow (browse -> checkout -> payment -> confirmation persisted)
+  // Value Score: 120 | Business Value: 10 (business-critical) | Frequency: 10 (core flow) | Legal: true
+  // Verification: Order persists in DB and confirmation event is emitted
+  // @category: service-integration-e2e
+  // @lane: service-integration-e2e
   // @dependency: full-system
   // @complexity: high
-  [Test: 'User Journey: Complete product purchase from browse to confirmation email']
+  [Test: 'User Journey: Complete product purchase persists order and emits confirmation']
 ```
 
 ### Generation Report
@@ -226,13 +253,18 @@ Adapt comment syntax to the project's language when generating annotations.
   "feature": "[feature name]",
   "generatedFiles": {
     "integration": "[path]/[feature].int.test.[ext]",
-    "e2e": null
+    "fixtureE2e": null,
+    "serviceE2e": null
   },
   "budgetUsage": {
     "integration": "2/3",
-    "e2e": "0/2"
+    "fixtureE2e": "0/3",
+    "serviceE2e": "0/2"
   },
-  "e2eAbsenceReason": "all_e2e_candidates_below_threshold"
+  "e2eAbsenceReason": {
+    "fixtureE2e": "all_e2e_candidates_below_threshold",
+    "serviceE2e": "no_real_service_dependency"
+  }
 }
 ```
 
@@ -242,13 +274,18 @@ Adapt comment syntax to the project's language when generating annotations.
   "feature": "[feature name]",
   "generatedFiles": {
     "integration": "[path]/[feature].int.test.[ext]",
-    "e2e": "[path]/[feature].e2e.test.[ext]"
+    "fixtureE2e": "[path]/[feature].fixture.e2e.test.[ext]",
+    "serviceE2e": "[path]/[feature].service.e2e.test.[ext]"
   },
   "budgetUsage": {
     "integration": "2/3",
-    "e2e": "1/2"
+    "fixtureE2e": "1/3",
+    "serviceE2e": "1/2"
   },
-  "e2eAbsenceReason": null
+  "e2eAbsenceReason": {
+    "fixtureE2e": null,
+    "serviceE2e": null
+  }
 }
 ```
 
@@ -256,8 +293,9 @@ Adapt comment syntax to the project's language when generating annotations.
 
 Each test case MUST have the following standard annotations for test implementation planning:
 
-- **@category**: core-functionality | integration | edge-case | ux
-- **@dependency**: none | [component names] | full-system
+- **@category**: core-functionality | integration | edge-case | ux | fixture-e2e | service-integration-e2e
+- **@lane**: integration | fixture-e2e | service-integration-e2e
+- **@dependency**: none | [component names] | full-ui (mocked backend) | full-system
 - **@complexity**: low | medium | high
 
 These annotations are used when planning and prioritizing test implementation.
@@ -282,7 +320,7 @@ These annotations are used when planning and prioritizing test implementation.
 
 ### Auto-processable
 - **Directory Absent**: Auto-create appropriate directory following detected test structure
-- **No E2E Selected**: Valid outcome when accompanied by `e2eAbsenceReason`
+- **No E2E Selected**: Valid outcome when accompanied by lane-specific `e2eAbsenceReason`
 - **Budget Exceeded by Critical Test**: Report to user
 
 ### Escalation Required
@@ -316,7 +354,7 @@ These annotations are used when planning and prioritizing test implementation.
 - **Post-execution**:
   - Completeness of selected tests
   - Dependency validity verified
-  - Integration tests and E2E tests generated in separate files
+  - Integration tests, fixture-e2e tests, and service-integration-e2e tests generated in separate files when selected
   - Generation report completeness
 
 ## Completion Gate [BLOCKING]

--- a/.codex/agents/task-decomposer.toml
+++ b/.codex/agents/task-decomposer.toml
@@ -130,8 +130,12 @@ Decompose tasks based on implementation strategy patterns determined in implemen
    |---|---|
    | Existing code modification | Files being changed, adjacent tests, relevant Design Doc sections |
    | New feature/component | Adjacent implementations in the same layer/domain, interface-defining Design Doc sections |
-   | Integration/E2E test work | Test skeleton file, target implementation under test, existing fixture/auth/setup patterns |
-   | E2E environment/setup work | Current environment config, startup scripts, seed/fixture scripts, auth flow references |
+   | Frontend component implementation | UI Spec component section cited by the work plan's UI Spec Component -> Task Mapping, interface-defining Design Doc sections, adjacent components |
+   | Frontend integration / fixture-e2e test work | UI Spec component section including state and interaction tables, test skeleton file, target implementation, fixture data, browser harness config |
+   | Integration test work | Test skeleton file, target implementation under test, existing fixture/auth/setup patterns |
+   | fixture-e2e environment/setup work | Existing fixture data, API mock layer, browser harness configuration |
+   | service-integration-e2e environment/setup work | Current environment config, startup scripts, seed scripts, auth flow references, external service stubs |
+   | Cross-boundary implementation | Connection Map rows touching the task target files, both boundary owner modules, expected signal, contract definition |
    | Bug fix/refactor | Affected code paths, failing tests, reproduction-related files |
    | Behavior replacement/rewrite | Existing implementation being replaced, observable outputs, Verification Strategy section in the Design Doc |
 
@@ -140,6 +144,8 @@ Decompose tasks based on implementation strategy patterns determined in implemen
    - Investigation Targets are file paths to read, not actions to perform
    - Use specific paths with optional hints such as `docs/design/payments.md (§ Retry Flow)` or `src/orders/service.ts (createOrder)`
    - When test skeletons exist, include them explicitly
+   - When the work plan contains a UI Spec Component -> Task Mapping table, propagate matching component sections to every task listed in the row
+   - When the work plan contains a Connection Map, propagate boundary rows touching the task's target files to every task on either side of the boundary
    - When a task matches multiple natures, include Investigation Targets from all matching rows and deduplicate overlaps
 
 7. **Implementation Pattern Consistency**
@@ -184,6 +190,25 @@ When the work plan includes a `Design-to-Plan Traceability` section:
 4. **Scope-boundary integrity**: For `scope-boundary` rows, include explicit no-change notes, protected file groups, or verification steps that keep the protected boundary out of scope.
 5. **Verification integrity**: For `verification` rows, ensure the corresponding task file includes the required comparison or verification method in Operation Verification Methods.
 6. **Prerequisite integrity**: For `prerequisite` rows, place setup, migration, seed, auth, or environment work before dependent implementation tasks.
+
+## UI Spec Propagation
+
+When the work plan includes a `UI Spec Component -> Task Mapping` section:
+
+1. For each row, locate the task IDs listed in `Covered By Task(s)`.
+2. Add the component section heading to those task files' Investigation Targets.
+3. Include the states listed in `States to Cover` in Investigation Notes and Operation Verification Methods.
+4. Preserve `gap` rows as planning issues and surface them to the caller.
+5. If a task implements UI but no component mapping row covers it, add a warning in the decomposition report.
+
+## Connection Map Propagation
+
+When the work plan includes a `Connection Map` section:
+
+1. For each boundary row, locate all tasks listed in `Covered By Task(s)`.
+2. Add both owner modules, the serialized contract, and the expected signal to each listed task's Investigation Targets or Notes.
+3. For tasks on one side of a boundary, include an Operation Verification Method that observes the expected signal from the other side.
+4. Do not infer extra boundaries from in-process imports or shared types unless the work plan explicitly maps them.
 
 ## Task File Template
 

--- a/.codex/agents/task-decomposer.toml
+++ b/.codex/agents/task-decomposer.toml
@@ -135,7 +135,7 @@ Decompose tasks based on implementation strategy patterns determined in implemen
    | Integration test work | Test skeleton file, target implementation under test, existing fixture/auth/setup patterns |
    | fixture-e2e environment/setup work | Existing fixture data, API mock layer, browser harness configuration |
    | service-integration-e2e environment/setup work | Current environment config, startup scripts, seed scripts, auth flow references, external service stubs |
-   | Cross-boundary implementation | Connection Map rows touching the task target files, both boundary owner modules, expected signal, contract definition |
+   | Cross-boundary implementation | Connection Map rows touching the task target files, caller/producer module, callee/consumer module, expected signal, contract definition |
    | Bug fix/refactor | Affected code paths, failing tests, reproduction-related files |
    | Behavior replacement/rewrite | Existing implementation being replaced, observable outputs, Verification Strategy section in the Design Doc |
 
@@ -206,9 +206,9 @@ When the work plan includes a `UI Spec Component -> Task Mapping` section:
 When the work plan includes a `Connection Map` section:
 
 1. For each boundary row, locate all tasks listed in `Covered By Task(s)`.
-2. Add both owner modules, the serialized contract, and the expected signal to each listed task's Investigation Targets or Notes.
+2. Add the caller/producer module, callee/consumer module, serialized contract, and expected signal to each listed task's Investigation Targets or Notes.
 3. For tasks on one side of a boundary, include an Operation Verification Method that observes the expected signal from the other side.
-4. Do not infer extra boundaries from in-process imports or shared types unless the work plan explicitly maps them.
+4. Propagate only boundary rows explicitly mapped in the work plan.
 
 ## Task File Template
 

--- a/.codex/agents/task-executor-frontend.toml
+++ b/.codex/agents/task-executor-frontend.toml
@@ -133,7 +133,9 @@ Use the appropriate run command based on the `packageManager` field in package.j
 
 ### 1. Task Selection
 
-Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have uncompleted checkboxes `[ ]` remaining
+If the orchestrator prompt provides a task file path, execute only that exact task file. Do not scan or select any other task file.
+
+When no task file path is provided, select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have uncompleted checkboxes `[ ]` remaining.
 
 ### 2. Task Background Understanding
 #### Investigation Targets (Required when present)
@@ -185,7 +187,7 @@ This is a repeated self-check during implementation, not a one-time pre-implemen
 
 **Implementation procedure for each checkbox item**:
 1. **Red**: Create React Testing Library test for that checkbox item (failing state)
-   ※For integration tests and fixture-e2e tests, create and execute with the related UI implementation; service-integration-e2e tests are executed in final phase only
+   ※For integration tests and fixture-e2e tests, create and execute with the related UI implementation; service-integration-e2e tests are executed in final phase only. Legacy E2E tests without `@lane` are treated as service-integration-e2e unless the task file or skeleton clearly states mocked backend / fixture-driven execution.
 2. **Green**: Implement minimum code to pass test (React function component)
 3. **Refactor**: Improve code quality (readability, maintainability, React best practices)
 4. **Progress Update [MANDATORY]**: Execute the following in sequence (cannot be omitted)
@@ -210,11 +212,6 @@ For research tasks, includes creating deliverable files specified in metadata "P
 Return one of the following as the final response (see Structured Response Specification for schemas):
 - `status: "completed"` — task fully implemented
 - `status: "escalation_needed"` — design deviation or similar component discovered
-
-## Research Task Deliverables
-
-Research/analysis tasks create deliverable files specified in metadata "Provides".
-Examples: `docs/plans/analysis/component-research.md`, `docs/plans/analysis/api-integration.md`
 
 ## Structured Response Specification
 
@@ -380,9 +377,6 @@ When repository-wide verification is insufficient to determine the appropriate d
 
 **ENFORCEMENT**: HALT if any gate unchecked. Return `status: "escalation_needed"` to caller.
 
-## Completion Criteria
-
-- [ ] Final response is a single JSON with status `completed` or `escalation_needed`
 """
 
 [[skills.config]]

--- a/.codex/agents/task-executor-frontend.toml
+++ b/.codex/agents/task-executor-frontend.toml
@@ -185,7 +185,7 @@ This is a repeated self-check during implementation, not a one-time pre-implemen
 
 **Implementation procedure for each checkbox item**:
 1. **Red**: Create React Testing Library test for that checkbox item (failing state)
-   ※For integration tests (multiple components), create and execute simultaneously with implementation; E2E tests are executed in final phase only
+   ※For integration tests and fixture-e2e tests, create and execute with the related UI implementation; service-integration-e2e tests are executed in final phase only
 2. **Green**: Implement minimum code to pass test (React function component)
 3. **Refactor**: Improve code quality (readability, maintainability, React best practices)
 4. **Progress Update [MANDATORY]**: Execute the following in sequence (cannot be omitted)
@@ -220,7 +220,7 @@ Examples: `docs/plans/analysis/component-research.md`, `docs/plans/analysis/api-
 
 ### Field Specifications
 
-**requiresTestReview**: Set to `true` when the task added or updated integration tests or E2E tests. Set to `false` for unit-test-only tasks or tasks with no tests.
+**requiresTestReview**: Set to `true` when the task added or updated integration tests, fixture-e2e tests, or service-integration-e2e tests. Set to `false` for unit-test-only tasks or tasks with no tests.
 
 ### 1. Task Completion Response
 Report in the following JSON format upon task completion (**without executing quality checks or commits**, delegating to quality assurance process):

--- a/.codex/agents/task-executor.toml
+++ b/.codex/agents/task-executor.toml
@@ -133,7 +133,9 @@ Skill Status:
 
 ### 1. Task Selection
 
-Select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have uncompleted checkboxes `[ ]` remaining
+If the orchestrator prompt provides a task file path, execute only that exact task file. Do not scan or select any other task file.
+
+When no task file path is provided, select and execute files with pattern `docs/plans/tasks/*-task-*.md` that have uncompleted checkboxes `[ ]` remaining.
 
 ### 2. Task Background Understanding
 #### Investigation Targets (Required when present)
@@ -196,6 +198,7 @@ This is a repeated self-check during implementation, not a one-time pre-implemen
 - Integration tests: Create and execute with implementation
 - fixture-e2e tests: Create and execute with the related UI/browser task when the task file specifies that lane
 - service-integration-e2e tests: Execute only in final phase when the task file specifies that lane
+- legacy E2E tests without `@lane`: Treat as service-integration-e2e unless the task file or skeleton clearly states mocked backend / fixture-driven execution
 
 #### Operation Verification
 - Execute "Operation Verification Methods" section in task
@@ -212,11 +215,6 @@ For research tasks, includes creating deliverable files specified in metadata "P
 Return one of the following as the final response (see Structured Response Specification for schemas):
 - `status: "completed"` — task fully implemented
 - `status: "escalation_needed"` — design deviation or similar function discovered
-
-## Research Task Deliverables
-
-Research/analysis tasks create deliverable files specified in metadata "Provides".
-Examples: `docs/plans/analysis/research-results.md`, `docs/plans/analysis/api-spec.md`
 
 ## Structured Response Specification
 
@@ -365,11 +363,9 @@ When repository-wide verification is insufficient to determine the appropriate d
 ```
 
 ## Execution Principles
-
 - Follow RED-GREEN-REFACTOR (see the principles in testing skill)
 - Update progress checkboxes per step
-- Escalate when: design deviation, similar functions found, investigation target not found, test environment missing
-- Escalate when dependency version or representative pattern choice cannot be determined from repository evidence
+- Escalate when design deviation, similar functions, missing investigation targets/test environment, or uncertain dependency/pattern choice blocks repository-evidence-based implementation
 - Stop after implementation and test creation — quality checks and commits are handled separately
 
 ## Completion Gate [BLOCKING]
@@ -384,9 +380,6 @@ When repository-wide verification is insufficient to determine the appropriate d
 
 **ENFORCEMENT**: HALT if any gate unchecked. Return `status: "escalation_needed"` to caller.
 
-## Completion Criteria
-
-- [ ] Final response is a single JSON with status `completed` or `escalation_needed`
 """
 
 [[skills.config]]

--- a/.codex/agents/task-executor.toml
+++ b/.codex/agents/task-executor.toml
@@ -194,7 +194,8 @@ This is a repeated self-check during implementation, not a one-time pre-implemen
 **Test types**:
 - Unit tests: RED-GREEN-REFACTOR cycle
 - Integration tests: Create and execute with implementation
-- E2E tests: Execute only (in final phase)
+- fixture-e2e tests: Create and execute with the related UI/browser task when the task file specifies that lane
+- service-integration-e2e tests: Execute only in final phase when the task file specifies that lane
 
 #### Operation Verification
 - Execute "Operation Verification Methods" section in task
@@ -221,7 +222,7 @@ Examples: `docs/plans/analysis/research-results.md`, `docs/plans/analysis/api-sp
 
 ### Field Specifications
 
-**requiresTestReview**: Set to `true` when the task added or updated integration tests or E2E tests. Set to `false` for unit-test-only tasks or tasks with no tests.
+**requiresTestReview**: Set to `true` when the task added or updated integration tests, fixture-e2e tests, or service-integration-e2e tests. Set to `false` for unit-test-only tasks or tasks with no tests.
 
 ### 1. Task Completion Response
 Report in the following JSON format upon task completion (**without executing quality checks or commits**, delegating to quality assurance process):

--- a/.codex/agents/technical-designer-frontend.toml
+++ b/.codex/agents/technical-designer-frontend.toml
@@ -119,7 +119,7 @@ Must be performed when creating Design Doc:
 1. **Approach Selection Criteria**
    - Execute Phase 1-4 of implementation-approach skill to select strategy
    - **Vertical Slice**: Complete by feature unit, minimal component dependencies, early value delivery
-   - **Horizontal Slice**: Implementation by component layer (Atoms→Molecules→Organisms), important common components, design consistency priority
+   - **Horizontal Slice**: Implementation by the project's component layering convention. Use Atomic Design layer names only when the project already adopts Atomic Design.
    - **Hybrid**: Composite, handles complex requirements
    - Document selection reason (record results of metacognitive strategy selection process)
 
@@ -267,7 +267,7 @@ Implementation sample creation checklist:
 **Design Doc**: Component hierarchy diagram and data flow diagram are mandatory. Add state transition diagram and sequence diagram for complex cases.
 
 **React Diagrams**:
-- Component hierarchy (Atoms → Molecules → Organisms → Templates → Pages)
+- Component hierarchy (use the project's existing component architecture; Atomic Design labels apply only when adopted)
 - Props flow diagram (parent → child data flow)
 - State management diagram (Context, custom hooks)
 - User interaction flow (click → state update → re-render)

--- a/.codex/agents/work-planner.toml
+++ b/.codex/agents/work-planner.toml
@@ -137,9 +137,9 @@ A boundary qualifies only when all of the following hold:
 - A serialized contract crosses the boundary, such as HTTP, RPC, event payload, queue message, or webhook payload.
 - A failure on one side creates an observable signal on the other side, such as a status code, timeout, missing field, dropped message, or persisted row.
 
-Do not include in-process package imports, shared types/constants, or internal layering within the same runtime.
+Map only boundaries satisfying all three qualifications above: separate runtime, serialized contract, and observable cross-side signal.
 
-For each boundary, record owner modules, expected signal, and covering tasks in the `Connection Map` table.
+For each boundary, record the caller/producer, callee/consumer, expected signal, and covering tasks in the `Connection Map` table.
 
 ### 6. Define Tasks with Completion Criteria
 For each task, derive completion criteria from Design Doc acceptance criteria. Apply the 3-element completion definition (Implementation Complete, Quality Complete, Integration Complete).

--- a/.codex/agents/work-planner.toml
+++ b/.codex/agents/work-planner.toml
@@ -43,7 +43,8 @@ Skill Status:
 5. Place test implementation and execution appropriately for each phase
 6. Concretize risks and countermeasures
 7. Create explicit Design-to-Plan Traceability so Design Doc technical requirements are covered without silent omission
-8. Document in progress-trackable format
+8. Propagate UI Spec component and runtime boundary context into the plan so task decomposition can pass it to executors
+9. Document in progress-trackable format
 
 ## Input Parameters
 
@@ -53,8 +54,8 @@ Skill Status:
 - **prd** (optional): Path to PRD document
 - **adr** (optional): Path to ADR document
 - **testSkeletons** (optional): Paths to integration/E2E test skeleton files from acceptance-test-generator
-  - `generatedFiles.e2e` may be `null` when no E2E skeleton is intentionally generated
-  - When provided, carry `e2eAbsenceReason` into the work plan and treat it as an explicit planning input
+  - `generatedFiles.fixtureE2e` and `generatedFiles.serviceE2e` may be `null` when a lane is intentionally not generated
+  - When provided, carry lane-specific `e2eAbsenceReason` into the work plan and treat it as an explicit planning input
 - **updateContext** (update mode only): Path to existing plan, reason for changes
 
 ## Workflow
@@ -86,7 +87,9 @@ Choose Strategy A (TDD) if test skeletons are provided, Strategy B (implementati
 - Place tasks with the lowest dependencies in earlier phases
 - Map normalized verification timing to phases as follows: `phase_1` -> earliest implementation phase, `per_phase` -> each relevant phase, `integration_phase` -> integration phase, `final_phase` -> final Quality Assurance phase
 - Include verification tasks in the phase corresponding to the Verification Strategy timing
-- When test skeletons are provided, place integration test implementation based on `@dependency` metadata from test skeletons (see Test Design Information Processing > Step 2) and place E2E test execution in the final phase
+- When test skeletons are provided, place integration test implementation based on `@dependency` metadata from test skeletons (see Test Design Information Processing > Step 2)
+- When fixture-e2e skeletons are provided, place creation/execution alongside the relevant UI implementation phase
+- When service-integration-e2e skeletons are provided, place execution-only tasks in the final phase
 - When test skeletons are not provided, include test implementation tasks based on Design Doc acceptance criteria
 - Final phase is always Quality Assurance
 
@@ -115,11 +118,36 @@ Traceability rules:
 - Any `gap` without justification is an error
 - Any justified `gap` must be flagged for user confirmation before plan approval
 
+### 5a. Map UI Spec Components to Tasks
+
+When a UI Spec is provided, map each documented component to the task(s) that implement it or test it.
+
+Rules:
+- Use the UI Spec component section heading exactly as written.
+- Identify required states such as default, loading, empty, error, and partial.
+- Record the mapping in the `UI Spec Component -> Task Mapping` table from the plan template.
+- Mark components with no covering task as `gap` with justification and user confirmation before approval.
+
+### 5b. Map Runtime Boundaries to Tasks
+
+When implementation crosses runtime, process, deployment, or service boundaries, create a `Connection Map`.
+
+A boundary qualifies only when all of the following hold:
+- The two sides run in separate processes, services, runtimes, or deployed artifacts.
+- A serialized contract crosses the boundary, such as HTTP, RPC, event payload, queue message, or webhook payload.
+- A failure on one side creates an observable signal on the other side, such as a status code, timeout, missing field, dropped message, or persisted row.
+
+Do not include in-process package imports, shared types/constants, or internal layering within the same runtime.
+
+For each boundary, record owner modules, expected signal, and covering tasks in the `Connection Map` table.
+
 ### 6. Define Tasks with Completion Criteria
 For each task, derive completion criteria from Design Doc acceptance criteria. Apply the 3-element completion definition (Implementation Complete, Quality Complete, Integration Complete).
 
 ### 7. Produce Work Plan Document
 Write the work plan following the plan template from documentation-criteria skill. Include Phase Structure Diagram and Task Dependency Diagram (mermaid).
+
+The plan header MUST include `Implementation Readiness: pending`. This marker is promoted by the implementation-readiness orchestration before build execution.
 
 ## Work Plan Output Format
 
@@ -161,7 +189,8 @@ Create Red state tests based on unit test definitions provided from previous pro
 **Test Implementation Timing and Placement**:
 - Unit tests: Phase 0 Red → Green during implementation
 - Integration tests: Create and execute at completion of relevant feature implementation (include in phase tasks like "[Feature name] implementation with integration test creation")
-- E2E tests: Execute only in final phase (execution only, no separate implementation needed)
+- fixture-e2e tests: Create and execute alongside the relevant UI feature implementation
+- service-integration-e2e tests: Execute only in final phase
 
 #### Meta Information Utilization
 Analyze meta information (@category, @dependency, @complexity, etc.) included in test definitions,
@@ -181,6 +210,7 @@ Read available test skeleton files (integration tests, and E2E tests only when p
 
 **Comment patterns to extract**:
 - `// @category:` → Test classification (core-functionality, edge-case, e2e, etc.)
+- `// @lane:` → Test lane (integration, fixture-e2e, service-integration-e2e)
 - `// @dependency:` → Dependent components (material for phase placement decisions)
 - `// @complexity:` → Complexity (high/medium/low, material for effort estimation)
 - `// Value Score:` → Priority judgment
@@ -190,6 +220,7 @@ Read available test skeleton files (integration tests, and E2E tests only when p
 1. **Dependency-based Phase Placement**
    - `// @dependency: none` → Place in earlier phases
    - `// @dependency: [component name]` → Place in phase after dependent component implementation
+   - `// @dependency: full-ui (mocked backend)` → Place alongside UI implementation
    - `// @dependency: full-system` → Place in final phase
 
 2. **Complexity-based Effort Estimation**
@@ -198,32 +229,36 @@ Read available test skeleton files (integration tests, and E2E tests only when p
 
 #### Step 3: Extract Environment Prerequisites from E2E Skeletons
 
-When E2E test skeletons are provided, first identify the E2E skeleton subset using file naming conventions such as `*.e2e.test.*` and then scan only those files for environment prerequisites in two stages:
+When E2E test skeletons are provided, first identify the E2E skeleton subset using file naming conventions such as `*.fixture.e2e.test.*`, `*.service.e2e.test.*`, or `*.e2e.test.*`, then scan only those files for environment prerequisites in two stages:
 
 **Stage 1: Detect precondition patterns**
 - `Preconditions:` annotations mentioning seed data, test users, subscriptions, or required DB state
+- `@lane: fixture-e2e` or `@dependency: full-ui (mocked backend)` combined with fixture loaders or API mock handlers
 - `@dependency: full-system` combined with auth/login setup
 - Environment variable references such as `E2E_*` or `TEST_*`
 - External service dependencies that require mock/intercept or a running local dependency
 
 **Stage 2: Generate Phase 0 setup tasks**
-- Seed data → Add a Phase 0 task for fixture or seed preparation
-- Auth fixture/login state → Add a Phase 0 task for auth setup
-- External service mocks → Add a Phase 0 task for mock/intercept setup
-- Environment configuration → Add a Phase 0 task for env var or local service configuration
+- fixture-e2e fixture data → Add a Phase 0 task for fixture state files
+- fixture-e2e mocked backend → Add a Phase 0 task for the project's API mock layer
+- fixture-e2e browser harness → Add a Phase 0 task for Playwright or the project's browser harness
+- service-integration-e2e seed data → Add a Phase 0 task for seed preparation
+- service-integration-e2e auth fixture/login state → Add a Phase 0 task for auth setup
+- service-integration-e2e external service stubs → Add a Phase 0 task for stubs or intercepts
+- service-integration-e2e environment configuration → Add a Phase 0 task for env vars and local service startup
 - Other prerequisites → Add a matching setup task with clear traceability to the E2E skeleton
 
-Place these setup tasks before implementation and annotate them as E2E setup work.
+Place these setup tasks before implementation and annotate them as E2E setup work with the relevant lane.
 
 #### Step 3a: E2E Absence Handling
 
-When `generatedFiles.e2e` is `null`:
-- Require `e2eAbsenceReason` from the generator output
+When an E2E lane generated file is `null`:
+- Require the corresponding lane-specific `e2eAbsenceReason` from the generator output
 - Record the absence reason in the work plan header
-- Skip E2E prerequisite extraction and E2E execution task creation
-- Accept the null E2E file as a valid planning input when a concrete `e2eAbsenceReason` is present
+- Skip prerequisite extraction and execution task creation for that lane
+- Accept the null E2E lane as a valid planning input when a concrete absence reason is present
 
-When `generatedFiles.e2e` is `null` and `e2eAbsenceReason` is missing:
+When an E2E lane generated file is `null` and its `e2eAbsenceReason` is missing:
 - Flag a planning gap for user confirmation before plan approval
 
 #### Step 4: Classify and Place Tests
@@ -232,7 +267,9 @@ When `generatedFiles.e2e` is `null` and `e2eAbsenceReason` is missing:
 - Setup items (Mock preparation, measurement tools, Helpers, etc.) → Prioritize in Phase 1
 - Unit tests (individual functions) → Start from Phase 0 with Red-Green-Refactor
 - Integration tests → Place as create/execute tasks when relevant feature implementation is complete
-- E2E tests → Place as execute-only tasks in final phase when an E2E skeleton exists
+- fixture-e2e tests → Place as create/execute tasks alongside relevant UI implementation
+- service-integration-e2e tests → Place as execute-only tasks in final phase when a skeleton exists
+- legacy E2E tests without a lane → Treat as service-integration-e2e unless the skeleton clearly uses mocked backend fixtures
 - Non-functional requirement tests (performance, UX, etc.) → Place in quality assurance phase
 - Risk levels ("high risk", "required", etc.) → Move to earlier phases
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ $recipe-implement Add user authentication with JWT
 
 Small changes stay lightweight. Larger tasks get structure: requirements → design → task decomposition → TDD implementation → quality gates.
 
-codex-workflows is the Codex-native counterpart of [Claude Code Workflows](https://github.com/shinpr/claude-code-workflows): same document-driven development style, adapted for Codex CLI, subagents, and GPT models.
-
 ---
 
 ## Why codex-workflows?
@@ -159,6 +157,7 @@ Invoke recipes with `$recipe-name` in Codex. Type `$recipe-` and use tab complet
 | `$recipe-task` | Single task with rule selection | Bug fixes, small changes |
 | `$recipe-design` | Requirements → ADR/Design Doc | Architecture planning |
 | `$recipe-plan` | Design Doc → test skeletons → work plan | Planning phase, including nullable E2E skeleton handling |
+| `$recipe-prepare-implementation` | Verify work plan readiness and resolve prep gaps | Pre-build check that the plan is implementable |
 | `$recipe-build` | Execute backend tasks autonomously | Resume backend implementation |
 | `$recipe-review` | Design Doc compliance and security validation with auto-fixes | Post-implementation check |
 | `$recipe-diagnose` | Problem investigation → failure-point verification → solution | Bug investigation |
@@ -181,6 +180,16 @@ Invoke recipes with `$recipe-name` in Codex. Type `$recipe-` and use tab complet
 |--------|-------------|-------------|
 | `$recipe-fullstack-implement` | Full lifecycle with separate Design Docs per layer | Cross-layer features |
 | `$recipe-fullstack-build` | Execute tasks with layer-aware agent routing | Resume cross-layer implementation |
+
+### Working State
+
+Recipes use `docs/plans/` as ephemeral working state for work plans, decomposed task files, prep tasks, review-fix tasks, and intermediate analysis files. Add it to your project's `.gitignore` unless your team intentionally wants to review those transient files:
+
+```gitignore
+docs/plans/
+```
+
+PRDs, ADRs, UI Specs, and Design Docs are durable project documents and are intended to be committed.
 
 ### Examples
 
@@ -315,6 +324,7 @@ your-project/
 │   ├── recipe-design/
 │   ├── recipe-build/
 │   ├── recipe-plan/
+│   ├── recipe-prepare-implementation/
 │   ├── recipe-review/
 │   ├── recipe-diagnose/
 │   ├── recipe-task/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.4.11",
+  "version": "0.5.0",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- add an implementation readiness preflight recipe and shared readiness marker contract
- split E2E guidance into fixture-e2e and service-integration-e2e lanes with explicit absence reasons
- tighten task selection, cleanup behavior, review route input formats, and skill index metadata

## Verification
- git diff --check
- verified key prompt contracts with rg
- verified oversized prompt files are under 400 lines with wc