### PR TITLE
refine: harden task executor dependency escalation

### DIFF
--- a/.agents/skills/recipe-add-integration-tests/SKILL.md
+++ b/.agents/skills/recipe-add-integration-tests/SKILL.md
@@ -10,7 +10,7 @@ description: "Add integration/E2E tests to existing codebase using Design Docs."
 3. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
 4. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 **Context**: Test addition workflow for existing implementations
 

--- a/.agents/skills/recipe-build/SKILL.md
+++ b/.agents/skills/recipe-build/SKILL.md
@@ -11,7 +11,7 @@ description: "Execute decomposed backend tasks in autonomous execution mode usin
 4. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 5. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 ## Orchestrator Definition
 

--- a/.agents/skills/recipe-design/SKILL.md
+++ b/.agents/skills/recipe-design/SKILL.md
@@ -9,7 +9,7 @@ description: "Execute from codebase-scoped analysis to design document creation.
 2. [LOAD IF NOT ACTIVE] `implementation-approach` — implementation strategy
 3. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 **Context**: Dedicated to the design phase.
 

--- a/.agents/skills/recipe-diagnose/SKILL.md
+++ b/.agents/skills/recipe-diagnose/SKILL.md
@@ -9,7 +9,7 @@ description: "Investigate problem, verify findings, and derive solutions through
 2. [LOAD IF NOT ACTIVE] `coding-rules` — coding standards
 3. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 **Context**: Diagnosis flow to identify concrete failure points and present solutions
 

--- a/.agents/skills/recipe-front-adjust/SKILL.md
+++ b/.agents/skills/recipe-front-adjust/SKILL.md
@@ -12,7 +12,7 @@ description: "Adjust an implemented UI with external resource context, focused w
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination rules
 4. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 ## Execution Pattern
 

--- a/.agents/skills/recipe-front-build/SKILL.md
+++ b/.agents/skills/recipe-front-build/SKILL.md
@@ -11,7 +11,7 @@ description: "Execute frontend tasks in autonomous execution mode using task-exe
 4. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
 5. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 ## Orchestrator Definition
 

--- a/.agents/skills/recipe-front-design/SKILL.md
+++ b/.agents/skills/recipe-front-design/SKILL.md
@@ -12,7 +12,7 @@ description: "Execute from codebase-scoped analysis to frontend design document 
 3. [LOAD IF NOT ACTIVE] `external-resource-context` -- external resource hearing and lookup
 4. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 ## Orchestrator Definition
 

--- a/.agents/skills/recipe-front-plan/SKILL.md
+++ b/.agents/skills/recipe-front-plan/SKILL.md
@@ -12,7 +12,7 @@ description: "Create frontend work plan from design document with test skeleton 
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
 4. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 ## Orchestrator Definition
 

--- a/.agents/skills/recipe-front-review/SKILL.md
+++ b/.agents/skills/recipe-front-review/SKILL.md
@@ -12,7 +12,7 @@ description: "Frontend Design Doc compliance and security validation with option
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` -- AI development patterns
 4. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 ## Execution Method
 

--- a/.agents/skills/recipe-fullstack-build/SKILL.md
+++ b/.agents/skills/recipe-fullstack-build/SKILL.md
@@ -11,7 +11,7 @@ description: "Execute decomposed fullstack tasks with layer-aware agent routing 
 4. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination and workflow flows
 5. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 ## Orchestrator Definition
 

--- a/.agents/skills/recipe-fullstack-implement/SKILL.md
+++ b/.agents/skills/recipe-fullstack-implement/SKILL.md
@@ -16,7 +16,7 @@ description: "Orchestrate full-cycle implementation across backend and frontend 
 7. [LOAD IF NOT ACTIVE] `external-resource-context` -- external resource hearing and lookup
 8. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 ## Orchestrator Definition
 

--- a/.agents/skills/recipe-implement/SKILL.md
+++ b/.agents/skills/recipe-implement/SKILL.md
@@ -9,7 +9,7 @@ description: "Orchestrate the complete implementation lifecycle from requirement
 2. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
 3. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 # Full-Cycle Implementation
 

--- a/.agents/skills/recipe-plan/SKILL.md
+++ b/.agents/skills/recipe-plan/SKILL.md
@@ -10,7 +10,7 @@ description: "Create work plan from design document with optional test skeleton 
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 4. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 **Context**: Dedicated to the planning phase.
 

--- a/.agents/skills/recipe-prepare-implementation/SKILL.md
+++ b/.agents/skills/recipe-prepare-implementation/SKILL.md
@@ -12,7 +12,7 @@ description: "Verify that an approved work plan is implementable before build ex
 5. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` -- agent coordination
 6. [LOAD IF NOT ACTIVE] `llm-friendly-context` -- clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 ## Purpose
 

