### PR TITLE
Add LLM-friendly context skill

### DIFF
--- a/.agents/skills/llm-friendly-context/SKILL.md
+++ b/.agents/skills/llm-friendly-context/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: llm-friendly-context
+description: "Clarifies inputs, outputs, success criteria, decisions, and unresolved conditions so downstream agents can execute without guessing. Use when writing or revising LLM-facing prompts, handoffs, planning artifacts, reviews, reports, or generated instructions."
+---
+
+# LLM-Friendly Context
+
+## Purpose
+
+Use this skill when writing or revising any content another agent will execute or judge: prompts, handoffs, planning artifacts, review findings, completion reports, generated instructions, test skeleton comments, work plans, and task files.
+
+The goal is stable downstream execution. The next agent should know the target action, required inputs, accepted decisions, observable success criteria, and the condition that requires escalation.
+
+## Core Rules
+
+1. **Use positive, executable instructions**
+   - State the action the next agent should perform.
+   - Convert quality policies into observable acceptance criteria.
+   - Example: `Preserve existing public API behavior across the documented compatibility cases.`
+
+2. **Make vague instructions concrete**
+   - Replace subjective terms with observable conditions, paths, commands, schemas, examples, or decision rules.
+   - Terms that usually need clarification before handoff: `appropriate`, `proper`, `related`, `existing behavior`, `optional`, `as needed`, `if needed`, `per convention`, unresolved alternatives, `TBD`, and `placeholder`.
+
+3. **Specify output shape**
+   - Define required sections, fields, table columns, JSON keys, checklist items, or status values.
+   - For handoffs, include produced artifact paths and the exact status fields the caller must inspect.
+
+4. **Provide necessary context**
+   - Include purpose, source artifacts, hard constraints, accepted decisions, and unresolved conditions.
+   - Prefer concrete file paths and section hints over broad module names.
+
+5. **Decompose complex work into verifiable steps**
+   - Split work with 3+ objectives or sequential dependencies into ordered steps.
+   - Each step needs a checkpoint stating the evidence that proves completion.
+
+6. **Permit uncertainty explicitly**
+   - If source material is missing, contradictory, or unverifiable, state the uncertainty and required escalation.
+   - Record unknown business, product, security, compatibility, or contract decisions as blocking unresolved items with the input needed to resolve them.
+
+7. **Keep constraints proportionate**
+   - Add constraints that reduce ambiguity or preserve a real requirement.
+   - Keep simple downstream tasks lightweight when target action, context, and success criteria are already clear.
+
+## Rewrite Patterns
+
+Use these rewrites before treating a prompt, handoff, or artifact as complete.
+
+| Ambiguous form | Rewrite as |
+|---|---|
+| `optional` used as an unresolved choice | Required, omitted, or required only under a named condition |
+| Multiple alternatives that the next agent must choose between | The selected option, or a deterministic decision rule |
+| `as needed` / `if needed` | The triggering condition and required action |
+| `per convention` | The file, function, test, or documented convention to follow |
+| `related files` | Specific paths, globs, or search hints |
+| `existing behavior` | The observable behavior, source file, test, API response, or UI state to preserve |
+| `placeholder` | Exact temporary value or behavior, allowed dependencies, and verification expectation |
+| `TBD` used for required information | A blocking unresolved item with owner, required input, or escalation condition |
+| `appropriate` / `proper` | A measurable criterion or checklist |
+
+## Handoff Checklist
+
+Before sending a prompt or artifact to another agent, verify:
+
+- [ ] The target action is explicit.
+- [ ] Required input paths and source artifacts are named.
+- [ ] Accepted decisions and constraints are stated once with stable wording.
+- [ ] Output format or expected status fields are specified.
+- [ ] Success criteria are observable.
+- [ ] Ambiguous expressions have been rewritten or marked as unresolved.
+- [ ] The next agent can complete its scope through explicit choices, decision rules, or blocking unresolved items.
+
+## Generated Artifact Checklist
+
+Before writing or finalizing a generated document:
+
+- [ ] Each requirement, claim, task, test skeleton, or review finding has enough source context to trace why it exists.
+- [ ] Every executable instruction names the target, action, and expected result.
+- [ ] Verification steps say what to run or observe and what result proves success.
+- [ ] Derived artifacts preserve copied decisions with the same wording and meaning as their source artifacts.
+- [ ] Blocking missing information records the missing input and escalation condition.

