### PR TITLE
Improve autonomous review convergence

### DIFF
--- a/.agents/skills/recipe-add-integration-tests/SKILL.md
+++ b/.agents/skills/recipe-add-integration-tests/SKILL.md
@@ -8,7 +8,8 @@ description: "Add integration/E2E tests to existing codebase using Design Docs."
 1. [LOAD IF NOT ACTIVE] `testing` — test strategy and quality gates
 2. [LOAD IF NOT ACTIVE] `integration-e2e-testing` — integration and E2E test patterns
 3. [LOAD IF NOT ACTIVE] `documentation-criteria` — document creation rules and templates
-4. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
+4. [LOAD IF NOT ACTIVE] `subagents-orchestration-guide` — review revision convergence and agent coordination
+5. [LOAD IF NOT ACTIVE] `llm-friendly-context` — clear prompts, handoffs, and generated artifacts
 
 **Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
@@ -147,7 +148,7 @@ Keep `testsAdded` as reporting metadata only.
 
 Check Step 5 result:
 - `status: approved` -> Mark complete, proceed to Step 7
-- `status: needs_revision` -> Spawn the layer-appropriate executor with: "Fix the following issues in test files: [requiredFixes from Step 5]." Then return to Step 5. Maximum 2 revision cycles per task file; if still `needs_revision`, escalate to the user.
+- `status: needs_revision` -> Apply Review Revision Convergence from `subagents-orchestration-guide` with the layer-appropriate executor as the author, using `requiredFixes` as the review findings, then return to Step 5.
 
 ### Step 7: Quality Check
 

--- a/.agents/skills/recipe-add-integration-tests/SKILL.md
+++ b/.agents/skills/recipe-add-integration-tests/SKILL.md
@@ -148,7 +148,7 @@ Keep `testsAdded` as reporting metadata only.
 
 Check Step 5 result:
 - `status: approved` -> Mark complete, proceed to Step 7
-- `status: needs_revision` -> Apply Review Revision Convergence from `subagents-orchestration-guide` with the layer-appropriate executor as the author, using `requiredFixes` as the review findings, then return to Step 5.
+- `status: needs_revision` -> Apply Review Revision Convergence (`author`: layer-appropriate executor; `artifact`: changed test files); on `progression`, proceed to Step 7.
 
 ### Step 7: Quality Check
 

--- a/.agents/skills/recipe-build/SKILL.md
+++ b/.agents/skills/recipe-build/SKILL.md
@@ -78,7 +78,7 @@ Spawn document-reviewer agent: "Review the work plan before task decomposition. 
 
 Branch on `verdict.decision`:
 - `approved` -> spawn work-planner in update mode once to record `Status: approved` and `Conditions: none` in WorkPlan Review, then continue to user confirmation
-- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence from `subagents-orchestration-guide` with `work-planner` as the author, then repeat Work Plan Review
+- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence (`author`: work-planner; `artifact`: work plan); on `progression`, follow the `approved` branch
 - `rejected` -> stop before task decomposition and present the blocking findings to the user
 
 When task files don't exist and the WorkPlan Review section records `Status: approved` and `Conditions: none`, skip Work Plan Review and continue to user confirmation.
@@ -117,7 +117,7 @@ For EACH task, YOU MUST:
 3. **CHECK task-executor response**:
    - `status: "escalation_needed"` or `"blocked"` -> STOP and escalate to user
    - `requiresTestReview` is `true` -> Spawn integration-test-reviewer agent with `changedTestFiles: [integration/E2E paths from filesModified]`, `diffBase`, and `taskFile: [task-file-path]`; when matching integration/E2E skeleton paths are available from acceptance-test-generator output or task/work-plan references, pass only those paths as `skeletonFiles`
-     - `needs_revision` -> Return to step 2 with `requiredFixes`
+     - `needs_revision` -> Apply Review Revision Convergence (`author`: task-executor; `artifact`: changed test files); on `progression`, proceed to step 4
      - `approved` -> Proceed to step 4
      - `blocked` or unrecognized status -> STOP and escalate to user
    - `readyForQualityCheck: true` -> Proceed to step 4

--- a/.agents/skills/recipe-build/SKILL.md
+++ b/.agents/skills/recipe-build/SKILL.md
@@ -78,8 +78,7 @@ Spawn document-reviewer agent: "Review the work plan before task decomposition. 
 
 Branch on `verdict.decision`:
 - `approved` -> spawn work-planner in update mode once to record `Status: approved` and `Conditions: none` in WorkPlan Review, then continue to user confirmation
-- `approved_with_conditions` -> stop before task decomposition and report that the work plan needs update via recipe-plan
-- `needs_revision` -> stop before task decomposition and report that the work plan needs update via recipe-plan
+- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence from `subagents-orchestration-guide` with `work-planner` as the author, then repeat Work Plan Review
 - `rejected` -> stop before task decomposition and present the blocking findings to the user
 
 When task files don't exist and the WorkPlan Review section records `Status: approved` and `Conditions: none`, skip Work Plan Review and continue to user confirmation.

--- a/.agents/skills/recipe-front-build/SKILL.md
+++ b/.agents/skills/recipe-front-build/SKILL.md
@@ -78,7 +78,7 @@ Spawn document-reviewer agent: "Review the frontend work plan before task decomp
 
 Branch on `verdict.decision`:
 - `approved` -> spawn work-planner in update mode once to record `Status: approved` and `Conditions: none` in WorkPlan Review, then continue to user confirmation
-- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence from `subagents-orchestration-guide` with `work-planner` as the author, then repeat Work Plan Review
+- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence (`author`: work-planner; `artifact`: work plan); on `progression`, follow the `approved` branch
 - `rejected` -> stop before task decomposition and present the blocking findings to the user
 
 When task files don't exist and the WorkPlan Review section records `Status: approved` and `Conditions: none`, skip Work Plan Review and continue to user confirmation.
@@ -125,7 +125,7 @@ For EACH task, YOU MUST:
 3. **CHECK task-executor-frontend response**:
    - `status: "escalation_needed"` or `"blocked"` -> STOP and escalate to user
    - `requiresTestReview` is `true` -> Spawn integration-test-reviewer with `changedTestFiles: [integration/E2E paths from filesModified]`, `diffBase`, and `taskFile`; when matching integration/E2E skeleton paths are available from acceptance-test-generator output or task/work-plan references, pass only those paths as `skeletonFiles`
-     - `needs_revision` -> Return to step 2 with `requiredFixes`
+     - `needs_revision` -> Apply Review Revision Convergence (`author`: task-executor-frontend; `artifact`: changed test files); on `progression`, proceed to step 4
      - `approved` -> Proceed to step 4
      - `blocked` or unrecognized status -> STOP and escalate to user
    - `readyForQualityCheck: true` -> Proceed to step 4

--- a/.agents/skills/recipe-front-build/SKILL.md
+++ b/.agents/skills/recipe-front-build/SKILL.md
@@ -78,8 +78,7 @@ Spawn document-reviewer agent: "Review the frontend work plan before task decomp
 
 Branch on `verdict.decision`:
 - `approved` -> spawn work-planner in update mode once to record `Status: approved` and `Conditions: none` in WorkPlan Review, then continue to user confirmation
-- `approved_with_conditions` -> stop before task decomposition and report that the work plan needs update via recipe-front-plan
-- `needs_revision` -> stop before task decomposition and report that the work plan needs update via recipe-front-plan
+- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence from `subagents-orchestration-guide` with `work-planner` as the author, then repeat Work Plan Review
 - `rejected` -> stop before task decomposition and present the blocking findings to the user
 
 When task files don't exist and the WorkPlan Review section records `Status: approved` and `Conditions: none`, skip Work Plan Review and continue to user confirmation.

--- a/.agents/skills/recipe-front-plan/SKILL.md
+++ b/.agents/skills/recipe-front-plan/SKILL.md
@@ -60,7 +60,7 @@ Spawn document-reviewer agent: "Review the frontend work plan. doc_type: WorkPla
 
 Branch on `verdict.decision`:
 - `approved` -> spawn work-planner in update mode once to record `Status: approved` and `Conditions: none` in WorkPlan Review, then proceed to Step 5
-- `approved_with_conditions` or `needs_revision` -> spawn work-planner in update mode with the findings or conditions, then repeat Step 4. Use max 2 revision iterations as defined by the `needs_revision` row in subagents-orchestration-guide Approval Status Vocabulary.
+- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence from `subagents-orchestration-guide` with `work-planner` as the author, then repeat Step 4
 - `rejected` -> stop and present the blocking findings to the user.
 
 ### Step 5: Plan Approval

--- a/.agents/skills/recipe-front-plan/SKILL.md
+++ b/.agents/skills/recipe-front-plan/SKILL.md
@@ -60,7 +60,7 @@ Spawn document-reviewer agent: "Review the frontend work plan. doc_type: WorkPla
 
 Branch on `verdict.decision`:
 - `approved` -> spawn work-planner in update mode once to record `Status: approved` and `Conditions: none` in WorkPlan Review, then proceed to Step 5
-- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence from `subagents-orchestration-guide` with `work-planner` as the author, then repeat Step 4
+- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence (`author`: work-planner; `artifact`: work plan); on `progression`, follow the `approved` branch
 - `rejected` -> stop and present the blocking findings to the user.
 
 ### Step 5: Plan Approval

--- a/.agents/skills/recipe-fullstack-build/SKILL.md
+++ b/.agents/skills/recipe-fullstack-build/SKILL.md
@@ -88,8 +88,7 @@ Spawn document-reviewer agent: "Review the fullstack work plan before task decom
 
 Branch on `verdict.decision`:
 - `approved` -> spawn work-planner in update mode once to record `Status: approved` and `Conditions: none` in WorkPlan Review, then continue to user confirmation
-- `approved_with_conditions` -> stop before task decomposition and report that the work plan needs update via recipe-plan or the fullstack planning flow
-- `needs_revision` -> stop before task decomposition and report that the work plan needs update via recipe-plan or the fullstack planning flow
+- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence from `subagents-orchestration-guide` with `work-planner` as the author, then repeat Work Plan Review
 - `rejected` -> stop before task decomposition and present the blocking findings to the user
 
 When task files don't exist and the WorkPlan Review section records `Status: approved` and `Conditions: none`, skip Work Plan Review and continue to user confirmation.

--- a/.agents/skills/recipe-fullstack-build/SKILL.md
+++ b/.agents/skills/recipe-fullstack-build/SKILL.md
@@ -88,7 +88,7 @@ Spawn document-reviewer agent: "Review the fullstack work plan before task decom
 
 Branch on `verdict.decision`:
 - `approved` -> spawn work-planner in update mode once to record `Status: approved` and `Conditions: none` in WorkPlan Review, then continue to user confirmation
-- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence from `subagents-orchestration-guide` with `work-planner` as the author, then repeat Work Plan Review
+- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence (`author`: work-planner; `artifact`: work plan); on `progression`, follow the `approved` branch
 - `rejected` -> stop before task decomposition and present the blocking findings to the user
 
 When task files don't exist and the WorkPlan Review section records `Status: approved` and `Conditions: none`, skip Work Plan Review and continue to user confirmation.
@@ -135,7 +135,7 @@ For EACH task, YOU MUST:
 3. **CHECK executor response**:
    - `status: "escalation_needed"` or `"blocked"` -> STOP and escalate to user
    - `requiresTestReview` is `true` -> Spawn integration-test-reviewer with `changedTestFiles: [integration/E2E paths from filesModified]`, `diffBase`, and `taskFile`; when matching integration/E2E skeleton paths are available from acceptance-test-generator output or task/work-plan references, pass only those paths as `skeletonFiles`
-     - `needs_revision` -> Return to step 2 with `requiredFixes`
+     - `needs_revision` -> Apply Review Revision Convergence (`author`: layer-appropriate executor; `artifact`: changed test files); on `progression`, proceed to step 4
      - `approved` -> Proceed to step 4
      - `blocked` or unrecognized status -> STOP and escalate to user
    - `readyForQualityCheck: true` -> Proceed to step 4

--- a/.agents/skills/recipe-implement/SKILL.md
+++ b/.agents/skills/recipe-implement/SKILL.md
@@ -114,7 +114,7 @@ Before the first task, call `update_plan` once with first "Map active rules to t
 2. Check task-executor response:
    - `status: escalation_needed` or `blocked` -> Escalate to user
    - `requiresTestReview` is `true` -> Spawn integration-test-reviewer with changed integration/E2E paths from `filesModified`, `diffBase`, and `taskFile`; when matching integration/E2E skeleton paths are available from acceptance-test-generator output or task/work-plan references, pass only those paths as `skeletonFiles`
-     - `needs_revision` -> Return to step 1 with `requiredFixes`
+     - `needs_revision` -> Apply Review Revision Convergence (`author`: layer-appropriate executor; `artifact`: changed test files); on `progression`, proceed to step 3
      - `approved` -> Proceed to step 3
      - `blocked` or unrecognized status -> Escalate to user
    - Otherwise -> Proceed to step 3

--- a/.agents/skills/recipe-plan/SKILL.md
+++ b/.agents/skills/recipe-plan/SKILL.md
@@ -63,7 +63,7 @@ Spawn document-reviewer agent: "Review the work plan. doc_type: WorkPlan. target
 
 Branch on `verdict.decision`:
 - `approved` -> spawn work-planner in update mode once to record `Status: approved` and `Conditions: none` in WorkPlan Review, then proceed to Step 5
-- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence from `subagents-orchestration-guide` with `work-planner` as the author, then repeat Step 4
+- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence (`author`: work-planner; `artifact`: work plan); on `progression`, follow the `approved` branch
 - `rejected` -> stop and present the blocking findings to the user.
 
 ### Step 5: Plan Approval

--- a/.agents/skills/recipe-plan/SKILL.md
+++ b/.agents/skills/recipe-plan/SKILL.md
@@ -63,7 +63,7 @@ Spawn document-reviewer agent: "Review the work plan. doc_type: WorkPlan. target
 
 Branch on `verdict.decision`:
 - `approved` -> spawn work-planner in update mode once to record `Status: approved` and `Conditions: none` in WorkPlan Review, then proceed to Step 5
-- `approved_with_conditions` or `needs_revision` -> spawn work-planner in update mode with the findings or conditions, then repeat Step 4. Use max 2 revision iterations as defined by the `needs_revision` row in subagents-orchestration-guide Approval Status Vocabulary.
+- `approved_with_conditions` or `needs_revision` -> apply Review Revision Convergence from `subagents-orchestration-guide` with `work-planner` as the author, then repeat Step 4
 - `rejected` -> stop and present the blocking findings to the user.
 
 ### Step 5: Plan Approval

--- a/.agents/skills/recipe-reverse-engineer/SKILL.md
+++ b/.agents/skills/recipe-reverse-engineer/SKILL.md
@@ -108,20 +108,17 @@ Spawn document-reviewer agent: "Review the following PRD considering code verifi
 
 **Store output as**: `$STEP_4_OUTPUT`
 
+If `verdict.decision` is `rejected`, halt the current unit and escalate the blocking findings to the user.
+
 #### Step 5: Revision (conditional)
 