--- a/.agents/skills/recipe-reverse-engineer/SKILL.md
+++ b/.agents/skills/recipe-reverse-engineer/SKILL.md
@@ -10,7 +10,7 @@ description: "Generate PRD and Design Docs from existing codebase through discov
 3. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 4. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 **Context**: Reverse engineering workflow to create documentation from existing code
 

--- a/.agents/skills/recipe-review/SKILL.md
+++ b/.agents/skills/recipe-review/SKILL.md
@@ -10,7 +10,7 @@ description: "Design Doc compliance and security validation with optional auto-f
 3. [LOAD IF NOT ACTIVE] `ai-development-guide` — AI development patterns
 4. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 **Context**: Post-implementation quality assurance
 

--- a/.agents/skills/recipe-task/SKILL.md
+++ b/.agents/skills/recipe-task/SKILL.md
@@ -8,7 +8,7 @@ description: "Execute tasks with metacognitive analysis and appropriate rule sel
 1. [LOAD IF NOT ACTIVE] `task-analyzer` — task analysis and skill selection (rule-advisor handles remaining skill selection)
 2. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 # Task Execution with Metacognitive Analysis
 

--- a/.agents/skills/recipe-update-doc/SKILL.md
+++ b/.agents/skills/recipe-update-doc/SKILL.md
@@ -9,7 +9,7 @@ description: "Update existing design documents (Design Doc / PRD / ADR) with rev
 2. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — agent coordination and workflow flows
 3. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 **Context**: Dedicated to updating existing design documents.
 

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -5,7 +5,7 @@ description: "Guides subagent coordination through implementation workflows. Use
 
 # Subagents Orchestration Guide
 
-**Spawn rule**: every `spawn_agent` call MUST pass `fork_turns="none"` or `fork_context=false` for context isolation.
+**Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
 ## Role: The Orchestrator
 
@@ -104,12 +104,10 @@ Subagents CANNOT directly call other subagents — all coordination MUST flow th
 The orchestrator owns subagent completion. Base waiting decisions on assigned responsibility and observed state, not on an expectation of quick completion. Multi-step search, review, verification, generation, implementation, and quality work can run for extended periods.
 
 Use this contract:
-- Wait for required subagent outputs with `wait_agent`
-- Keep the current task assignment while the subagent remains `running`
-- Treat missing intermediate output as a normal execution state while the subagent remains `running`
-- Hold final artifact production until every required subagent output is available
-- After repeated empty waits, run non-destructive diagnostics: re-check prompt, inputs, expected deliverable, and agent-task fit; send a focused follow-up when it would clarify the pending deliverable
-- Resume waiting after diagnostics unless the user redirects the workflow or the orchestrator confirms a launch mistake
+- Workflow subagents are single-purpose workers expected to converge.
+- When waiting for a workflow subagent, set `timeout_ms` to the maximum value accepted by the active `wait_agent` tool and continue waiting until its completion notification is received.
+- Treat `timed_out=true` as pending and continue waiting.
+- Hold final artifact production until every required subagent output is available.
 
 Treat the following as explicit contradictory evidence:
 - The subagent returns a terminal status such as `approved`, `needs_revision`, `blocked`, `skipped`, `completed`, or `escalation_needed`
@@ -122,11 +120,10 @@ Close a running subagent only when the user redirects the workflow, the orchestr
 
 ## How to Spawn Agents
 
-Spawn agents using natural language prompts. Provide clear context about what the agent should accomplish. Every `spawn_agent` call MUST include `fork_turns="none"` or `fork_context=false` (see Spawn rule at top of this skill).
+Spawn agents using natural language prompts. Provide clear context about what the agent should accomplish. Apply the Spawn rule above.
 
 ### Spawn Prompt Requirements
 