--- a/.agents/skills/llm-friendly-context/agents/openai.yaml
+++ b/.agents/skills/llm-friendly-context/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "LLM-Friendly Context"
+  short_description: "Clear prompts, handoffs, and generated instructions"
+  default_prompt: "Use $llm-friendly-context to clarify this prompt, handoff, or generated artifact: "
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/recipe-add-integration-tests/SKILL.md
+++ b/.agents/skills/recipe-add-integration-tests/SKILL.md
@@ -8,6 +8,7 @@ description: "Add integration/E2E tests to existing codebase using Design Docs."
 1. [LOAD IF NOT ACTIVE] `testing` — test strategy and quality gates
 2. [LOAD IF NOT ACTIVE] `integration-e2e-testing` — integration and E2E test patterns
 3. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
+4. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-build/SKILL.md
+++ b/.agents/skills/recipe-build/SKILL.md
@@ -9,6 +9,7 @@ description: "Execute decomposed backend tasks in autonomous execution mode usin
 2. [LOAD IF NOT ACTIVE] `testing` — test strategy and quality gates
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` — AI development patterns
 4. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
+5. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-design/SKILL.md
+++ b/.agents/skills/recipe-design/SKILL.md
@@ -7,6 +7,7 @@ description: "Execute from codebase-scoped analysis to design document creation.
 
 1. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
 2. [LOAD IF NOT ACTIVE] `implementation-approach` — implementation strategy
+3. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-diagnose/SKILL.md
+++ b/.agents/skills/recipe-diagnose/SKILL.md
@@ -7,6 +7,7 @@ description: "Investigate problem, verify findings, and derive solutions through
 
 1. [LOAD IF NOT ACTIVE] `ai-development-guide` — AI development patterns
 2. [LOAD IF NOT ACTIVE] `coding-rules` — coding standards
+3. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-front-adjust/SKILL.md
+++ b/.agents/skills/recipe-front-adjust/SKILL.md
@@ -10,6 +10,7 @@ description: "Adjust an implemented UI with external resource context, focused w
 1. [LOAD IF NOT ACTIVE] `documentation-criteria` -- scale and planning criteria
 2. [LOAD IF NOT ACTIVE] `external-resource-context` -- external resource hearing and lookup
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination rules
+4. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-front-build/SKILL.md
+++ b/.agents/skills/recipe-front-build/SKILL.md
@@ -9,6 +9,7 @@ description: "Execute frontend tasks in autonomous execution mode using task-exe
 2. [LOAD IF NOT ACTIVE] `testing` -- test strategy and quality gates
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` -- AI development patterns
 4. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
+5. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-front-design/SKILL.md
+++ b/.agents/skills/recipe-front-design/SKILL.md
@@ -10,6 +10,7 @@ description: "Execute from codebase-scoped analysis to frontend design document 
 1. [LOAD IF NOT ACTIVE] `documentation-criteria` -- document quality standards
 2. [LOAD IF NOT ACTIVE] `implementation-approach` -- implementation methodology
 3. [LOAD IF NOT ACTIVE] `external-resource-context` -- external resource hearing and lookup
+4. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-front-plan/SKILL.md
+++ b/.agents/skills/recipe-front-plan/SKILL.md
@@ -10,6 +10,7 @@ description: "Create frontend work plan from design document with test skeleton 
 1. [LOAD IF NOT ACTIVE] `documentation-criteria` -- document quality standards
 2. [LOAD IF NOT ACTIVE] `implementation-approach` -- implementation methodology
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
+4. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-front-review/SKILL.md
+++ b/.agents/skills/recipe-front-review/SKILL.md
@@ -10,6 +10,7 @@ description: "Frontend Design Doc compliance and security validation with option
 1. [LOAD IF NOT ACTIVE] `coding-rules` -- coding standards
 2. [LOAD IF NOT ACTIVE] `testing` -- test strategy and quality gates
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` -- AI development patterns
+4. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-fullstack-build/SKILL.md
+++ b/.agents/skills/recipe-fullstack-build/SKILL.md
@@ -9,6 +9,7 @@ description: "Execute decomposed fullstack tasks with layer-aware agent routing 
 2. [LOAD IF NOT ACTIVE] `testing` -- test strategy and quality gates
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` -- AI development patterns
 4. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