-**Trigger Conditions** (any one of the following):
-- Review status is "Needs Revision" or "Rejected"
-- Critical discrepancies exist in `$STEP_3_OUTPUT`
-- consistencyScore < 70
-
-Spawn prd-creator agent: "Update PRD based on review feedback and code verification results. Operation Mode: update. Existing PRD: $STEP_2_OUTPUT. Review Feedback: $STEP_4_OUTPUT. Code Verification Results: $STEP_3_OUTPUT. Address discrepancies by severity. Critical and major items require correction. Minor items: correct if straightforward, otherwise leave as-is with rationale."
-
-**Loop Control**: Apply Review Revision Convergence from `subagents-orchestration-guide` with `prd-creator` as the author and `$STEP_4_OUTPUT` as the prior review.
+- If `verdict.decision` is `needs_revision`, apply Review Revision Convergence (`author`: prd-creator; `artifact`: `$STEP_2_OUTPUT`); on `progression`, retain its final review as the current review and evaluate the next bullet.
+- If the current review permits progression and critical discrepancies exist in `$STEP_3_OUTPUT` or consistencyScore < 70, spawn prd-creator once: "Update PRD based on code verification results. Operation Mode: update. Existing PRD: $STEP_2_OUTPUT. Code Verification Results: $STEP_3_OUTPUT. Address discrepancies by severity. Critical and major items require correction. Minor items: correct if straightforward, otherwise leave as-is with rationale." Then re-run Step 4 and route the new verdict only; this verification-triggered correction runs once per unit.
+- After the applicable revision bullets complete, continue to Unit Completion.
 
 #### Unit Completion
 
-- [ ] Review status is "Approved" or "Approved with Conditions"
+- [ ] `verdict.decision` is `approved` or `approved_with_conditions`
 - [ ] Human review passed (if enabled in Step 0)
 
 **Next**: Proceed to next unit. After all units -> Phase 2.
@@ -214,20 +211,17 @@ Spawn document-reviewer agent: "Review the following Design Doc considering code
 
 **Store output as**: `$STEP_9_OUTPUT`
 
+If `verdict.decision` is `rejected`, halt the current unit and escalate the blocking findings to the user.
+
 #### Step 10: Revision (conditional)
 
-**Trigger Conditions** (same as Step 5):
-- Review status is "Needs Revision" or "Rejected"
-- Critical discrepancies exist in `$STEP_8_OUTPUT`
-- consistencyScore < 70
-
-Spawn technical-designer agent: "Update Design Doc based on review feedback and code verification results. Operation Mode: update. Existing Design Doc: $STEP_7_OUTPUT. Review Feedback: $STEP_9_OUTPUT. Code Verification Results: $STEP_8_OUTPUT. Address discrepancies by severity. Critical and major items require correction. Minor items: correct if straightforward, otherwise leave as-is with rationale."
-
-**Loop Control**: Apply Review Revision Convergence from `subagents-orchestration-guide` with `technical-designer` as the author and `$STEP_9_OUTPUT` as the prior review.
+- If `verdict.decision` is `needs_revision`, apply Review Revision Convergence (`author`: technical-designer; `artifact`: `$STEP_7_OUTPUT`); on `progression`, retain its final review as the current review and evaluate the next bullet.
+- If the current review permits progression and critical discrepancies exist in `$STEP_8_OUTPUT` or consistencyScore < 70, spawn technical-designer once: "Update Design Doc based on code verification results. Operation Mode: update. Existing Design Doc: $STEP_7_OUTPUT. Code Verification Results: $STEP_8_OUTPUT. Address discrepancies by severity. Critical and major items require correction. Minor items: correct if straightforward, otherwise leave as-is with rationale." Then re-run Step 9 and route the new verdict only; this verification-triggered correction runs once per unit.
+- After the applicable revision bullets complete, continue to Unit Completion.
 
 #### Unit Completion
 
-- [ ] Review status is "Approved" or "Approved with Conditions"
+- [ ] `verdict.decision` is `approved` or `approved_with_conditions`
 - [ ] Human review passed (if enabled in Step 0)
 
 **Next**: Proceed to next unit. After all units -> Final Report.
@@ -246,7 +240,7 @@ Output summary including:
 | Discovery finds nothing | Ask user for project structure hints |
 | Generation fails | Log failure, continue with other units, report in summary |
 | consistencyScore < 50 | **[STOP — BLOCKING]** Flag for mandatory human review. **CANNOT proceed until user explicitly confirms.** |
-| Review cannot converge because authoritative input is missing or contradictory | Present the exact missing or contradictory input |
+| Review Revision Convergence returns `non_convergent` | Stop the unit loop, present the exact unresolved findings and attempted corrections, then wait |
 
 ## Completion Criteria
 

--- a/.agents/skills/recipe-reverse-engineer/SKILL.md
+++ b/.agents/skills/recipe-reverse-engineer/SKILL.md
@@ -117,8 +117,7 @@ Spawn document-reviewer agent: "Review the following PRD considering code verifi
 
 Spawn prd-creator agent: "Update PRD based on review feedback and code verification results. Operation Mode: update. Existing PRD: $STEP_2_OUTPUT. Review Feedback: $STEP_4_OUTPUT. Code Verification Results: $STEP_3_OUTPUT. Address discrepancies by severity. Critical and major items require correction. Minor items: correct if straightforward, otherwise leave as-is with rationale."
 
-**Loop Control**: Maximum 2 revision cycles. After 2 cycles, flag for human review regardless of status.
-ENFORCEMENT: Exceeding 2 revision cycles without flagging produces unreviewed output.
+**Loop Control**: Apply Review Revision Convergence from `subagents-orchestration-guide` with `prd-creator` as the author and `$STEP_4_OUTPUT` as the prior review.
 
 #### Unit Completion
 
@@ -224,7 +223,7 @@ Spawn document-reviewer agent: "Review the following Design Doc considering code
 
 Spawn technical-designer agent: "Update Design Doc based on review feedback and code verification results. Operation Mode: update. Existing Design Doc: $STEP_7_OUTPUT. Review Feedback: $STEP_9_OUTPUT. Code Verification Results: $STEP_8_OUTPUT. Address discrepancies by severity. Critical and major items require correction. Minor items: correct if straightforward, otherwise leave as-is with rationale."
 
