### PR TITLE
Add user-scoped installation support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - run: npm test
+      - run: npm run check:skills-index

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ This works best when repository knowledge is explicit and local. Short `AGENTS.m
 
 ### Install
 
+Install into the current project:
+
 ```bash
 cd your-project
 npx codex-workflows install
@@ -129,6 +131,16 @@ This copies into your project:
 - `.codex/agents/` — Subagent TOML definitions
 - Manifest file for tracking managed files
 
+To make the workflows available to Codex across all projects, install them into
+your user-level `CODEX_HOME` instead:
+
+```bash
+npx codex-workflows install --user
+```
+
+This installs skills into `$CODEX_HOME/skills/` and agents into
+`$CODEX_HOME/agents/`. When `CODEX_HOME` is not set, it defaults to `~/.codex`.
+
 ### Update
 
 ```bash
@@ -137,6 +149,9 @@ npx codex-workflows update --dry-run
 
 # Apply updates
 npx codex-workflows update
+
+# Update a user-level installation
+npx codex-workflows update --user
 ```
 
 Files you've modified locally are preserved — the updater compares each file against its hash at install time and skips any file you've changed. New files from the update are added automatically.
@@ -144,6 +159,9 @@ Files you've modified locally are preserved — the updater compares each file a
 ```bash
 # Check installed version
 npx codex-workflows status
+
+# Check a user-level installation
+npx codex-workflows status --user
 ```
 
 ---
@@ -374,6 +392,10 @@ A: Designed for the latest GPT models. Lightweight subagents (e.g. rule-advisor)
 **Q: Can I customize the agents?**
 
 A: Yes. Edit the TOML files in `.codex/agents/` — change model, sandbox_mode, developer_instructions, or skills.config. Files you modify locally are preserved during `npx codex-workflows update`.
+
+For a user-level installation, edit the files in `$CODEX_HOME/agents/` and use
+`npx codex-workflows update --user`. User-level files modified after installation
+are preserved in the same way.
 
 **Q: What's the difference between `$recipe-implement` and `$recipe-fullstack-implement`?**
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,249 +1,353 @@
 #!/usr/bin/env node
 
-const fs = require("fs");
-const path = require("path");
 const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 const MANIFEST_FILE = ".codex-workflows-manifest.json";
-const COPY_DIRS = [".agents", ".codex"];
+const PROJECT_COPY_MAPPINGS = [
+  { source: ".agents", destination: ".agents" },
+  { source: ".codex", destination: ".codex" },
+];
+const USER_COPY_MAPPINGS = [
+  { source: ".agents/skills", destination: "skills" },
+  { source: ".codex/agents", destination: "agents" },
+];
+const COMMAND_OPTIONS = {
+  install: new Set(["--user"]),
+  update: new Set(["--dry-run", "--user"]),
+  status: new Set(["--user"]),
+  "--version": new Set(),
+  "-v": new Set(),
+  "--help": new Set(),
+  "-h": new Set(),
+};
 