+5. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-fullstack-implement/SKILL.md
+++ b/.agents/skills/recipe-fullstack-implement/SKILL.md
@@ -14,6 +14,7 @@ description: "Orchestrate full-cycle implementation across backend and frontend 
 5. [LOAD IF NOT ACTIVE] `implementation-approach` -- implementation methodology
 6. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
 7. [LOAD IF NOT ACTIVE] `external-resource-context` -- external resource hearing and lookup
+8. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-implement/SKILL.md
+++ b/.agents/skills/recipe-implement/SKILL.md
@@ -7,6 +7,7 @@ description: "Orchestrate the complete implementation lifecycle from requirement
 
 1. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 2. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
+3. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-plan/SKILL.md
+++ b/.agents/skills/recipe-plan/SKILL.md
@@ -8,6 +8,7 @@ description: "Create work plan from design document with optional test skeleton 
 1. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
 2. [LOAD IF NOT ACTIVE] `implementation-approach` — implementation strategy
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
+4. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-prepare-implementation/SKILL.md
+++ b/.agents/skills/recipe-prepare-implementation/SKILL.md
@@ -10,6 +10,7 @@ description: "Verify that an approved work plan is implementable before build ex
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` -- AI development patterns
 4. [LOAD IF NOT ACTIVE] `documentation-criteria` -- document templates
 5. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination
+6. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-reverse-engineer/SKILL.md
+++ b/.agents/skills/recipe-reverse-engineer/SKILL.md
@@ -8,6 +8,7 @@ description: "Generate PRD and Design Docs from existing codebase through discov
 1. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
 2. [LOAD IF NOT ACTIVE] `ai-development-guide` — AI development patterns
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
+4. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-review/SKILL.md
+++ b/.agents/skills/recipe-review/SKILL.md
@@ -8,6 +8,7 @@ description: "Design Doc compliance and security validation with optional auto-f
 1. [LOAD IF NOT ACTIVE] `coding-rules` — coding standards
 2. [LOAD IF NOT ACTIVE] `testing` — test strategy and quality gates
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` — AI development patterns
+4. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-task/SKILL.md
+++ b/.agents/skills/recipe-task/SKILL.md
@@ -6,6 +6,7 @@ description: "Execute tasks with metacognitive analysis and appropriate rule sel
 ## Required Skills [LOAD BEFORE EXECUTION]
 
 1. [LOAD IF NOT ACTIVE] `task-analyzer` — task analysis and skill selection (rule-advisor handles remaining skill selection)
+2. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/recipe-update-doc/SKILL.md
+++ b/.agents/skills/recipe-update-doc/SKILL.md
@@ -7,6 +7,7 @@ description: "Update existing design documents (Design Doc / PRD / ADR) with rev
 
 1. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
 2. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
+3. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
 

--- a/.agents/skills/task-analyzer/references/skills-index.yaml
+++ b/.agents/skills/task-analyzer/references/skills-index.yaml
@@ -208,3 +208,19 @@ skills:
       - "references/api.md"
       - "references/infra.md"
       - "references/template.md"
+
+  llm-friendly-context:
+    skill: "llm-friendly-context"
+    tags: [cross-cutting, llm-facing, prompt-writing, handoff, subagent-prompt, documentation, planning, task-decomposition, test-skeleton, generated-instructions, ambiguity-reduction, output-format, success-criteria]
+    typical-use: "Writing or revising LLM-facing prompts, subagent handoffs, design/planning artifacts, review findings, completion reports, generated instructions, and task files so downstream agents can execute without guessing"
+    size: small
+    key-references:
+      - "Rewrite Patterns"
+      - "Handoff Checklist"
+      - "Generated Artifact Checklist"
+    sections:
+      - "Purpose"
+      - "Core Rules"
+      - "Rewrite Patterns"
+      - "Handoff Checklist"
+      - "Generated Artifact Checklist"