-**Loop Control**: Maximum 2 revision cycles. After 2 cycles, flag for human review regardless of status.
+**Loop Control**: Apply Review Revision Convergence from `subagents-orchestration-guide` with `technical-designer` as the author and `$STEP_9_OUTPUT` as the prior review.
 
 #### Unit Completion
 
@@ -247,7 +246,7 @@ Output summary including:
 | Discovery finds nothing | Ask user for project structure hints |
 | Generation fails | Log failure, continue with other units, report in summary |
 | consistencyScore < 50 | **[STOP — BLOCKING]** Flag for mandatory human review. **CANNOT proceed until user explicitly confirms.** |
-| Review rejects after 2 revisions | Stop loop, flag for human intervention |
+| Review cannot converge because authoritative input is missing or contradictory | Present the exact missing or contradictory input |
 
 ## Completion Criteria
 

--- a/.agents/skills/recipe-update-doc/SKILL.md
+++ b/.agents/skills/recipe-update-doc/SKILL.md
@@ -125,9 +125,10 @@ Spawn document-reviewer agent: "Review the following updated document. doc_type:
 **Store output as**: `$STEP_5_OUTPUT`
 
 **On review result**:
-- Approved or approved with conditions -> Present review results to the user for approval, then proceed to Step 6 after approval
-- Needs revision -> Apply Review Revision Convergence from `subagents-orchestration-guide` with [Update Agent from Step 2] as the author and return to Step 4
-- Rejected -> Present the exact blocking findings and required user decision, then end
+- `approved` -> **[STOP — BLOCKING]** Present review results to the user and proceed to Step 6 only after explicit approval
+- `approved_with_conditions` -> Apply the Approval Status Vocabulary conditions handling, then **[STOP — BLOCKING]** present the result and proceed to Step 6 only after explicit approval
+- `needs_revision` -> Apply Review Revision Convergence (`author`: [Update Agent from Step 2]; `artifact`: target document); on `progression`, follow the matching approved branch
+- `rejected` -> **[STOP — BLOCKING]** Present the exact blocking findings and required user decision, then wait
 
 ### Step 6: Consistency Verification (Design Doc only) [Stop]
 
@@ -150,7 +151,7 @@ For Design Doc, spawn design-sync agent: "Verify consistency of the updated Desi
 |-------|--------|
 | Target document not found | Report and end (suggest $recipe-design instead) |
 | Sub-agent update fails | Log failure, present error to user, retry once |
-| Review cannot converge because authoritative input is missing or contradictory | Present the exact missing or contradictory input |
+| Review Revision Convergence returns `non_convergent` | Stop the loop, present the exact unresolved findings and attempted corrections, then wait |
 | design-sync detects conflicts | Present to user for resolution decision |
 
 ## Completion Criteria

--- a/.agents/skills/recipe-update-doc/SKILL.md
+++ b/.agents/skills/recipe-update-doc/SKILL.md
@@ -124,16 +124,10 @@ Spawn document-reviewer agent: "Review the following updated document. doc_type:
 
 **Store output as**: `$STEP_5_OUTPUT`
 
-**[STOP — BLOCKING]** Present review results to user for approval.
-**CANNOT proceed until user explicitly confirms.**
-
 **On review result**:
-- Approved -> Proceed to Step 6
-- Needs revision -> Return to Step 4 with review feedback (max 2 iterations):
-  Spawn [Update Agent from Step 2] agent: "Operation Mode: update. Existing Document: [path from Step 1]. Review Feedback to Address: $STEP_5_OUTPUT. Address each issue raised in the review feedback."
-- **After 2 rejections** -> Flag for human review, present accumulated feedback to user and end
-
-Present review result to user for approval.
+- Approved or approved with conditions -> Present review results to the user for approval, then proceed to Step 6 after approval
+- Needs revision -> Apply Review Revision Convergence from `subagents-orchestration-guide` with [Update Agent from Step 2] as the author and return to Step 4
+- Rejected -> Present the exact blocking findings and required user decision, then end
 
 ### Step 6: Consistency Verification (Design Doc only) [Stop]
 
@@ -156,7 +150,7 @@ For Design Doc, spawn design-sync agent: "Verify consistency of the updated Desi
 |-------|--------|
 | Target document not found | Report and end (suggest $recipe-design instead) |
 | Sub-agent update fails | Log failure, present error to user, retry once |
-| Review rejects after 2 revisions | Stop loop, flag for human intervention |
+| Review cannot converge because authoritative input is missing or contradictory | Present the exact missing or contradictory input |
 | design-sync detects conflicts | Present to user for resolution decision |
 
 ## Completion Criteria

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -138,7 +138,7 @@ These values standardize review and approval decisions. Review and approval agen
 | `approved` | Review/approval agents | All criteria met | Proceed to next phase |
 | `approved_with_conditions` | Document agents | Criteria met with minor open items | Proceed — carry conditions as input to next phase |
 | `approved_with_notes` | security-reviewer | Only hardening/policy findings | Proceed — include notes in completion report (no resolution required) |
-| `needs_revision` | Review/approval agents | Significant issues found | Return to author agent for revision (max 2 iterations) |
+| `needs_revision` | Review/approval agents | Significant issues found | Return to author agent under Review Revision Convergence |
 | `rejected` | Document agents | Fundamental problems | Halt workflow, escalate to user |
 | `blocked` | security-reviewer | Committed secrets or high-confidence exploitable risk | Halt workflow immediately, escalate to user (requires human intervention) |
 | `skipped` | Review/approval agents whose schema permits skipping | Preconditions not met for this step | Report reason, proceed |