-- Set `fork_context=false` or `fork_turns="none"` on every spawn for context isolation.
 - Each spawn prompt must name the target deliverable, input paths, and expected result. When invoking `task-executor*`, include the exact task file path, for example: `Execute the implementation task. Task file: docs/plans/tasks/[filename].md.`
 
 ## Explicit Stop Points [MANDATORY]
@@ -324,11 +321,9 @@ Stop autonomous execution and escalate to user in the following cases:
 4. **User explicitly stops**: Direct stop instruction or interruption
 
 Continue autonomous execution in the following situations:
-- A subagent takes longer than expected
-- `wait_agent` returns without a completion payload while the subagent remains `running`
+- A workflow subagent is still pending
+- `wait_agent` returns `timed_out=true`
 - The orchestrator has partial context but is still waiting on a required subagent output
-
-If repeated waits return the same `running` state, apply the completion-diagnostics contract above.
 
 Use the task loop defined in the autonomous execution diagram above. The canonical per-task cycle is:
 1. task-executor implementation

--- a/.codex/agents/task-executor-frontend.toml
+++ b/.codex/agents/task-executor-frontend.toml
@@ -156,6 +156,24 @@ When the task file, Dependencies, or Investigation Targets reference `docs/proje
 3. **Cross-check against Investigation Notes**: Ensure planned implementation is consistent with the observations recorded in the task file
 4. **Execute determination**: Determine continue/escalation per "Mandatory Judgment Criteria" above
 
+#### Unimplemented Dependency Handling
+
+Apply this when Pre-implementation Verification finds that a dependency required by this task is absent or unimplemented, including a Design Doc dependency marked `requires-new-creation`. A missing dependency is a stop condition only when it prevents preserving the required contract and no local, reversible construct can satisfy it.
+
+1. Determine whether a local, reversible construct preserves the required contract. Valid constructs are a local slice (a minimal implementation of the dependency's required contract, confined to Target Files), or a contract-preserving stub/adapter scoped to Target Files. The construct qualifies only when all conditions hold:
+   - It preserves the public or cross-boundary contract required by the Design Doc, task, AC, Reference Contracts, and Binding Decisions.
+   - It satisfies only the calls or behavior this task requires.
+   - It keeps schema, global configuration, and shared dependency direction unchanged.
+   - It can be removed or replaced when the real dependency is implemented without changing callers or this task's observable behavior.
+2. Branch on the result:
+   - At least one local, reversible approach preserves the contract, and choosing among equivalent approaches carries no architectural trade-off: proceed with it and record the integration handoff in Investigation Notes, including what the real dependency must later provide and where it connects.
+   - The qualifying conditions fail, or several valid constructs differ on an architectural trade-off such as placement, dependency direction, or contract shape: stop and return `status: "escalation_needed"` with `escalation_type: "design_compliance_violation"` using Design Doc Deviation Escalation. Populate every `details` field required by that schema and set top-level `recommendation`. Map fields as follows:
+     - `details.design_doc_expectation`: Design Doc requirement for the dependency and required contract.
+     - `details.actual_situation`: Absent/unimplemented dependency plus the exact undecided decision.
+     - `details.why_cannot_implement`: Why no qualifying local construct preserves the contract, or why the valid constructs require an architectural decision.
+     - `details.attempted_approaches`: Local slice, stub, adapter, or other constructs considered, with one-line result for each.
+     - `recommendation`: Specific user decision needed to unblock implementation.
+
 #### Adjacent Case Sweep (Required when the task file has a `Change Category` field set to one or more of `bug-fix`, `regression`, `state-change`, `boundary-change`)
 
 Run this check after Pre-implementation Verification and before the Binding Decision Check. Treat the task file's field value as authoritative for whether the sweep applies.
@@ -186,7 +204,7 @@ Run this check after Pre-implementation Verification and before behavior-first i
 Run this check after Pre-implementation Verification and before behavior-first implementation when the task file contains a Reference Contracts section with one or more rows.
 
 1. Confirm each Source in the Reference Contracts table has been read. Sources should also appear in Investigation Targets.
-2. Verify source fidelity before planning: locate the Required Observable Value in the Source and confirm it matches verbatim. If the value is not found or the task row differs by summary, omission, reordered fields, changed labels, or changed conditions, stop implementation and return `status: "escalation_needed"` with `escalation_type: "design_compliance_violation"`. Set `details.design_doc_expectation` to the Source value or "source value not found" and `details.actual_situation` to the task row's Required Observable Value.
+2. Verify source fidelity before planning: locate the Required Observable Value in the Source and confirm it matches verbatim. If the value is not found or the task row differs by summary, omission, reordered fields, changed labels, or changed conditions, stop implementation and return `status: "escalation_needed"` with `escalation_type: "design_compliance_violation"` using Design Doc Deviation Escalation. Populate every `details` field required by that schema and set top-level `recommendation`. Map the Source value or "source value not found" to `details.design_doc_expectation`, the task row's Required Observable Value to `details.actual_situation`, the source-fidelity mismatch to `details.why_cannot_implement`, the source lookup and comparison attempts to `details.attempted_approaches`, and the task or source correction needed to `recommendation`.
 3. Use the Investigation Notes format below while recording the planned approach and evaluation results.
    - `### Reference Contracts Evaluation`
    - `[source] planned: [one sentence planned approach]`
