### PR TITLE
Refine skill consistency rules

### DIFF
--- a/.agents/skills/coding-rules/SKILL.md
+++ b/.agents/skills/coding-rules/SKILL.md
@@ -93,7 +93,8 @@ Nearby code is a starting point for investigation, not a sufficient basis for ad
 
 ## Commenting Principles
 
-- Document "what" and "why", not "how"
+- Prefer names, types, and structure over comments
+- Add comments only for why, limitations, edge cases, or public API contracts
 - No historical information — use version control
 - Remove commented-out code
 - Keep comments concise and timeless

--- a/.agents/skills/coding-rules/references/typescript.md
+++ b/.agents/skills/coding-rules/references/typescript.md
@@ -6,7 +6,8 @@
 - **No Unused "Just in Case" Code** - Violates YAGNI principle (Kent Beck)
 
 ## Comment Writing Rules
-- **Function Description Focus**: Describe what the code "does"
+- **Code-First Default**: Use names, types, and structure to show what the code does
+- **Intent Focus**: Use comments only for why, limitations, edge cases, or public API contracts
 - **History in Version Control**: Record development history in commits and PRs instead of code comments
 - **Timeless**: Write only content that remains valid whenever read
 - **Conciseness**: Keep explanations to necessary minimum
@@ -147,7 +148,7 @@ const response = await fetch('/api/data') // Backend handles API key authenticat
 - Delete unused code immediately
 - Delete debug `console.log()`
 - No commented-out code (manage history with version control)
-- Comments explain "why" (not "what")
+- Comments explain intent, constraints, or contracts that code cannot express directly
 
 ## Error Handling
 

--- a/.agents/skills/documentation-criteria/SKILL.md
+++ b/.agents/skills/documentation-criteria/SKILL.md
@@ -21,7 +21,7 @@ description: "Documentation creation criteria for PRD, ADR, Design Doc, UI Spec,
 | New Feature Addition (backend) | PRD -> [ADR] -> Design Doc -> Work Plan | After PRD approval |
 | New Feature Addition (frontend/fullstack) | PRD -> **UI Spec** -> [ADR] -> Design Doc -> Work Plan | UI Spec before Design Doc |
 | ADR Conditions Met (see below) | ADR -> Design Doc -> Work Plan | Start immediately |
-| 6+ Files | ADR -> Design Doc -> Work Plan (REQUIRED) | Start immediately |
+| 6+ Files | [ADR if conditions apply] -> Design Doc -> Work Plan (Design Doc + Work Plan REQUIRED) | Start immediately |
 | 3-5 Files | Design Doc -> Work Plan (REQUIRED) | Start immediately |
 | 1-2 Files | None | Direct implementation |
 
@@ -124,7 +124,7 @@ description: "Documentation creation criteria for PRD, ADR, Design Doc, UI Spec,
 `Proposed` -> `Accepted` -> `Deprecated`/`Superseded`/`Rejected`
 
 ## AI Automation Rules [MANDATORY]
-- 5+ files: MUST suggest ADR creation
+- 6+ files: MUST evaluate ADR conditions
 - Contract/data flow change detected: ADR REQUIRED
 - Check existing ADRs before implementation — ALWAYS verify alignment
 

--- a/.agents/skills/recipe-front-review/SKILL.md
+++ b/.agents/skills/recipe-front-review/SKILL.md
@@ -51,8 +51,9 @@ Spawn security-reviewer agent: "Design Doc: [path]. Implementation files: [file 
 **If security-reviewer returned `blocked`**: Stop immediately. Report the blocked finding and escalate to user. Do not proceed to fix steps.
 
 **Code compliance criteria (considering project stage)**:
-- Prototype: Pass at 70%+
-- Production: 90%+ recommended
+- `code-reviewer` verdict is `pass`
+- Coverage thresholds pass only when configured by the project, task file, work plan, or Design Doc
+- Determine pass/fail from the `code-reviewer` verdict and configured coverage thresholds; treat `complianceRate` as diagnostic context only
 
 **Security criteria**:
 - `approved` or `approved_with_notes` -> Pass

--- a/.agents/skills/recipe-review/SKILL.md
+++ b/.agents/skills/recipe-review/SKILL.md
@@ -53,8 +53,9 @@ Spawn security-reviewer agent: "Design Doc: [path]. Implementation files: [file 
 **If security-reviewer returned `blocked`**: Stop immediately. Report the blocked finding and escalate to user. Do not proceed to fix steps.
 
 **Code compliance criteria (considering project stage)**:
-- Prototype: Pass at 70%+
-- Production: 90%+ REQUIRED
+- `code-reviewer` verdict is `pass`
+- Coverage thresholds pass only when configured by the project, task file, work plan, or Design Doc
+- Determine pass/fail from the `code-reviewer` verdict and configured coverage thresholds; treat `complianceRate` as diagnostic context only
 
 **Security criteria**:
 - `approved` or `approved_with_notes` -> Pass

--- a/.agents/skills/testing/references/typescript.md
+++ b/.agents/skills/testing/references/typescript.md
@@ -207,8 +207,9 @@ export const test = base.extend<{ authenticatedPage: Page }>({
 
 ### E2E Budget
 
-- **MAX 1-2 E2E tests per feature**
-- Only generate an additional non-reserved E2E test when `Value Score >= 50`
+- Follow `integration-e2e-testing` lane limits: fixture-e2e MAX 3 and service-integration-e2e MAX 1-2 per feature
+- Generate the reserved fixture-e2e user journey when eligible
+- Only generate additional non-reserved E2E tests when the lane threshold is met (`Value Score >= 20` for fixture-e2e, `Value Score > 50` for service-integration-e2e)
 - Prefer fewer comprehensive journey tests over many granular tests
 
 ### Test Isolation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- align commenting guidance around code-first comments for intent, constraints, edge cases, and public contracts
- make ADR creation conditional on documented ADR criteria for 6+ file changes
- align TypeScript E2E guidance with fixture and service E2E lane thresholds
- delegate review pass/fail decisions to code-reviewer verdicts and configured coverage thresholds
- bump package version to 0.7.1

## Validation
- npm run check:skills-index
- git diff --check