@@ -148,6 +148,17 @@ Handling rules:
 - `approved_with_notes`: include the notes in the completion report for awareness
 
 **ENFORCEMENT**: Using any status value outside this vocabulary for a review or approval decision is a VIOLATION.
+
+### Review Revision Convergence [MANDATORY]
+
+Review-result routing runs before any adjacent user-approval stop. Reach the approval stop only after the review status permits progression under the Approval Status Vocabulary.
+
+On `needs_revision`, and on WorkPlan `approved_with_conditions`:
+1. Pass the complete findings or conditions to the author agent in update mode.
+2. Re-run the same reviewer with the previous review included as prior review context. Use `prior_context_check` when the reviewer provides it; otherwise compare its finding IDs or normalized required fixes.
+3. Continue the author-review loop until the review permits progression or identifies an item that requires escalation under the existing `rejected`, `blocked`, or requirement-change rules.
+
+Revision loops have no fixed iteration limit. After each review, compare unresolved findings by stable ID, or by normalized category, location, and description when IDs are absent. When the same unresolved set and evidence recur unchanged, run a convergence pass: inspect the governing sources, artifact, author output, and reviewer evidence; then give the author one targeted correction per evidence-resolved finding. Escalate only when a faithful correction requires a missing or contradictory authoritative input or an explicit user decision, and name that exact input or decision. The orchestrator selects the next route from this evidence; user input is requested only for the exact unresolved input or decision.
 
 ### WorkPlan Review State [MANDATORY]
 
@@ -251,7 +262,7 @@ Flow rules:
 - Pass `codebase-analyzer` output to the designer as `Codebase Analysis`
 - Pass Design Doc path to `code-verifier`, then pass `code_verification` to `document-reviewer`
 - Fullstack layer sequencing is defined in `references/monorepo-flow.md`
-- Run WorkPlan review after every Medium/Large work plan creation or update and before batch approval. On `needs_revision` or WorkPlan `approved_with_conditions`, return to `work-planner` in update mode and re-review for max 2 revision iterations as defined by the `needs_revision` row in Approval Status Vocabulary. On `rejected`, halt and escalate to the user.
+- Run WorkPlan review after every Medium/Large work plan creation or update and before batch approval. On `needs_revision` or WorkPlan `approved_with_conditions`, apply Review Revision Convergence with `work-planner` as the author. On `rejected`, halt and escalate to the user.
 
 ## Autonomous Execution Mode
 

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -136,29 +136,32 @@ These values standardize review and approval decisions. Review and approval agen
 | Status | Scope | Meaning | Next Action |
 |--------|-------|---------|-------------|
 | `approved` | Review/approval agents | All criteria met | Proceed to next phase |
-| `approved_with_conditions` | Document agents | Criteria met with minor open items | Proceed — carry conditions as input to next phase |
+| `approved_with_conditions` | Document agents | Criteria met with minor open items | Proceed per document-specific handling; WorkPlan uses WorkPlan Review State |
 | `approved_with_notes` | security-reviewer | Only hardening/policy findings | Proceed — include notes in completion report (no resolution required) |
-| `needs_revision` | Review/approval agents | Significant issues found | Return to author agent under Review Revision Convergence |
+| `needs_revision` | Review/approval agents | Significant issues found | Use Review Revision Convergence when the active workflow owns the repair author; otherwise use the workflow's specific routing |
 | `rejected` | Document agents | Fundamental problems | Halt workflow, escalate to user |
 | `blocked` | security-reviewer | Committed secrets or high-confidence exploitable risk | Halt workflow immediately, escalate to user (requires human intervention) |
 | `skipped` | Review/approval agents whose schema permits skipping | Preconditions not met for this step | Report reason, proceed |
 
 Handling rules:
-- `approved_with_conditions`: append the listed conditions to the document's open-items section, carry them into the next phase, and resolve them before implementation
+- `approved_with_conditions` for PRD, ADR, UI Spec, and Design Doc: append the listed conditions to the document's open-items section, carry them into the next phase, and resolve them before implementation
 - `approved_with_notes`: include the notes in the completion report for awareness
 
 **ENFORCEMENT**: Using any status value outside this vocabulary for a review or approval decision is a VIOLATION.
 
 ### Review Revision Convergence [MANDATORY]
 
-Review-result routing runs before any adjacent user-approval stop. Reach the approval stop only after the review status permits progression under the Approval Status Vocabulary.
+Review-result routing runs before any adjacent user-approval stop. Reach the approval stop only after the review status permits progression under the Approval Status Vocabulary. This procedure applies when the active workflow owns an author that can repair the reviewed artifact; review-only routing and Post-Implementation Verification retain their specific contracts.
 
-On `needs_revision`, and on WorkPlan `approved_with_conditions`:
-1. Pass the complete findings or conditions to the author agent in update mode.
-2. Re-run the same reviewer with the previous review included as prior review context. Use `prior_context_check` when the reviewer provides it; otherwise compare its finding IDs or normalized required fixes.
-3. Continue the author-review loop until the review permits progression or identifies an item that requires escalation under the existing `rejected`, `blocked`, or requirement-change rules.
+Inputs are `author`, `artifact`, `reviewer`, and the complete `current_review` response. Callers name the author and artifact; reviewer and current review are the active review agent and its response. The procedure retains the preceding response as `previous_review`.
 
