### PR TITLE
Add skills index pre-commit check

### DIFF
--- a/.agents/skills/task-analyzer/references/skills-index.yaml
+++ b/.agents/skills/task-analyzer/references/skills-index.yaml
@@ -16,6 +16,7 @@ skills:
     sections:
       - "Language-Specific References"
       - "Core Philosophy [MANDATORY]"
+      - "Minimum Surface Terms [MANDATORY]"
       - "Code Quality [MANDATORY]"
       - "Function Design [MANDATORY]"
       - "Error Handling [MANDATORY]"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "codex-workflows",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",
   "repository": {
     "type": "git",
     "url": "https://github.com/shinpr/codex-workflows"
+  },
+  "scripts": {
+    "check:skills-index": "node scripts/check-skills-index.mjs",
+    "hooks:install": "git config core.hooksPath scripts/hooks"
   },
   "bin": {
     "codex-workflows": "./bin/cli.js"

--- a/scripts/check-skills-index.mjs
+++ b/scripts/check-skills-index.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const INDEX_PATH = join(ROOT, '.agents', 'skills', 'task-analyzer', 'references', 'skills-index.yaml')
+const SKILLS_DIR = join(ROOT, '.agents', 'skills')
+
+function parseSkillsIndex(content) {
+  const skills = {}
+  const lines = content.split('\n')
+
+  let currentSkill = null
+  let inSections = false
+
+  for (const [index, line] of lines.entries()) {
+    const skillMatch = /^ {2}([\w-]+):\s*$/.exec(line)
+    if (skillMatch) {
+      currentSkill = skillMatch[1]
+      skills[currentSkill] = { sections: [], lineNumber: index + 1 }
+      inSections = false
+      continue
+    }
+
+    if (!currentSkill) continue
+
+    if (/^ {4}sections:\s*$/.test(line)) {
+      inSections = true
+      continue
+    }
+
+    if (/^ {4}[\w-]+:/.test(line)) {
+      inSections = false
+      continue
+    }
+
+    if (!inSections) continue
+
+    const itemMatch = /^ {6}- "(.*)"\s*$/.exec(line)
+    if (itemMatch) {
+      skills[currentSkill].sections.push(itemMatch[1])
+    }
+  }
+
+  return skills
+}
+
+function extractH2Headings(markdown) {
+  return markdown
+    .split('\n')
+    .filter((line) => line.startsWith('## '))
+    .map((line) => line.replace(/^## /, '').trim())
+}
+
+function diffArrays(expected, actual) {
+  const max = Math.max(expected.length, actual.length)
+  const mismatches = []
+
+  for (let index = 0; index < max; index++) {
+    if (expected[index] !== actual[index]) {
+      mismatches.push({
+        index,
+        expected: expected[index] ?? '<missing>',
+        actual: actual[index] ?? '<missing>',
+      })
+    }
+  }
+
+  return mismatches
+}
+
+async function main() {
+  const indexContent = await readFile(INDEX_PATH, 'utf8')
+  const skills = parseSkillsIndex(indexContent)
+  const skillNames = Object.keys(skills)
+
+  if (skillNames.length === 0) {
+    console.error('check-skills-index: no skill entries parsed from skills-index.yaml; parser may be broken')
+    process.exit(1)
+  }
+
+  let failed = 0
+  const reports = []
+
+  for (const name of skillNames) {
+    const skillMdPath = join(SKILLS_DIR, name, 'SKILL.md')
+    let markdown
+
+    try {
+      markdown = await readFile(skillMdPath, 'utf8')
+    } catch {
+      reports.push(`x ${name}: SKILL.md not found at ${skillMdPath} (yaml entry references a non-existent skill)`)
+      failed++
+      continue
+    }
+
+    const expected = skills[name].sections
+    const actual = extractH2Headings(markdown)
+
+    if (expected.length === 0) {
+      reports.push(`! ${name}: yaml has no sections listed (expected at least one to validate)`)
+      failed++
+      continue
+    }
+
+    const mismatches = diffArrays(expected, actual)
+    if (mismatches.length === 0) {
+      reports.push(`ok ${name}: ${expected.length} sections match`)
+      continue
+    }
+
+    reports.push(`x ${name}: ${mismatches.length} mismatch(es)`)
+    for (const mismatch of mismatches) {
+      reports.push(`    [${mismatch.index}] yaml: "${mismatch.expected}"`)
+      reports.push(`        md:   "${mismatch.actual}"`)
+    }
+    failed++
+  }
+
+  for (const line of reports) {
+    console.log(line)
+  }
+
+  if (failed > 0) {
+    console.error(`\ncheck-skills-index: ${failed} skill(s) failed`)
+    console.error('Either update .agents/skills/task-analyzer/references/skills-index.yaml to match the SKILL.md headings,')
+    console.error('or update the SKILL.md headings to match the yaml. Order matters.')
+    process.exit(1)
+  }
+
+  console.log(`\ncheck-skills-index: all ${skillNames.length} skill(s) consistent`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+npm run check:skills-index --silent


### PR DESCRIPTION
## Summary
- Add a Node-based skills index consistency check for indexed SKILL.md section headings
- Add a repository-local pre-commit hook that runs the skills index check
- Add npm scripts for running the check and installing the hook path
- Bump package version to 0.6.2

## Verification
- npm run check:skills-index --silent
- scripts/hooks/pre-commit
- git diff --check