@@ -196,7 +214,7 @@ Run this check after Pre-implementation Verification and before behavior-first i
 5. Evaluate each row's Compliance Check against the planned approach. Record the result as `Y`, `N`, or `Unknown` with a one-line rationale.
 6. Branch per row:
    - `Y`: proceed
-   - `N`: stop implementation and return `status: "escalation_needed"` with `escalation_type: "design_compliance_violation"`. Set `details.design_doc_expectation` to the row's Required Observable Value and `details.actual_situation` to the planned approach.
+   - `N`: stop implementation and return `status: "escalation_needed"` with `escalation_type: "design_compliance_violation"` using Design Doc Deviation Escalation. Populate every `details` field required by that schema and set top-level `recommendation`. Map the row's Required Observable Value to `details.design_doc_expectation`, the planned approach to `details.actual_situation`, the Compliance Check failure to `details.why_cannot_implement`, the planned approach and alternatives considered to `details.attempted_approaches`, and the implementation or Design Doc decision needed to `recommendation`.
    - `Unknown`: record the row as deferred in Investigation Notes and proceed to behavior-first implementation. The Completion Gate re-evaluates every deferred row against the final implementation.
 
 #### Reference Representativeness (Applied During Implementation)

--- a/.codex/agents/task-executor.toml
+++ b/.codex/agents/task-executor.toml
@@ -156,6 +156,24 @@ When the task file, Dependencies, or Investigation Targets reference `docs/proje
 3. **Cross-check against Investigation Notes**: Ensure planned implementation is consistent with the observations recorded in the task file
 4. **Execute determination**: Determine continue/escalation per "Mandatory Judgment Criteria" above
 
+#### Unimplemented Dependency Handling
+
+Apply this when Pre-implementation Verification finds that a dependency required by this task is absent or unimplemented, including a Design Doc dependency marked `requires-new-creation`. A missing dependency is a stop condition only when it prevents preserving the required contract and no local, reversible construct can satisfy it.
+
+1. Determine whether a local, reversible construct preserves the required contract. Valid constructs are a local slice (a minimal implementation of the dependency's required contract, confined to Target Files), or a contract-preserving stub/adapter scoped to Target Files. The construct qualifies only when all conditions hold:
+   - It preserves the public or cross-boundary contract required by the Design Doc, task, AC, Reference Contracts, and Binding Decisions.
+   - It satisfies only the calls or behavior this task requires.
+   - It keeps schema, global configuration, and shared dependency direction unchanged.
+   - It can be removed or replaced when the real dependency is implemented without changing callers or this task's observable behavior.
+2. Branch on the result:
+   - At least one local, reversible approach preserves the contract, and choosing among equivalent approaches carries no architectural trade-off: proceed with it and record the integration handoff in Investigation Notes, including what the real dependency must later provide and where it connects.
+   - The qualifying conditions fail, or several valid constructs differ on an architectural trade-off such as placement, dependency direction, or contract shape: stop and return `status: "escalation_needed"` with `escalation_type: "design_compliance_violation"` using Design Doc Deviation Escalation. Populate every `details` field required by that schema and set top-level `recommendation`. Map fields as follows:
+     - `details.design_doc_expectation`: Design Doc requirement for the dependency and required contract.
+     - `details.actual_situation`: Absent/unimplemented dependency plus the exact undecided decision.
+     - `details.why_cannot_implement`: Why no qualifying local construct preserves the contract, or why the valid constructs require an architectural decision.
+     - `details.attempted_approaches`: Local slice, stub, adapter, or other constructs considered, with one-line result for each.
+     - `recommendation`: Specific user decision needed to unblock implementation.
+
 #### Adjacent Case Sweep (Required when the task file has a `Change Category` field set to one or more of `bug-fix`, `regression`, `state-change`, `boundary-change`)
 
 Run this check after Pre-implementation Verification and before the Binding Decision Check. Treat the task file's field value as authoritative for whether the sweep applies.
@@ -186,7 +204,7 @@ Run this check after Pre-implementation Verification and before the TDD cycle wh
 Run this check after Pre-implementation Verification and before the TDD cycle when the task file contains a Reference Contracts section with one or more rows.
 
 1. Confirm each Source in the Reference Contracts table has been read. Sources should also appear in Investigation Targets.
-2. Verify source fidelity before planning: locate the Required Observable Value in the Source and confirm it matches verbatim. If the value is not found or the task row differs by summary, omission, reordered fields, changed labels, or changed conditions, stop implementation and return `status: "escalation_needed"` with `escalation_type: "design_compliance_violation"`. Set `details.design_doc_expectation` to the Source value or "source value not found" and `details.actual_situation` to the task row's Required Observable Value.
+2. Verify source fidelity before planning: locate the Required Observable Value in the Source and confirm it matches verbatim. If the value is not found or the task row differs by summary, omission, reordered fields, changed labels, or changed conditions, stop implementation and return `status: "escalation_needed"` with `escalation_type: "design_compliance_violation"` using Design Doc Deviation Escalation. Populate every `details` field required by that schema and set top-level `recommendation`. Map the Source value or "source value not found" to `details.design_doc_expectation`, the task row's Required Observable Value to `details.actual_situation`, the source-fidelity mismatch to `details.why_cannot_implement`, the source lookup and comparison attempts to `details.attempted_approaches`, and the task or source correction needed to `recommendation`.
 3. Use the Investigation Notes format below while recording the planned approach and evaluation results.
    - `### Reference Contracts Evaluation`
    - `[source] planned: [one sentence planned approach]`