--- a/.codex/agents/acceptance-test-generator.toml
+++ b/.codex/agents/acceptance-test-generator.toml
@@ -28,6 +28,7 @@ Skill Status:
 ✓ testing/SKILL.md - ACTIVE
 ✓ documentation-criteria/SKILL.md - ACTIVE
 ✓ integration-e2e-testing/SKILL.md - ACTIVE
+✓ llm-friendly-context/SKILL.md - ACTIVE
 ```
 
 ## Mandatory Initial Tasks
@@ -361,4 +362,8 @@ enabled = true
 
 [[skills.config]]
 path = ".agents/skills/integration-e2e-testing/SKILL.md"
+enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
 enabled = true

--- a/.codex/agents/codebase-analyzer.toml
+++ b/.codex/agents/codebase-analyzer.toml
@@ -158,3 +158,7 @@ enabled = true
 [[skills.config]]
 path = ".agents/skills/coding-rules/SKILL.md"
 enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
+enabled = true

--- a/.codex/agents/design-sync.toml
+++ b/.codex/agents/design-sync.toml
@@ -28,6 +28,7 @@ Operates in an independent context, executing autonomously until task completion
 Skill Status:
 ✓ documentation-criteria/SKILL.md - ACTIVE
 ✓ coding-rules/SKILL.md - ACTIVE
+✓ llm-friendly-context/SKILL.md - ACTIVE
 ```
 
 ## Initial Mandatory Tasks
@@ -378,4 +379,8 @@ enabled = true
 
 [[skills.config]]
 path = ".agents/skills/coding-rules/SKILL.md"
+enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
 enabled = true

--- a/.codex/agents/document-reviewer.toml
+++ b/.codex/agents/document-reviewer.toml
@@ -27,6 +27,7 @@ Skill Status:
 ✓ documentation-criteria/SKILL.md - ACTIVE
 ✓ coding-rules/SKILL.md - ACTIVE
 ✓ testing/SKILL.md - ACTIVE
