### PR TITLE
Normalize npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "author": "Shinsuke Kagawa",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shinpr/codex-workflows"
+    "url": "git+https://github.com/shinpr/codex-workflows.git"
   },
   "scripts": {
     "check:skills-index": "node scripts/check-skills-index.mjs",
     "hooks:install": "git config core.hooksPath scripts/hooks"
   },
   "bin": {
-    "codex-workflows": "./bin/cli.js"
+    "codex-workflows": "bin/cli.js"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
## Summary
- normalize the repository URL to npm's git URL format
- remove the leading ./ from the package bin path
- prevent npm publish from auto-correcting package metadata during publish

## Validation
- npm run check:skills-index
- git diff --check
- npm --cache /private/tmp/codex-workflows-npm-cache publish --dry-run