-Revision loops have no fixed iteration limit. After each review, compare unresolved findings by stable ID, or by normalized category, location, and description when IDs are absent. When the same unresolved set and evidence recur unchanged, run a convergence pass: inspect the governing sources, artifact, author output, and reviewer evidence; then give the author one targeted correction per evidence-resolved finding. Escalate only when a faithful correction requires a missing or contradictory authoritative input or an explicit user decision, and name that exact input or decision. The orchestrator selects the next route from this evidence; user input is requested only for the exact unresolved input or decision.
+1. Invoke the author through its existing update or repair contract with the complete current findings.
+2. Re-run the reviewer through its declared input contract. Include the previous review JSON as `prior feedback` only when that reviewer accepts or scans prior-context input.
+3. Return `progression` when the review status satisfies the caller's phase gate; the WorkPlan phase gate accepts `approved`. Return `escalation` with the artifact, triggering findings, and attempted corrections for `rejected`, `blocked`, or a requirement change.
+4. Otherwise compare unresolved findings between `previous_review` and `current_review`. Match document-reviewer findings by `issues[].id`, or by normalized category, location, and description when an ID is absent. Match integration-test-reviewer findings by normalized `testName`, `issueType`, and `expectedClaim`, or by normalized `requiredFixes` text when structured issue fields are absent; normalization ignores case and whitespace only. Compare unresolved severity-count vectors from highest to lowest; progress exists when the first changed count decreases, or when new governing-source evidence makes a correction executable. Each distinct evidence item establishes progress on its first use for the matched finding and is then recorded as evaluated.
+5. On no progress, run one convergence pass using the governing sources to give the author targeted corrections. If the next review still makes no progress, return `non_convergent` with the artifact, unresolved findings, and attempted corrections.
+
+`progression`, `escalation`, and `non_convergent` are procedure control states, separate from the review and approval decisions governed by the Approval Status Vocabulary. The procedure owns the author-review loop; callers route its returned state exactly once and continue from the named destination. Observable progress governs loop length. The default route for `escalation` and `non_convergent` halts the current phase and presents the returned artifact, unresolved findings, and attempted corrections to the user; a caller-defined route takes precedence.
 
 ### WorkPlan Review State [MANDATORY]
 
@@ -166,7 +169,7 @@ Medium and Large work plans must contain a `WorkPlan Review` section. Small simp
 
 Handling rules:
 - After WorkPlan review returns `approved`, invoke work-planner in update mode once to record the review section, without changing implementation content.
-- Treat WorkPlan `approved_with_conditions` the same as `needs_revision`: return to work-planner in update mode with the conditions, then re-review. Conditions must not be carried into task decomposition or implementation readiness.
+- WorkPlan `approved_with_conditions` enters Review Revision Convergence with `work-planner` as the author. Resolve the conditions within convergence before task decomposition or implementation readiness.
 - A material work plan update resets `WorkPlan Review` to `Status: pending`.
 - Standalone build recipes apply WorkPlan review only before task decomposition, not after task files already exist.
 
@@ -193,7 +196,7 @@ Subagents respond in JSON format. The final response from each JSON-returning su
 | `ui-analyzer` | `externalResources`, `componentStructure`, `propsPatterns`, `cssLayout`, `stateDisplay`, `focusAreas`, `candidateWriteSet`, `limitations` |
 | `task-executor*` | `status`, `escalation_type` (`design_compliance_violation`, `similar_function_found`, `similar_component_found`, `investigation_target_not_found`, `out_of_scope_file`, `dependency_version_uncertain`, `binding_decision_violation`, `test_environment_not_ready`), `filesModified`, `requiresTestReview` |
 | `quality-fixer*` | Inputs: `task_file`, `filesModified`; outputs: `status`, `reason`, `stubFindings`, `blockingIssues`, `missingPrerequisites` |
-| `document-reviewer` | `verdict.decision`, `verdict.conditions` |
+| `document-reviewer` | `verdict.decision`, `verdict.conditions`, `issues`, `prior_context_check` |
 | `code-verifier` | `summary.status`, `blockingReason`, `discrepancies`, `reverseCoverage` |
 | `design-sync` | `sync_status` |
 | `integration-test-reviewer` | Inputs: `changedTestFiles`, `diffBase`, optional review-basis inputs; outputs: `status`, `reviewBasis`, `requiredFixes` |
@@ -262,7 +265,7 @@ Flow rules:
 - Pass `codebase-analyzer` output to the designer as `Codebase Analysis`
 - Pass Design Doc path to `code-verifier`, then pass `code_verification` to `document-reviewer`
 - Fullstack layer sequencing is defined in `references/monorepo-flow.md`
-- Run WorkPlan review after every Medium/Large work plan creation or update and before batch approval. On `needs_revision` or WorkPlan `approved_with_conditions`, apply Review Revision Convergence with `work-planner` as the author. On `rejected`, halt and escalate to the user.
+- Run WorkPlan review after every Medium/Large work plan creation or update and before batch approval. On `needs_revision` or WorkPlan `approved_with_conditions`, apply Review Revision Convergence (`author`: work-planner; `artifact`: work plan); on `progression`, follow the `approved` branch. On `rejected`, halt and escalate to the user.
 
 ## Autonomous Execution Mode
 