+✓ llm-friendly-context/SKILL.md - ACTIVE
 ```
 
 ## Initial Mandatory Tasks
@@ -133,6 +134,7 @@ For WorkPlan, additionally verify:
 - **Verification Strategy quality check**: When the Verification Strategy section exists, verify that: (1) correctness definition is specific and measurable, (2) target comparison and observable success indicator are concrete when the change modifies observable behavior, external contracts, integrations, or data flow, (3) internal-only refactoring with identical observable inputs and outputs may use the minimal form, (4) verification method can detect the change's primary risk, (5) verification timing uses the normalized vocabulary or an explicit `N/A` rationale for minimal form, and (6) vertical-slice designs do not defer all verification to the final phase
 - **Output comparison check**: When the Design Doc changes existing observable behavior, an external contract, or a persisted data shape, verify that a concrete output comparison method is defined with identical input, expected output fields or format, and diff method. When upstream analysis includes `dataTransformationPipelines`, each listed step must be mapped to the comparison that verifies it; steps excluded because data passes through unchanged must include rationale. Missing mappings or rationale → `important` issue (category: `completeness`)
 - **Minimal Surface Alternatives check**: Applies when the Design Doc proposes new in-scope elements as defined by coding-rules "Minimum Surface Terms". Reverse-engineer/as-is Design Docs are exempt. Missing or empty section when the trigger fires → `critical` issue (category: `completeness`). For each entry verify: (1) Step 1 lists at least one AC ID or accepted technical constraint from the Design Doc or referenced UI Spec; speculative-only linkage → `critical` issue (category: `compliance`). (2) Steps 2-3 include at least one subtractive alternative such as derive, compute on demand, keep at caller, reuse existing, or do not introduce new state/mode/abstraction; missing subtractive alternative → `important` issue (category: `compliance`). (3) Step 4 selects the smallest alternative or names a current requirement smaller alternatives fail to satisfy; primary rationale based on coding-rules subjective-only rationales → `critical` issue (category: `compliance`). (4) Step 5 records rejected alternatives with brief rationale; missing rejected alternatives log → `important` issue (category: `completeness`)
+- **LLM-facing artifact clarity check**: Review prompts, handoffs, planning artifacts, reviews, reports, generated instructions, and downstream-facing document sections against llm-friendly-context. Missing required target/action/source/output fields that make downstream work non-executable is a `critical` issue (category: `clarity`). Unresolved alternatives, optional behavior, placeholders, or decision wording that can cause divergent downstream execution is an `important` issue (category: `clarity`). Accepted decisions must be stated once with stable wording and carried consistently from source artifacts.
 - **WorkPlan semantic gate**:
   - Coverage is checked where each item lives in the plan: each acceptance criterion is covered by a task whose Completion Criteria or Proof Obligations reference the AC ID or claim identifier; each data contract, state transition, boundary, prerequisite, and protected scope item has a Design-to-Plan Traceability row mapped to a task or an explicit out-of-scope entry; each non-serialized binding observable Design Doc value is copied into Reference Contract Values when applicable; each serialized binding value is recorded in Connection Map with concrete Serialized Format and Consumer Parse Rule. Missing coverage is a `critical` issue (category: `completeness`).
   - Distinguish the cause for an uncovered acceptance criterion: when the source Design Doc supports it but no task maps to it, classify as a plan omission (`critical`, fixable by re-planning); when the source document or inputs give it no basis, classify as `rejected` because re-planning cannot invent the missing source requirement.
@@ -226,6 +228,7 @@ Include in output when `prior_context_count > 0`:
 - [ ] Dependencies described as existing verified against codebase or authoritative external source
 - [ ] Field propagation map present when fields cross component boundaries
 - [ ] Minimal Surface Alternatives covers every new in-scope element when applicable
+- [ ] LLM-facing artifacts satisfy llm-friendly-context: explicit target/action/source/output, observable success criteria, stable accepted decisions, and concrete unresolved-item escalation
 
 ## Review Criteria (for Comprehensive Mode)
 
@@ -332,4 +335,8 @@ enabled = true
 
 [[skills.config]]
 path = ".agents/skills/testing/SKILL.md"
+enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
 enabled = true

--- a/.codex/agents/prd-creator.toml
+++ b/.codex/agents/prd-creator.toml
@@ -24,6 +24,7 @@ You are a specialized AI assistant for creating Product Requirements Documents (
 ```
 Skill Status:
 ✓ documentation-criteria/SKILL.md - ACTIVE
+✓ llm-friendly-context/SKILL.md - ACTIVE
 ```
 
 ## Initial Mandatory Tasks
@@ -262,4 +263,8 @@ Before documenting any claim, assess confidence level:
 
 [[skills.config]]
 path = ".agents/skills/documentation-criteria/SKILL.md"
+enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
 enabled = true

--- a/.codex/agents/scope-discoverer.toml
+++ b/.codex/agents/scope-discoverer.toml
@@ -28,6 +28,7 @@ Skill Status:
 ✓ ai-development-guide/SKILL.md - ACTIVE
 ✓ coding-rules/SKILL.md - ACTIVE
 ✓ implementation-approach/SKILL.md - ACTIVE
+✓ llm-friendly-context/SKILL.md - ACTIVE
 ```
 
 ## Required Initial Tasks
@@ -214,4 +215,8 @@ enabled = true
 
 [[skills.config]]
 path = ".agents/skills/implementation-approach/SKILL.md"
+enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
 enabled = true

--- a/.codex/agents/task-decomposer.toml
+++ b/.codex/agents/task-decomposer.toml
@@ -28,6 +28,7 @@ Skill Status:
 ✓ testing/SKILL.md - ACTIVE
 ✓ coding-rules/SKILL.md - ACTIVE
 ✓ implementation-approach/SKILL.md - ACTIVE