-function main(argv = process.argv, cwd = process.cwd()) {
-  const command = argv[2];
-  const targetDir = cwd;
-  const sourceDir = path.resolve(__dirname, "..");
-
-  function getVersion() {
-    try {
-      const pkg = JSON.parse(
-        fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")
-      );
-      return pkg.version;
-    } catch (e) {
-      console.error(`Error reading package.json: ${e.message}`);
-      process.exit(2);
-    }
-  }
-
-  function fileHash(filePath) {
-    const content = fs.readFileSync(filePath);
-    return crypto.createHash("sha256").update(content).digest("hex");
-  }
-
-  function copyDirRecursive(src, dest) {
-    let copied = 0;
-    if (!fs.existsSync(src)) return copied;
-    fs.mkdirSync(dest, { recursive: true });
-    for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
-      if (entry.isSymbolicLink()) continue;
-      const srcPath = path.join(src, entry.name);
-      const destPath = path.join(dest, entry.name);
-      if (entry.isDirectory()) {
-        copied += copyDirRecursive(srcPath, destPath);
-      } else {
-        fs.copyFileSync(srcPath, destPath);
-        copied++;
-      }
-    }
-    return copied;
-  }
-
-  function collectFiles(dir, base) {
-    const files = [];
-    if (!fs.existsSync(dir)) return files;
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      if (entry.isSymbolicLink()) continue;
-      const fullPath = path.join(dir, entry.name);
-      const relPath = path.join(base, entry.name);
-      if (entry.isDirectory()) {
-        files.push(...collectFiles(fullPath, relPath));
-      } else {
-        files.push(relPath);
-      }
-    }
-    return files;
-  }
-
-  function readManifest() {
-    const manifestPath = path.join(targetDir, MANIFEST_FILE);
-    if (!fs.existsSync(manifestPath)) return null;
-    try {
-      return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-    } catch (e) {
-      console.error(`Error: ${MANIFEST_FILE} is corrupt: ${e.message}`);
-      console.error("Delete the file and run 'install' again, or fix it manually.");
-      process.exit(2);
-    }
-  }
-
-  function writeManifest(fileHashes) {
-    const manifestPath = path.join(targetDir, MANIFEST_FILE);
-    const manifest = {
-      version: getVersion(),
-      installedAt: new Date().toISOString(),
-      files: fileHashes,
-    };
-    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
-  }
-
-  function install() {
-    const manifest = readManifest();
-    if (manifest) {
-      console.log(
-        `codex-workflows v${manifest.version} is already installed. Use 'update' to upgrade.`
-      );
-      process.exit(1);
-    }
-
-    const version = getVersion();
-    console.log(`Installing codex-workflows v${version}...\n`);
-
-    const fileHashes = {};
-    let totalCopied = 0;
-
-    for (const dir of COPY_DIRS) {
-      const src = path.join(sourceDir, dir);
-      const dest = path.join(targetDir, dir);
-      const copied = copyDirRecursive(src, dest);
-      totalCopied += copied;
-      for (const relPath of collectFiles(dest, dir)) {
-        fileHashes[relPath] = fileHash(path.join(targetDir, relPath));
-      }
-      if (copied > 0) console.log(`  ${dir}/ — ${copied} files`);
-    }
-
-    writeManifest(fileHashes);
-    console.log(`\nDone. ${totalCopied} files installed.`);
-  }
-
-  function update(dryRun) {
-    const manifest = readManifest();
-    if (!manifest) {
-      console.log("codex-workflows is not installed. Run 'install' first.");
-      process.exit(1);
-    }
-
-    // Migrate old manifest format (array) to new format (hash map)
-    const installedHashes = Array.isArray(manifest.files)
-      ? Object.fromEntries(manifest.files.map(f => [f, null]))
-      : manifest.files;
-
-    const currentVersion = manifest.version;
-    const newVersion = getVersion();
-    console.log(
-      `${dryRun ? "[DRY RUN] " : ""}Updating codex-workflows v${currentVersion} → v${newVersion}\n`
-    );
-
-    let updated = 0;
-    let added = 0;
-    let skipped = 0;
-    let preserved = 0;
-    const preservedFiles = new Set();
-
-    for (const dir of COPY_DIRS) {
-      const src = path.join(sourceDir, dir);
-      if (!fs.existsSync(src)) continue;
-      const sourceFiles = collectFiles(src, dir);
-      for (const relPath of sourceFiles) {
-        const srcFile = path.join(sourceDir, relPath);
-        const destFile = path.join(targetDir, relPath);
-
-        // New file — always add
-        if (!fs.existsSync(destFile)) {
-          if (dryRun) console.log(`  + ${relPath} (new)`);
-          else {
-            fs.mkdirSync(path.dirname(destFile), { recursive: true });
-            fs.copyFileSync(srcFile, destFile);
-          }
-          added++;
-          continue;
-        }
-
-        const srcContent = fs.readFileSync(srcFile);
-        const destContent = fs.readFileSync(destFile);
-
-        // Identical — skip
-        if (srcContent.equals(destContent)) { skipped++; continue; }
-
-        // Check if user modified the file since last install/update
-        const storedHash = installedHashes[relPath];
-        if (storedHash) {
-          const currentHash = crypto.createHash("sha256").update(destContent).digest("hex");
-          if (currentHash !== storedHash) {
-            // User modified this file — preserve their changes
-            console.log(`  ~ ${relPath} (modified locally, skipping)`);
-            preservedFiles.add(relPath);
-            preserved++;
-            continue;
-          }
-        }
-
-        // File unchanged by user (or not previously tracked) — safe to update
-        if (dryRun) console.log(`  * ${relPath} (updated)`);
-        else fs.copyFileSync(srcFile, destFile);
-        updated++;
-      }
-    }
-
-    if (!dryRun) {
-      const newHashes = {};
-      for (const dir of COPY_DIRS) {
-        for (const relPath of collectFiles(path.join(targetDir, dir), dir)) {
-          if (preservedFiles.has(relPath) && installedHashes[relPath]) {
-            // Keep original hash so preserved files stay protected on next update
-            newHashes[relPath] = installedHashes[relPath];
-          } else {
-            newHashes[relPath] = fileHash(path.join(targetDir, relPath));
-          }
-        }
-      }
-      writeManifest(newHashes);
-    }
-
-    const parts = [`${added} added`, `${updated} updated`, `${skipped} unchanged`];
-    if (preserved > 0) parts.push(`${preserved} preserved (local changes)`);
-    console.log(`\n${dryRun ? "[DRY RUN] " : ""}${parts.join(", ")}.`);
-  }
-
-  function status() {
-    const manifest = readManifest();
-    if (!manifest) {
-      console.log("codex-workflows is not installed.");
-      return;
-    }
-    const fileCount = Array.isArray(manifest.files)
-      ? manifest.files.length
-      : Object.keys(manifest.files).length;
-    console.log(`Version:   ${manifest.version}`);
-    console.log(`Installed: ${manifest.installedAt}`);
-    console.log(`Files:     ${fileCount} managed`);
-  }
-
-  function showHelp() {
-    console.log(`
-codex-workflows — Agentic coding skills & subagents for Codex CLI
-
-Usage:
-  npx codex-workflows install              Install skills and agents
-  npx codex-workflows update               Update managed files
-  npx codex-workflows update --dry-run     Preview changes without applying
-  npx codex-workflows status               Show installation info
-  npx codex-workflows --version            Show version
-  npx codex-workflows --help               Show this help
-`);
-  }
-
-  switch (command) {
-    case "install": install(); break;
-    case "update": update(argv.includes("--dry-run")); break;
-    case "status": status(); break;
-    case "--version": case "-v": console.log(getVersion()); break;
-    case "--help": case "-h": case undefined: showHelp(); break;
-    default:
-      console.error(`Unknown command: ${command}`);
-      showHelp();
-      process.exit(1);
+class CliError extends Error {
+  constructor(message, exitCode = 1) {
+    super(message);
+    this.exitCode = exitCode;
   }
 }
 
-main();
+function parseCommand(argv) {
+  const command = argv[2];
+  const args = argv.slice(3);
+  const allowedOptions = COMMAND_OPTIONS[command];
+
+  if (allowedOptions) {
+    const unknownOption = args.find(arg => !allowedOptions.has(arg));
+    if (unknownOption) {
+      throw new CliError(`Unknown option for '${command}': ${unknownOption}`);
+    }
+  }
+
+  return {
+    command,
+    dryRun: args.includes("--dry-run"),
+    scope: args.includes("--user") ? "user" : "project",
+  };
+}
+
+function resolveCodexHome() {
+  const configuredHome = process.env.CODEX_HOME;
+  if (!configuredHome) return path.join(os.homedir(), ".codex");
+  if (!path.isAbsolute(configuredHome)) {
+    throw new CliError("CODEX_HOME must be an absolute path.");
+  }
+  return configuredHome;
+}
+
+function createInstallation({ scope, cwd, sourceDir }) {
+  const targetDir = scope === "user" ? resolveCodexHome() : cwd;
+  return {
+    copyMappings: scope === "user" ? USER_COPY_MAPPINGS : PROJECT_COPY_MAPPINGS,
+    manifestPath: path.join(targetDir, MANIFEST_FILE),
+    scope,
+    sourceDir,
+    targetDir,
+  };
+}
+
+function getVersion(sourceDir) {
+  try {
+    const packagePath = path.join(sourceDir, "package.json");
+    return JSON.parse(fs.readFileSync(packagePath, "utf8")).version;
+  } catch (error) {
+    throw new CliError(`Error reading package.json: ${error.message}`, 2);
+  }
+}
+
+function fileHash(filePath) {
+  const content = fs.readFileSync(filePath);
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+function copyDirRecursive(source, destination) {
+  let copied = 0;
+  if (!fs.existsSync(source)) return copied;
+  fs.mkdirSync(destination, { recursive: true });
+
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) continue;
+    const sourcePath = path.join(source, entry.name);
+    const destinationPath = path.join(destination, entry.name);
+    if (entry.isDirectory()) {
+      copied += copyDirRecursive(sourcePath, destinationPath);
+    } else {
+      fs.copyFileSync(sourcePath, destinationPath);
+      copied++;
+    }
+  }
+  return copied;
+}
+
+function collectRelativeFiles(directory, base = "") {
+  const files = [];
+  if (!fs.existsSync(directory)) return files;
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) continue;
+    const fullPath = path.join(directory, entry.name);
+    const relativePath = path.join(base, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectRelativeFiles(fullPath, relativePath));
+    } else {
+      files.push(relativePath);
+    }
+  }
+  return files;
+}
+
+function collectManagedFiles(installation) {
+  const files = [];
+  for (const mapping of installation.copyMappings) {
+    const sourceRoot = path.join(installation.sourceDir, mapping.source);
+    for (const relativePath of collectRelativeFiles(sourceRoot)) {
+      files.push({
+        destinationPath: path.join(
+          installation.targetDir,
+          mapping.destination,
+          relativePath
+        ),
+        manifestPath: path.join(mapping.destination, relativePath),
+        sourcePath: path.join(sourceRoot, relativePath),
+      });
+    }
+  }
+  return files;
+}
+
+function readManifest(installation) {
+  if (!fs.existsSync(installation.manifestPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(installation.manifestPath, "utf8"));
+  } catch (error) {
+    throw new CliError(
+      `Error: ${MANIFEST_FILE} is corrupt: ${error.message}\n` +
+      "Delete the file and run 'install' again, or fix it manually.",
+      2
+    );
+  }
+}
+
+function writeManifest({ installation, fileHashes, version }) {
+  const manifest = {
+    version,
+    installedAt: new Date().toISOString(),
+    scope: installation.scope,
+    files: fileHashes,
+  };
+  fs.mkdirSync(installation.targetDir, { recursive: true });
+  fs.writeFileSync(
+    installation.manifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`
+  );
+}
+
+function assertNoUserConflicts(scope, files) {
+  if (scope !== "user") return;
+  const conflicts = files.filter(file => {
+    if (!fs.existsSync(file.destinationPath)) return false;
+    return !fs.readFileSync(file.sourcePath).equals(
+      fs.readFileSync(file.destinationPath)
+    );
+  });
+  if (conflicts.length === 0) return;
+
+  const conflictList = conflicts.map(file => `  ${file.manifestPath}`).join("\n");
+  throw new CliError(
+    `Install conflict: existing user files would be overwritten:\n${conflictList}\n` +
+    "Move or remove the conflicting files, then run install again."
+  );
+}
+
+function install(installation) {
+  const existingManifest = readManifest(installation);
+  if (existingManifest) {
+    throw new CliError(
+      `codex-workflows v${existingManifest.version} is already installed. ` +
+      "Use 'update' to upgrade."
+    );
+  }
+
+  const version = getVersion(installation.sourceDir);
+  const files = collectManagedFiles(installation);
+  assertNoUserConflicts(installation.scope, files);
+  console.log(`Installing codex-workflows v${version} (${installation.scope})...\n`);
+
+  let totalCopied = 0;
+  for (const mapping of installation.copyMappings) {
+    const source = path.join(installation.sourceDir, mapping.source);
+    const destination = path.join(installation.targetDir, mapping.destination);
+    const copied = copyDirRecursive(source, destination);
+    totalCopied += copied;
+    if (copied > 0) console.log(`  ${mapping.destination}/ — ${copied} files`);
+  }
+
+  const fileHashes = Object.fromEntries(
+    files.map(file => [file.manifestPath, fileHash(file.destinationPath)])
+  );
+  writeManifest({ installation, fileHashes, version });
+  console.log(`\nDone. ${totalCopied} files installed.`);
+}
+
+function updateManagedFile({ file, installedHashes, dryRun, preservedFiles }) {
+  if (!fs.existsSync(file.destinationPath)) {
+    if (dryRun) console.log(`  + ${file.manifestPath} (new)`);
+    else {
+      fs.mkdirSync(path.dirname(file.destinationPath), { recursive: true });
+      fs.copyFileSync(file.sourcePath, file.destinationPath);
+    }
+    return "added";
+  }
+
+  const sourceContent = fs.readFileSync(file.sourcePath);
+  const destinationContent = fs.readFileSync(file.destinationPath);
+  if (sourceContent.equals(destinationContent)) return "skipped";
+
+  const storedHash = installedHashes[file.manifestPath];
+  if (storedHash && fileHash(file.destinationPath) !== storedHash) {
+    console.log(`  ~ ${file.manifestPath} (modified locally, skipping)`);
+    preservedFiles.add(file.manifestPath);
+    return "preserved";
+  }
+
+  if (dryRun) console.log(`  * ${file.manifestPath} (updated)`);
+  else fs.copyFileSync(file.sourcePath, file.destinationPath);
+  return "updated";
+}
+
+function buildUpdatedHashes({ files, installedHashes, preservedFiles }) {
+  return Object.fromEntries(files.map(file => {
+    const storedHash = installedHashes[file.manifestPath];
+    const hash = preservedFiles.has(file.manifestPath) && storedHash
+      ? storedHash
+      : fileHash(file.destinationPath);
+    return [file.manifestPath, hash];
+  }));
+}
+
+function update(installation, dryRun) {
+  const manifest = readManifest(installation);
+  if (!manifest) throw new CliError("codex-workflows is not installed. Run 'install' first.");
+
+  const installedHashes = Array.isArray(manifest.files)
+    ? Object.fromEntries(manifest.files.map(file => [file, null]))
+    : manifest.files;
+  const version = getVersion(installation.sourceDir);
+  const prefix = dryRun ? "[DRY RUN] " : "";
+  console.log(`${prefix}Updating codex-workflows v${manifest.version} → v${version}\n`);
+
+  const files = collectManagedFiles(installation);
+  const preservedFiles = new Set();
+  const counts = { added: 0, updated: 0, skipped: 0, preserved: 0 };
+  for (const file of files) {
+    const result = updateManagedFile({ file, installedHashes, dryRun, preservedFiles });
+    counts[result]++;
+  }
+
+  if (!dryRun) {
+    const fileHashes = buildUpdatedHashes({ files, installedHashes, preservedFiles });
+    writeManifest({ installation, fileHashes, version });
+  }
+  printUpdateSummary(counts, dryRun);
+}
+
+function printUpdateSummary(counts, dryRun) {
+  const parts = [
+    `${counts.added} added`,
+    `${counts.updated} updated`,
+    `${counts.skipped} unchanged`,
+  ];
+  if (counts.preserved > 0) {
+    parts.push(`${counts.preserved} preserved (local changes)`);
+  }
+  console.log(`\n${dryRun ? "[DRY RUN] " : ""}${parts.join(", ")}.`);
+}
+
+function status(installation) {
+  const manifest = readManifest(installation);
+  if (!manifest) {
+    console.log("codex-workflows is not installed.");
+    return;
+  }
+  const fileCount = Array.isArray(manifest.files)
+    ? manifest.files.length
+    : Object.keys(manifest.files).length;
+  console.log(`Version:   ${manifest.version}`);
+  console.log(`Installed: ${manifest.installedAt}`);
+  console.log(`Scope:     ${manifest.scope ?? installation.scope}`);
+  console.log(`Files:     ${fileCount} managed`);
+}
+
+function showHelp() {
+  console.log(`
+codex-workflows — Agentic coding skills & subagents for Codex CLI
+
+Usage:
+  npx codex-workflows install [--user]             Install skills and agents
+  npx codex-workflows update [--user]              Update managed files
+  npx codex-workflows update [--user] --dry-run    Preview changes without applying
+  npx codex-workflows status [--user]              Show installation info
+  npx codex-workflows --version                    Show version
+  npx codex-workflows --help                       Show this help
+
+Scopes:
+  default   Install into the current project
+  --user    Install into CODEX_HOME (defaults to ~/.codex)
+`);
+}
+
+function run({ command, dryRun, installation }) {
+  switch (command) {
+    case "install": install(installation); break;
+    case "update": update(installation, dryRun); break;
+    case "status": status(installation); break;
+    case "--version": case "-v": console.log(getVersion(installation.sourceDir)); break;
+    case "--help": case "-h": case undefined: showHelp(); break;
+    default:
+      showHelp();
+      throw new CliError(`Unknown command: ${command}`);
+  }
+}
+
+function main(argv = process.argv, cwd = process.cwd()) {
+  try {
+    const parsed = parseCommand(argv);
+    const installation = createInstallation({
+      scope: parsed.scope,
+      cwd,
+      sourceDir: path.resolve(__dirname, ".."),
+    });
+    run({ ...parsed, installation });
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = error.exitCode ?? 2;
+  }
+}
+
+if (require.main === module) main();
+
 module.exports = { main };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "check:skills-index": "node scripts/check-skills-index.mjs",
-    "hooks:install": "git config core.hooksPath scripts/hooks"
+    "hooks:install": "git config core.hooksPath scripts/hooks",
+    "test": "node --test scripts/tests/cli.test.js"
   },
   "bin": {
     "codex-workflows": "bin/cli.js"

--- a/scripts/tests/cli.test.js
+++ b/scripts/tests/cli.test.js
@@ -1,0 +1,130 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { afterEach, test } = require("node:test");
+
+const CLI_PATH = path.resolve(__dirname, "../../bin/cli.js");
+const temporaryDirectories = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function makeTemporaryDirectory(name) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function runCli(args, options = {}) {
+  const cwd = options.cwd ?? makeTemporaryDirectory("codex-workflows-cwd");
+  const home = options.home ?? makeTemporaryDirectory("codex-workflows-home");
+  const env = { ...process.env, HOME: home };
+
+  if (options.codexHome) env.CODEX_HOME = options.codexHome;
+  else delete env.CODEX_HOME;
+
+  return spawnSync(process.execPath, [CLI_PATH, ...args], {
+    cwd,
+    env,
+    encoding: "utf8",
+  });
+}
+
+test("installs into the current directory by default", () => {
+  const cwd = makeTemporaryDirectory("codex-workflows-project");
+
+  const result = runCli(["install"], { cwd });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(path.join(cwd, ".agents/skills/coding-rules/SKILL.md")), true);
+  assert.equal(fs.existsSync(path.join(cwd, ".codex/agents/solver.toml")), true);
+  assert.equal(fs.existsSync(path.join(cwd, ".codex-workflows-manifest.json")), true);
+});
+
+test("installs skills and agents into CODEX_HOME with --user", () => {
+  const cwd = makeTemporaryDirectory("codex-workflows-project");
+  const codexHome = makeTemporaryDirectory("codex-workflows-codex-home");
+  const unrelatedFile = path.join(codexHome, "skills/personal/SKILL.md");
+  fs.mkdirSync(path.dirname(unrelatedFile), { recursive: true });
+  fs.writeFileSync(unrelatedFile, "personal skill\n");
+
+  const result = runCli(["install", "--user"], { cwd, codexHome });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(path.join(codexHome, "skills/coding-rules/SKILL.md")), true);
+  assert.equal(fs.existsSync(path.join(codexHome, "agents/solver.toml")), true);
+  assert.equal(fs.existsSync(path.join(cwd, ".agents")), false);
+  assert.equal(fs.existsSync(path.join(cwd, ".codex")), false);
+
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(codexHome, ".codex-workflows-manifest.json"), "utf8")
+  );
+  assert.equal(manifest.scope, "user");
+  assert.equal(Object.hasOwn(manifest.files, "skills/coding-rules/SKILL.md"), true);
+  assert.equal(Object.hasOwn(manifest.files, "agents/solver.toml"), true);
+  assert.equal(Object.hasOwn(manifest.files, "skills/personal/SKILL.md"), false);
+});
+
+test("uses ~/.codex when CODEX_HOME is not set", () => {
+  const cwd = makeTemporaryDirectory("codex-workflows-project");
+  const home = makeTemporaryDirectory("codex-workflows-home");
+
+  const result = runCli(["install", "--user"], { cwd, home });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    fs.existsSync(path.join(home, ".codex/skills/coding-rules/SKILL.md")),
+    true
+  );
+  assert.equal(fs.existsSync(path.join(home, ".codex/agents/solver.toml")), true);
+});
+
+test("fails before writing when a user-scoped file conflicts", () => {
+  const cwd = makeTemporaryDirectory("codex-workflows-project");
+  const codexHome = makeTemporaryDirectory("codex-workflows-codex-home");
+  const conflictingFile = path.join(codexHome, "agents/solver.toml");
+  fs.mkdirSync(path.dirname(conflictingFile), { recursive: true });
+  fs.writeFileSync(conflictingFile, "user-owned content\n");
+
+  const result = runCli(["install", "--user"], { cwd, codexHome });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /install conflict/i);
+  assert.equal(fs.readFileSync(conflictingFile, "utf8"), "user-owned content\n");
+  assert.equal(fs.existsSync(path.join(codexHome, "skills/coding-rules/SKILL.md")), false);
+  assert.equal(fs.existsSync(path.join(codexHome, ".codex-workflows-manifest.json")), false);
+});
+
+test("updates and reports status for a user-scoped installation", () => {
+  const cwd = makeTemporaryDirectory("codex-workflows-project");
+  const codexHome = makeTemporaryDirectory("codex-workflows-codex-home");
+  const installResult = runCli(["install", "--user"], { cwd, codexHome });
+  assert.equal(installResult.status, 0, installResult.stderr);
+
+  const modifiedAgent = path.join(codexHome, "agents/solver.toml");
+  fs.appendFileSync(modifiedAgent, "\n# personal override\n");
+
+  const updateResult = runCli(["update", "--user"], { cwd, codexHome });
+  assert.equal(updateResult.status, 0, updateResult.stderr);
+  assert.match(updateResult.stdout, /modified locally, skipping/);
+  assert.match(fs.readFileSync(modifiedAgent, "utf8"), /personal override/);
+
+  const statusResult = runCli(["status", "--user"], { cwd, codexHome });
+  assert.equal(statusResult.status, 0, statusResult.stderr);
+  assert.match(statusResult.stdout, /Scope:\s+user/);
+});
+
+test("rejects unsupported options instead of ignoring them", () => {
+  const cwd = makeTemporaryDirectory("codex-workflows-project");
+
+  const result = runCli(["install", "--global"], { cwd });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /unknown option/i);
+  assert.equal(fs.existsSync(path.join(cwd, ".agents")), false);
+});


### PR DESCRIPTION
## Summary

- add a `--user` scope to `install`, `update`, and `status`
- install user-scoped skills and agents under `CODEX_HOME`, defaulting to `~/.codex`
- keep project-scoped installation as the default and preserve its existing paths
- fail before writing when user-owned files would be overwritten
- track only package-managed files in the installation manifest
- document the new workflow and bump the package version to `0.9.1`
- add CLI coverage under `scripts/tests` and run it in GitHub Actions

## Verification

- `npm test`
- `npm run check:skills-index`
- `npm pack --dry-run`
- JavaScript syntax and workflow YAML validation

## Release note

After this PR is merged, `0.9.1` still needs to be published to npm before the new option is available through `npx codex-workflows`.