@@ -297,7 +300,7 @@ Batch approval -> Start autonomous execution mode
       -> Escalation judgment:
           - escalation_needed/blocked -> Escalate to user
           - requiresTestReview: true -> integration-test-reviewer with changedTestFiles from filesModified, diffBase, taskFile, and matching skeletonFiles when available from acceptance-test-generator output or task/work-plan references
-              - needs_revision -> back to task-executor
+              - needs_revision -> Review Revision Convergence (`author`: task-executor/task-executor-frontend; `artifact`: changed test files); on `progression` -> quality-fixer
               - approved -> quality-fixer
               - blocked/unrecognized -> Escalate to user
           - No issues -> quality-fixer
@@ -320,6 +323,7 @@ Stop autonomous execution and escalate to user in the following cases:
 2. **Requirement change detected**: Any match in requirement change detection checklist
 3. **Work-planner update restriction violated**: Requirement changes after task-decomposer starts require overall redesign
 4. **User explicitly stops**: Direct stop instruction or interruption
+5. **Review cannot converge**: Review Revision Convergence returns `non_convergent`; report its artifact, unresolved findings, and attempted corrections
 
 Continue autonomous execution in the following situations:
 - A workflow subagent is still pending

--- a/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -107,7 +107,7 @@ After work-planner creates or updates the plan, spawn document-reviewer:
 
 > "Review the fullstack work plan. doc_type: WorkPlan. target: [work plan path]. mode: composite. Review semantic traceability to all Design Docs, UI Spec when present, Reference Contract Values fidelity, cross-layer boundary coverage, early verification placement, real-boundary verification coverage, Proof Strategy, Failure Mode Checklist, Review Scope, and Quality Assurance coverage."
 
-On `needs_revision` or `approved_with_conditions`, apply Review Revision Convergence from the parent skill with `work-planner` as the author. On `rejected`, halt and escalate to the user. Stop for batch approval only after WorkPlan review returns `approved` and the plan's `WorkPlan Review` section records `Status: approved` with `Conditions: none`.
+On `needs_revision` or `approved_with_conditions`, apply Review Revision Convergence (`author`: work-planner; `artifact`: work plan); on `progression`, follow the `approved` branch. On `rejected`, halt and escalate to the user. Stop for batch approval only after WorkPlan review returns `approved` and the plan's `WorkPlan Review` section records `Status: approved` with `Conditions: none`.
 
 ## Task Decomposition Phase
 

--- a/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -107,7 +107,7 @@ After work-planner creates or updates the plan, spawn document-reviewer:
 
 > "Review the fullstack work plan. doc_type: WorkPlan. target: [work plan path]. mode: composite. Review semantic traceability to all Design Docs, UI Spec when present, Reference Contract Values fidelity, cross-layer boundary coverage, early verification placement, real-boundary verification coverage, Proof Strategy, Failure Mode Checklist, Review Scope, and Quality Assurance coverage."
 
-On `needs_revision` or `approved_with_conditions`, return to work-planner in update mode and re-review for max 2 revision iterations as defined by the `needs_revision` row in Approval Status Vocabulary. On `rejected`, halt and escalate to the user. Stop for batch approval only after WorkPlan review returns `approved` and the plan's `WorkPlan Review` section records `Status: approved` with `Conditions: none`.
+On `needs_revision` or `approved_with_conditions`, apply Review Revision Convergence from the parent skill with `work-planner` as the author. On `rejected`, halt and escalate to the user. Stop for batch approval only after WorkPlan review returns `approved` and the plan's `WorkPlan Review` section records `Status: approved` with `Conditions: none`.
 
 ## Task Decomposition Phase
 

--- a/.codex/agents/document-reviewer.toml
+++ b/.codex/agents/document-reviewer.toml
@@ -255,26 +255,26 @@ Include in output when `prior_context_count > 0`:
 - Gate 0: All structural existence checks pass
 - Consistency score > 90
 - Completeness score > 85
-- No rule violations (severity: high is zero)
+- Zero rule violations at `important` or `critical`
 - No blocking issues
-- Prior context items (if any): All critical/major resolved
+- Prior context items (if any): All `critical` and `important` items resolved
 
 ### Approved with Conditions
 - Gate 0: All structural existence checks pass
 - Consistency score > 80
 - Completeness score > 75
-- Only minor rule violations (severity: medium or below)
+- Highest rule-violation severity is `important`, when rule violations exist
 - Only easily fixable issues
-- Prior context items (if any): At most 1 major unresolved
+- Prior context items (if any): At most 1 `important` item unresolved and zero `critical` items unresolved
 
 ### Needs Revision
 - Gate 0: Any structural existence check fails OR
 - Consistency score < 80 OR
 - Completeness score < 75 OR
-- Serious rule violations (severity: high)
+- At least one rule violation has severity `critical`
 - Blocking issues present
 - Design Convergence gate fails
-- Prior context items (if any): 2+ major unresolved OR any critical unresolved
+- Prior context items (if any): 2+ `important` items unresolved OR any `critical` item unresolved
 - complexity_level is medium/high but complexity_rationale lacks (1) requirements/ACs or (2) constraints/risks
 
 ### Rejected

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

- make review revision loops continue while observable progress exists
- route convergence failures and escalation states consistently across planning and build recipes
- align reviewer status and severity contracts and bump the package version to 0.9.4

## Validation

- npm test
- npm run check:skills-index
- git diff --check