@@ -196,7 +214,7 @@ Run this check after Pre-implementation Verification and before the TDD cycle wh
 5. Evaluate each row's Compliance Check against the planned approach. Record the result as `Y`, `N`, or `Unknown` with a one-line rationale.
 6. Branch per row:
    - `Y`: proceed
-   - `N`: stop implementation and return `status: "escalation_needed"` with `escalation_type: "design_compliance_violation"`. Set `details.design_doc_expectation` to the row's Required Observable Value and `details.actual_situation` to the planned approach.
+   - `N`: stop implementation and return `status: "escalation_needed"` with `escalation_type: "design_compliance_violation"` using Design Doc Deviation Escalation. Populate every `details` field required by that schema and set top-level `recommendation`. Map the row's Required Observable Value to `details.design_doc_expectation`, the planned approach to `details.actual_situation`, the Compliance Check failure to `details.why_cannot_implement`, the planned approach and alternatives considered to `details.attempted_approaches`, and the implementation or Design Doc decision needed to `recommendation`.
    - `Unknown`: record the row as deferred in Investigation Notes and proceed to the TDD cycle. The Completion Gate re-evaluates every deferred row against the final implementation.
 
 #### Reference Representativeness (Applied During Implementation)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

- Add explicit task-executor guidance for absent or unimplemented dependencies.
- Allow local, reversible Target Files-scoped constructs only when they preserve the required contract and carry no architectural trade-off.
- Require Design Doc deviation escalations to populate all required details fields and top-level recommendations for Reference Contract failures.
- Bump package version to 0.8.1.

## Verification

- npm run check:skills-index
- git diff --check