+✓ llm-friendly-context/SKILL.md - ACTIVE
 ```
 
 ## Initial Mandatory Tasks
@@ -418,6 +419,11 @@ Please execute decomposed tasks according to the order.
 - [ ] Quality assurance steps are excluded from tasks (handled separately)
 - [ ] Every research task has concrete deliverables defined
 - [ ] All inter-task dependencies are explicitly stated
+- [ ] Every generated task resolves alternatives or optional behavior to an explicit choice, deterministic decision rule, or blocking unresolved item
+- [ ] Placeholder behavior states the exact temporary output, allowed dependency use, and verification expectation
+- [ ] Target Files and Investigation Targets are concrete enough for the executor to read without guessing
+- [ ] Each task is compile/runtime viable at its own commit boundary, or the dependency that makes it viable is explicit
+- [ ] Generated task files, overview, and phase completion files preserve the same decisions from the work plan and referenced Design Doc/UI Spec/ADR rows
 
 ## Completion Gate [BLOCKING]
 
@@ -446,4 +452,8 @@ enabled = true
 
 [[skills.config]]
 path = ".agents/skills/implementation-approach/SKILL.md"
+enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
 enabled = true

--- a/.codex/agents/technical-designer-frontend.toml
+++ b/.codex/agents/technical-designer-frontend.toml
@@ -391,3 +391,7 @@ enabled = true
 [[skills.config]]
 path = ".agents/skills/external-resource-context/SKILL.md"
 enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
+enabled = true

--- a/.codex/agents/technical-designer.toml
+++ b/.codex/agents/technical-designer.toml
@@ -408,3 +408,7 @@ enabled = true
 [[skills.config]]
 path = ".agents/skills/external-resource-context/SKILL.md"
 enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
+enabled = true

--- a/.codex/agents/ui-analyzer.toml
+++ b/.codex/agents/ui-analyzer.toml
@@ -149,3 +149,7 @@ enabled = true
 [[skills.config]]
 path = ".agents/skills/external-resource-context/SKILL.md"
 enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
+enabled = true

--- a/.codex/agents/ui-spec-designer.toml
+++ b/.codex/agents/ui-spec-designer.toml
@@ -25,6 +25,8 @@ You are a UI specification specialist AI assistant for creating UI Specification
 Skill Status:
 ✓ documentation-criteria/SKILL.md - ACTIVE
 ✓ coding-rules/SKILL.md - ACTIVE
+✓ external-resource-context/SKILL.md - ACTIVE
+✓ llm-friendly-context/SKILL.md - ACTIVE
 ```
 
 ## Initial Mandatory Tasks
@@ -163,4 +165,8 @@ enabled = true
 
 [[skills.config]]
 path = ".agents/skills/external-resource-context/SKILL.md"
+enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
 enabled = true

--- a/.codex/agents/work-planner.toml
+++ b/.codex/agents/work-planner.toml
@@ -28,6 +28,7 @@ Skill Status:
 ✓ coding-rules/SKILL.md - ACTIVE
 ✓ testing/SKILL.md - ACTIVE
 ✓ implementation-approach/SKILL.md - ACTIVE
+✓ llm-friendly-context/SKILL.md - ACTIVE
 ```
 
 ## Initial Mandatory Tasks
@@ -465,4 +466,8 @@ enabled = true
 
 [[skills.config]]
 path = ".agents/skills/implementation-approach/SKILL.md"
+enabled = true
+
+[[skills.config]]
+path = ".agents/skills/llm-friendly-context/SKILL.md"
 enabled = true

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ These are applied automatically based on context. You rarely need to think about
 | `implementation-approach` | Strategy selection: vertical / horizontal / hybrid slicing |
 | `integration-e2e-testing` | Integration/E2E test design, value-based selection, review criteria |
 | `external-resource-context` | Access methods for design sources, design systems, API schemas, and verification environments |
+| `llm-friendly-context` | Clear prompts, handoffs, generated artifacts, task files, and review findings for downstream agents |
 | `task-analyzer` | Task analysis, scale estimation, skill selection |
 | `subagents-orchestration-guide` | Multi-agent coordination, workflow flows, guided autonomous execution |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary
- Add the new `llm-friendly-context` skill for clearer LLM-facing prompts, handoffs, planning artifacts, reviews, reports, and generated instructions.
- Load the skill from recipe workflows and artifact-producing agents so downstream-facing outputs preserve explicit inputs, outputs, decisions, success criteria, and unresolved conditions.
- Add document-reviewer clarity checks and task-decomposer self-checks for downstream execution stability.
- Register the skill in the task analyzer index and README.
- Bump package version to `0.8.0`.

## Validation
- `npm run check:skills-index`
- `git diff --check`