### PR TITLE
Scope ADR decisions and batch reviews

### DIFF
--- a/.agents/skills/documentation-criteria/SKILL.md
+++ b/.agents/skills/documentation-criteria/SKILL.md
@@ -23,9 +23,9 @@ description: "Documentation creation criteria for PRD, ADR, Design Doc, UI Spec,
 
 Build one path in this order:
 
-1. An ADR condition sets the scale floor to Medium; select the resulting scale's base path.
+1. Select the base path from Structural Scale.
 2. Frontend or fullstack scope inserts UI Spec immediately before the Design Doc.
-3. An ADR condition inserts ADR immediately before the Design Doc.
+3. One or more qualifying ADR decision points insert an ADR batch immediately before the Design Doc. A qualifying decision point sets the scale floor to Medium.
 
 **ENFORCEMENT**: EVALUATE structural scale and ADR conditions BEFORE starting implementation
 
@@ -39,18 +39,27 @@ Classify the decision burden, not repository layout. File count is supporting ev
 | Medium | One coherent outcome coordinates across a boundary or requires a durable design decision |
 | Large | Multiple independently valuable outcomes require separate design decisions |
 
-An ADR condition sets the floor at Medium because it creates a durable decision. Large applies when multiple independently valuable outcomes require separate design decisions; one coherent outcome remains Medium across multiple layers.
+A qualifying ADR decision point sets the floor at Medium because it creates a durable decision. Large applies when multiple independently valuable outcomes require separate design decisions; one coherent outcome remains Medium across multiple layers. ADR decision points come from the Choice and Durability filters independently of scale.
 
 ## ADR Creation Conditions
 
-Create an ADR when implementation depends on a durable technical choice that future work must understand or preserve, such as:
+Apply both filters in order for each technical topic within the confirmed implementation scope:
+
+1. **Choice requires judgment** — current requirements, accepted decisions, and representative repository patterns support at least two credible materially distinct options whose selection requires comparison.
+2. **Decision is durable** — choosing among those options materially changes a responsibility, dependency direction, shared contract, persistence model, technology dependency, reversibility, or lifecycle cost that future work must understand or preserve.
+
+Create one ADR for each topic that passes both filters. Route topics with one evident choice, generic technical concerns, operational possibilities, and rejected activities directly to the Design Doc or out of current design as applicable.
+
+Treat choices as one decision point when they must be selected or reconsidered together. Use separate decision points when each choice can be selected and revisited independently.
+
+Qualifying durable choices include:
 
 - introducing or replacing a technology, library, platform, storage model, or external dependency;
 - changing ownership, dependency direction, trust boundary, or a shared public contract in a way with credible materially different alternatives;
 - reversing or superseding an accepted architecture decision;
 - choosing an irreversible or high-cost-to-reverse data or compatibility strategy.
 
-A local contract, data-flow, state, or component change that follows an accepted design and has no material alternative belongs in the Design Doc. Create an ADR for a durable decision with materially distinct alternatives; counts of files, consumers, nesting levels, states, or steps remain supporting evidence rather than decision criteria.
+A local contract, data-flow, state, or component change that follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible belongs in the Design Doc. Counts of files, consumers, nesting levels, states, steps, and Structural Scale remain supporting evidence rather than ADR criteria.
 
 ## Detailed Document Definitions
 
@@ -60,7 +69,7 @@ A local contract, data-flow, state, or component change that follows an accepted
 
 ### ADR (Architecture Decision Record)
 **Purpose**: Record technical decision rationale and background
-**Scope**: Decision, rationale, credible alternatives actually considered, architecture impact, consequences, and principled implementation guidance only. Record Why now, Known unknowns, Kill criteria, and diagrams when they change how the decision is judged or reversed; otherwise use a brief N/A. Implementation procedures and code examples belong in Design Doc, while schedule and resource assignments belong in Work Plan.
+**Scope**: One qualifying technical decision point, its credible alternatives, requirement and repository fit, current-scope benefit, lifecycle cost, maintainability, selected necessary-and-sufficient option, consequences, and reconsideration conditions. An ADR narrows the technical solution space; the confirmed requirements remain the product and implementation scope. Implementation procedures and code examples belong in Design Doc, while schedule and resource assignments belong in Work Plan.
 
 ### UI Specification
 **Purpose**: Define UI structure, screen transitions, component decomposition, and interaction design
@@ -95,10 +104,10 @@ A local contract, data-flow, state, or component change that follows an accepted
 
 ## Creation Process [MANDATORY]
 
-**STEP 1**: **Problem Analysis** — Change scale assessment, ADR condition check
-**STEP 2**: **ADR Option Consideration** (when creating an ADR) — Compare every credible materially distinct option found in requirements, repository evidence, or the current approach; record why no additional alternative is credible when only one remains
-**STEP 3**: **Creation** — Use templates, include measurable conditions
-**STEP 4**: **Approval** — document review followed by user approval enables implementation
+**STEP 1**: **Problem Analysis** — Determine Structural Scale, applicable documents, and candidate technical decision points
+**STEP 2**: **ADR Choice Check when candidates exist** — Retain in-scope topics whose selection requires comparison between at least two credible materially distinct options and has durable impact
+**STEP 3**: **Creation** — Create each applicable document from its template; complete every qualifying ADR file before ADR review
+**STEP 4**: **Approval** — Review applicable artifacts and obtain user approval; supply the complete ADR path set to one review and one approval request
 
 **ENFORCEMENT**: Begin implementation when the documents required for the relevant scale are approved.
 
@@ -116,9 +125,9 @@ A local contract, data-flow, state, or component change that follows an accepted
 `Proposed` -> `Accepted` -> `Deprecated`/`Superseded`/`Rejected`
 
 ## AI Automation Rules [MANDATORY]
-- Evaluate ADR conditions independently from file count
+- Apply the Choice filter before the Durability filter and independently from Structural Scale
 - Check existing ADRs that govern the changed responsibility
-- Create an ADR only when the durable-decision conditions above apply
+- Create one ADR per decision point that passes both filters, then review the complete batch together
 
 ## Diagram Requirements
 

--- a/.agents/skills/documentation-criteria/references/adr-template.md
+++ b/.agents/skills/documentation-criteria/references/adr-template.md
@@ -8,6 +8,12 @@
 
 [Describe the background and reasons why this decision is needed. Include the essence of the problem, current challenges, and constraints]
 
+## Decision Point
+
+- **Question**: [The technical choice requiring comparison and selection]
+- **Why a decision exists**: [Evidence for at least two credible materially distinct options]
+- **Scope boundary**: [Approved requirement or existing contract this decision serves]
+
 ## Decision
 
 [Describe the actual decision made. Aim for specific and clear descriptions]
@@ -18,9 +24,8 @@
 |------|---------|
 | **Decision** | [The decision in one sentence] |
 | **Why this** | [Why this option over alternatives (1-3 lines)] |
-| **Why now** | [Timing rationale when timing changes the decision; otherwise N/A] |
 | **Known unknowns** | [Uncertainty that changes implementation or verification; otherwise N/A] |
-| **Kill criteria** | [Observable reversal signal when reversal is a credible current path; otherwise N/A] |
+| **Reconsider when** | [Observable condition that changes the option comparison; otherwise N/A] |
 
 ## Rationale
 
@@ -28,17 +33,14 @@
 
 ### Options Considered
 
-Include every credible materially distinct option supported by requirements, repository evidence, or the current approach. When only one option remains credible, record the evidence that rules out another material alternative instead of inventing options.
+Compare every credible materially distinct option supported by current requirements and repository evidence. Relative, evidence-backed cost is sufficient for the selection.
 
-1. **Option 1**: [Description]
-   - Pros: [List advantages]
-   - Cons: [List disadvantages]
+| Option | Requirement and repository fit | Current-scope benefit | Lifecycle cost | Maintainability | Material trade-offs |
+|---|---|---|---|---|---|
+| [Option 1] | [fit and evidence] | [benefit required now] | [implementation, operation, change, reversal] | [fit with ownership and representative patterns] | [trade-offs] |
+| [Option 2] | [fit and evidence] | [benefit required now] | [implementation, operation, change, reversal] | [fit with ownership and representative patterns] | [trade-offs] |
 
-2. **Option 2 (when credible)**: [Description]
-   - Pros: [List advantages]
-   - Cons: [List disadvantages]
-
-**Selected**: [Option and why its trade-offs best preserve the approved outcome]
+**Selected**: [The smallest sufficient option whose maintainability and lifecycle cost are justified by its current-scope benefit]
 
 ## Consequences
 
@@ -61,7 +63,6 @@ Include every credible materially distinct option supported by requirements, rep
 ## Implementation Guidance
 
 [Principled direction only. Implementation procedures go to Design Doc]
-Example: "Use dependency injection" (good), "Implement in Phase 1" (bad)
 
 ## Related Information
 

--- a/.agents/skills/recipe-design/SKILL.md
+++ b/.agents/skills/recipe-design/SKILL.md
@@ -16,14 +16,14 @@ description: "Execute from codebase-scoped analysis to design document creation.
 
 ## Orchestrator Definition
 
-**Core Identity**: Coordinate design, perform lightweight workflow operations directly, and invoke specialists for design judgment and review.
+**Core Identity**: Coordinate design, make workflow decisions from compact specialist materials, and invoke specialists for analysis, authoring, and review.
 
 **Execution Plan**: Reuse the active execution plan. When the workflow has multiple dependent actions and no plan exists, create one that tracks them through final verification.
 
 **Execution Protocol**:
-1. **Spawn agents for analysis and document work** -- your role is to invoke sub-agents, pass data between them, and report results. The Step 1 scope bootstrap is an orchestrator-local pass limited to locating seed files.
+1. **Spawn agents for analysis and document work** -- your role is to invoke sub-agents, select from their compact evidence against governing requirements, pass the selected material onward, and report results.
 2. **Run the design flow below in order**:
-   - Execute: scope bootstrap -> codebase-analyzer -> [Stop: Scope confirmation] -> optional PRD update/review/[Stop: PRD approval] -> optional ADR/review/[Stop: ADR approval] -> Design Doc -> code-verifier -> document-reviewer -> design-sync -> [Stop: Design approval]
+   - Execute: scope evidence -> codebase-analyzer -> [Stop: Scope confirmation] -> optional PRD update/review/[Stop: PRD approval] -> optional ADR batch/batch review/[Stop: ADR-batch approval] -> Design Doc -> code-verifier/Review Resolution -> document-reviewer -> design-sync -> [Stop: Design approval]
    - **[STOP — BLOCKING]** At every `[Stop: ...]` marker -> Present status to user for confirmation. **CANNOT proceed until user explicitly confirms.**
 3. **Scope**: Complete when design documents receive approval
 
@@ -33,13 +33,13 @@ ENFORCEMENT: Skipping any quality gate invalidates the design output.
 ## Workflow Overview
 
 ```
-Requirements -> scope bootstrap -> codebase-analyzer -> [Stop: Scope confirmation]
+Requirements -> scope evidence -> codebase-analyzer -> [Stop: Scope confirmation]
                                                             |
                                       optional PRD update/review -> [Stop: PRD approval]
                                                             |
-                                             optional ADR/review -> [Stop: ADR approval]
+                                   optional ADR batch/review -> [Stop: ADR-batch approval]
                                                             |
-                                      Design Doc -> code-verifier -> document-reviewer
+                         Design Doc -> code-verifier -> Review Resolution -> document-reviewer
                                                             |
                                                     design-sync -> [Stop: Design approval]
 ```
@@ -47,10 +47,10 @@ Requirements -> scope bootstrap -> codebase-analyzer -> [Stop: Scope confirmatio
 ## Scope Boundaries
 
 **Included in this skill**:
-- Scope bootstrap: locating seed files so codebase-analyzer receives a populated input
+- Compact scope and cost evidence from requirement-analyzer; the orchestrator owns requirement, scale, and ADR decisions
 - Codebase analysis with codebase-analyzer (entry point of the design phase)
 - Scope confirmation with the user, grounded in codebase-analyzer findings
-- ADR creation when documentation-criteria identifies a durable technical decision
+- One ADR per qualifying decision point found in the current scope, created and reviewed as one batch
 - Design Doc creation with technical-designer
 - Document review with document-reviewer
 - Design Doc consistency verification with design-sync
@@ -65,45 +65,25 @@ Execute the process below within design scope.
 
 ## Execution Process
 
-### Step 1: Scope Bootstrap
-Build a lightweight seed for codebase-analyzer. This is a file-location pass only, with no deep reading and no design decisions.
+### Step 1: Scope and Cost Evidence
 
-1. Extract candidate keywords from the user requirements: feature names, domain nouns, identifiers, route names, API names, or file-like terms.
-2. Search each keyword separately with `rg -l --glob '!**/{node_modules,dist,build,coverage,.git}/**' --glob '!**/*.{lock,min.js,map}' '<keyword>'`. If `rg` is unavailable, use `grep -RIl` with the same exclusions where possible.
-3. Bucket matches as `source`, `test`, `docs`, and `generated_or_vendor`. Exclude `generated_or_vendor` from the seed.
-4. Rank matches in this order: path or filename match, exported symbol or route/API match, source content match, tests for selected source files, docs for selected source files.
-5. Collect the final seed as `affectedFiles`, and keep a one-line `seedRationale` for each file.
-6. If the search returns no source files, expand once to likely responsibility boundaries and representative siblings. An empty direct-match set is valid for a new surface; pass the relevant boundary evidence to codebase-analyzer. Ask the user only when the requested design target still cannot be identified from the request and repository.
-7. For a broad match set, pass the highest-signal files and their containing responsibility boundaries. File count does not create a user stop.
-
-Construct `requirement_analysis` with:
-- `affectedFiles`: the Step 1 seed
-- `affectedLayers`: layers inferred from paths, or `["unknown"]` when unclear
-- `scale`: provisional Structural Scale from the apparent outcomes, responsibility boundaries, and durable design decisions; affected paths are supporting evidence
-- `purpose`: the user requirements
-- `confidence`: `confirmed` when target files are explicit or the ranked seed is focused; otherwise `provisional`
-- `adrRequired`: apply the documentation-criteria durable-decision conditions; local changes that follow an accepted design remain in the Design Doc
-- `adrReason`: the specific matched ADR condition, or `null`
-- `prdRequired`: `true` when scale is `large` and no existing PRD covers the scope; otherwise `false`
-- `scopeDependencies`: questions whose answers can change the target files, scale, or document type
-- `questions`: user-facing questions needed before design
-- `documentTypeRationale`: whether the Design Doc requires a preceding ADR and the governing ADR condition
-- `seedRationale`: one-line reason for each file in `affectedFiles`
-- `technicalConsiderations`: include any obvious user-stated constraints, risks, and dependencies; use empty lists only when none are stated
+Spawn requirement-analyzer with the original requirements. Treat its request signals, scope evidence, cost evidence, and questions as material; the orchestrator determines requirements, scale, and ADR routing.
 
 ### Step 2: Codebase Analysis
-Spawn codebase-analyzer agent: "Analyze the existing codebase to provide evidence for Design Doc creation. requirement_analysis: [Step 1 requirement_analysis]. requirements: $ARGUMENTS. target_paths: [Step 1 affectedFiles]."
+Spawn codebase-analyzer agent: "Analyze the existing codebase to provide compact decision materials for requirement confirmation, ADR selection, minimal Design Doc creation, and verification. requirement_analysis: [Step 1 scopeEvidence]. requirements: $ARGUMENTS. target_paths: [Step 1 scopeEvidence.affectedFiles]."
 
 ### Step 3: Scope Confirmation
-After codebase-analyzer returns, confirm the requirements and determine whether an ADR precedes the Design Doc:
+After codebase-analyzer returns, confirm the requirements, determine Structural Scale, and identify qualifying ADR decision points:
 1. Locate a related PRD and read its Converged Outcome, MVP scope, Future / Out of Scope, and open requirement fields. If the related PRD is ambiguous, ask the user to select or provide its path, or confirm none exists, before continuing.
 2. When those fields match the current request and returned scope facts, use the PRD path as the current carrier and proceed directly to scope confirmation.
-3. When no current carrier exists, load `requirement-convergence`, build and judge its record from the request and scope facts, estimate rough cost, and run the hearing on fields below `ready`. Mark an existing but incomplete or scope-mismatched PRD for update; otherwise mark the carrier as absent.
+3. When a current carrier is absent, load `requirement-convergence`. The orchestrator builds and judges its record from the user's wording, using Step 1 scope/cost evidence and Step 2 analysis for trade-offs, questions, and routing decisions. Mark an existing but incomplete or scope-mismatched PRD for update; otherwise mark the carrier as absent.
+4. Apply the documentation-criteria Choice filter, then the Durability filter, to Step 2 `decisionMaterials.candidateDecisionPoints`. `adrDecisionPoints` contains every current-scope point that passes both filters; an empty array routes directly to Design Doc regardless of scale.
+5. Determine Structural Scale and set `prdRequired` when the scale is Large and the current PRD carrier is absent.
 
 Present the design scope to the user:
 - Target files/modules: `analysisScope.filesAnalyzed` and directly relevant modules
-- Affected layers: inferred from `analysisScope.categoriesDetected`, `focusAreas`, and paths
-- Recommended document path: Design Doc alone or ADR followed by Design Doc, with `documentTypeRationale`, `adrRequired`, and `adrReason`
+- Affected layers: `analysisScope.affectedLayers`
+- Recommended document path: Design Doc alone or an ADR batch followed by Design Doc, with every qualifying `adrDecisionPoint` and its filter evidence
 - PRD status: whether `prdRequired` is true and whether the convergence carrier is current, requires update, or is absent
 - Unknowns/assumptions: `limitations` and unresolved risks
 - Questions before design: scope questions that change the design target or scale, including technical wording whose mandatory/candidate status is outcome-relevant and ambiguous
@@ -117,9 +97,9 @@ Ask the user to choose one:
 
 If `prdRequired` is true and the user neither provides a PRD path nor explicitly approves proceeding without a PRD, stop. This recipe does not create PRDs.
 
-After confirmation, set the final scale from documentation-criteria Structural Scale and recompute `adrRequired`, `adrReason`, `prdRequired`, `confidence`, and `documentTypeRationale`. A current PRD carrier is passed by path. Carry the compact `convergence` object only when a Design Doc has no current PRD carrier.
-
 **[STOP — BLOCKING]** Wait for user confirmation before proceeding.
+
+After confirmation, record the final scale, derive `adrRequired` from `adrDecisionPoints.length > 0`, and record `documentTypeRationale` from the actual ADR decision points. When the user's answer changes the scope or PRD carrier, recompute the affected values before proceeding. Use the current PRD path as carrier when available; otherwise use the compact `convergence` object.
 
 ### Step 4: Upstream Approval and Design Document Creation
 When Step 3 marked an existing PRD for update, spawn prd-creator in update mode with that PRD path and the confirmed `convergence` object. Review the updated PRD with document-reviewer using its path as `target`, then resolve findings through Review Resolution. After the review permits approval, present the updated PRD for user approval. Continue with its path as the carrier after approval.
@@ -127,16 +107,19 @@ When Step 3 marked an existing PRD for update, spawn prd-creator in update mode 
 **[STOP — BLOCKING when a PRD was updated]** Wait for user approval of the updated PRD.
 
 Create documents according to `documentTypeRationale`:
-- Design Doc only: Spawn technical-designer agent: "document_to_create: DesignDoc. Create Design Doc based on the requirements. requirements_verbatim: [original user requirements]. confirmed_requirement_context: [complete confirmed requirement context from Step 3, including the current PRD carrier path or convergence when no carrier exists, confirmed scope, user answers, confirmed scale, adrRequired, adrReason, prdRequired, explicit no-PRD approval when applicable, documentTypeRationale, scopeDependencies, questions, and seedRationale]. Codebase analysis: [output from Step 2]. Follow `document_to_create` for this invocation; `documentTypeRationale` describes the overall confirmed path. Include component design, acceptance criteria, Direct MVP, failed current constraints or Material Risks, necessary additions, and subtraction evidence."
-- Both ADR and Design Doc: first spawn technical-designer with `document_to_create: ADR`. Review the created ADR with document-reviewer using `doc_type: ADR`, `target: [ADR path]`, and the Step 2 codebase analysis, then resolve findings through Review Resolution. After the review permits approval, present the ADR for user approval and record its status as `Accepted`. Only then spawn technical-designer with `document_to_create: DesignDoc`, `adr_path: [accepted ADR path]`, the original user requirements as `requirements_verbatim`, the same `confirmed_requirement_context`, and the same codebase analysis output. The Design Doc must reference the accepted ADR decision.
+- When `adrDecisionPoints` is non-empty, spawn technical-designer once with `document_to_create: ADRBatch`, `decision_points: [adrDecisionPoints]`, confirmed requirements, and `decision_materials: [only the Step 2 reuse, invalidation, option/cost, contract, and decision-changing unknown material relevant to those points]`. Review all returned `paths[]` in one document-reviewer invocation using `doc_type: ADRBatch` and `targets: [all paths]`. Apply Review Resolution to the batch, rerun the batch review when an accepted correction changes a file, then present one ADR-batch approval request.
 
-**[STOP — BLOCKING when an ADR was created]** Wait for user approval of the ADR before creating the Design Doc.
+**[STOP — BLOCKING when ADRs were created]** Wait for one user approval of the reviewed ADR batch before creating the Design Doc.
+
+Record every approved ADR file as `Accepted` when ADRs were created. Spawn technical-designer with `document_to_create: DesignDoc`, `adr_paths: [accepted ADR paths or []]`, the confirmed requirement carrier, and `decision_materials: [only Step 2 material that changes reuse, implementation validity, a selected ADR decision, a preserved contract, or verification]`. The confirmed requirements define scope, and selected ADR decisions constrain their relevant technical questions.
 
 ### Step 5: Code Verification
 Spawn code-verifier agent: "Verify the Design Doc against the current codebase. document_path: [Design Doc path from Step 4]. doc_type: design-doc."
 
+Apply Review Resolution to every discrepancy before document review. Pass `apply` corrections only to technical-designer in update mode, then rerun code-verifier. When the `apply` set is empty, carry the resolved verification summary, declines with reasons, and material limitations to Step 6.
+
 ### Step 6: Document Review
-Spawn document-reviewer agent: "Review the Design Doc for consistency, completeness, and adopted design validity. doc_type: DesignDoc. review_context: creation. target: [Design Doc path]. requirements_verbatim: [original user requirements]. confirmed_requirement_context: [complete confirmed requirement context from Step 3]. codebase_analysis: [output from Step 2]. code_verification: [output from Step 5]."
+Spawn document-reviewer agent: "Review the Design Doc for consistency, completeness, and adopted design validity. doc_type: DesignDoc. review_context: creation. target: [Design Doc path]. requirements_verbatim: [original user requirements]. confirmed_requirement_context: [complete confirmed requirement context from Step 3]. decision_materials: [only Step 2 material that constrains this design]. verification_resolution: [resolved Step 5 evidence]."
 
 Route the result before consistency verification:
 - `approved`: continue
@@ -150,12 +133,12 @@ Spawn design-sync agent: "Verify consistency of the design document with other e
 
 ## Completion Criteria
 
-- [ ] Built the Step 1 scope bootstrap seed or obtained target files/modules from the user
-- [ ] Spawned codebase-analyzer with populated requirement context and passed its findings into design creation
+- [ ] Obtained compact scope and cost evidence while retaining requirement, scale, and ADR decisions in the orchestrator
+- [ ] Spawned codebase-analyzer and passed only decision-relevant material into ADR/Design Doc creation
 - [ ] Converged the requirement and persisted the record
 - [ ] Confirmed the design scope with the user before document creation
-- [ ] Created all documents required by `documentTypeRationale` via technical-designer
-- [ ] Spawned code-verifier and passed its findings into document review for Design Docs
+- [ ] Created one ADR per qualifying decision point and reviewed the complete batch once, or routed an empty decision-point set directly to Design Doc
+- [ ] Applied Review Resolution to code-verifier discrepancies before document review
 - [ ] Spawned document-reviewer and addressed feedback
 - [ ] Spawned design-sync for consistency verification for Design Docs
 - [ ] Obtained user approval for design document

--- a/.agents/skills/recipe-front-design/SKILL.md
+++ b/.agents/skills/recipe-front-design/SKILL.md
@@ -18,12 +18,12 @@ Load `external-resource-context` in Step 4 only when a named external source is 
 
 ## Orchestrator Definition
 
-**Core Identity**: Coordinate frontend design, perform lightweight workflow operations directly, and invoke specialists for design judgment and review.
+**Core Identity**: Coordinate frontend design, make workflow decisions from compact specialist materials, and invoke specialists for analysis, authoring, and review.
 
 **Execution Plan**: Reuse the active execution plan. When the workflow has multiple dependent actions and no plan exists, create one that tracks them through final verification.
 
 **Execution Method**:
-- Scope bootstrap -> performed by the orchestrator as a file-location pass
+- Scope and cost evidence -> performed by requirement-analyzer
 - Codebase analysis -> performed by codebase-analyzer
 - Scope confirmation -> performed by the orchestrator with user confirmation
 - UI fact gathering -> performed by ui-analyzer
@@ -37,13 +37,13 @@ Orchestrator spawns agents and passes structured data between them.
 ## Scope Boundaries
 
 **Included in this skill**:
-- Scope bootstrap: locating seed files so codebase-analyzer receives a populated input
+- Compact scope and cost evidence from requirement-analyzer; the orchestrator owns requirement, scale, UI scope, and ADR decisions
 - Codebase analysis with codebase-analyzer (entry point of the frontend design phase)
 - Scope confirmation with the user, grounded in codebase-analyzer findings
 - Focused external resource hearing when a current design decision requires it
 - UI fact gathering with ui-analyzer
 - UI Specification creation with ui-spec-designer (prototype code inquiry included)
-- ADR creation when documentation-criteria identifies a durable technical decision
+- One ADR per qualifying decision point found in the current scope, created and reviewed as one batch
 - Design Doc creation with technical-designer-frontend
 - Document review with document-reviewer
 
@@ -53,45 +53,25 @@ Requirements: $ARGUMENTS
 
 ## Execution Flow
 
-### Step 1: Scope Bootstrap
-Build a lightweight seed for codebase-analyzer. This is a file-location pass only, with no deep reading and no design decisions.
+### Step 1: Scope and Cost Evidence
 
-1. Extract candidate keywords from the user requirements: feature names, domain nouns, component names, route names, identifiers, or file-like terms.
-2. Search each keyword separately with `rg -l --glob '!**/{node_modules,dist,build,coverage,.git}/**' --glob '!**/*.{lock,min.js,map}' '<keyword>'`. If `rg` is unavailable, use `grep -RIl` with the same exclusions where possible.
-3. Bucket matches as `source`, `test`, `docs`, and `generated_or_vendor`. Exclude `generated_or_vendor` from the seed.
-4. Rank matches in this order: path or filename match, component/route/hook/API symbol match, source content match, tests for selected source files, docs for selected source files.
-5. Collect matched frontend and shared file paths as `affectedFiles`, and keep a one-line `seedRationale` for each file.
-6. If the search returns no frontend or shared source files, expand once to likely route, component, and shared-state boundaries plus representative siblings. An empty direct-match set is valid for a new surface; pass the relevant boundary evidence to codebase-analyzer. Ask the user only when the requested UI target still cannot be identified from the request and repository.
-7. For a broad match set, pass the highest-signal files and their containing responsibility boundaries. File count does not create a user stop.
-
-Construct `requirement_analysis` with:
-- `affectedFiles`: the Step 1 seed
-- `affectedLayers`: `["frontend"]` plus `shared` when shared files are included
-- `scale`: provisional Structural Scale from the apparent outcomes, responsibility boundaries, and durable design decisions; affected paths are supporting evidence
-- `purpose`: the user requirements
-- `confidence`: `confirmed` when target files are explicit or the ranked seed is focused; otherwise `provisional`
-- `adrRequired`: apply the documentation-criteria durable-decision conditions; local component, state, routing, or data-flow changes that follow an accepted design remain in the Design Doc
-- `adrReason`: the specific matched ADR condition, or `null`
-- `prdRequired`: `true` when scale is `large` and no existing PRD covers the scope; otherwise `false`
-- `scopeDependencies`: questions whose answers can change the target files, scale, UI surface, or document type
-- `questions`: user-facing questions needed before design
-- `documentTypeRationale`: whether the Design Doc requires a preceding ADR and the governing ADR condition
-- `seedRationale`: one-line reason for each file in `affectedFiles`
-- `technicalConsiderations`: include any obvious user-stated constraints, risks, and dependencies; use empty lists only when none are stated
+Spawn requirement-analyzer with the original requirements. Treat its request signals, scope evidence, cost evidence, and questions as material; the orchestrator determines requirements, scale, UI scope, and ADR routing.
 
 ### Step 2: Codebase Analysis
-Spawn codebase-analyzer agent: "Analyze the existing codebase to provide evidence for frontend Design Doc creation. Focus on existing implementations, state paths, API integrations, and constraints the design should respect. requirement_analysis: [Step 1 requirement_analysis]. requirements: [original user requirements]. layer: frontend. target_paths: [Step 1 affectedFiles]. focus_areas: component hierarchy, state management, UI interactions, data fetching."
+Spawn codebase-analyzer agent: "Analyze the existing codebase to provide compact decision materials for frontend requirement confirmation, ADR selection, minimal Design Doc creation, and verification. requirement_analysis: [Step 1 scopeEvidence]. requirements: [original user requirements]. layer: frontend. target_paths: [Step 1 scopeEvidence.affectedFiles]. focus_areas: component hierarchy, state management, UI interactions, data fetching."
 
 ### Step 3: Scope Confirmation
-After codebase-analyzer returns, determine whether the Design Doc also requires an ADR:
+After codebase-analyzer returns, confirm requirements, determine Structural Scale, and collect candidate ADR decision points:
 1. Locate a related PRD and read its Converged Outcome, MVP scope, Future / Out of Scope, and open requirement fields. If the related PRD is ambiguous, ask the user to select or provide its path, or confirm none exists, before continuing.
 2. When those fields match the current request and returned scope facts, use the PRD path as the current carrier and proceed directly to scope confirmation.
-3. When no current carrier exists, load `requirement-convergence`, build and judge its record from the request and scope facts, estimate rough cost, and run the hearing on fields below `ready`. Mark an existing but incomplete or scope-mismatched PRD for update; otherwise mark the carrier as absent.
+3. When a current carrier is absent, load `requirement-convergence`. The orchestrator builds and judges its record from the user's wording, using Step 1 scope/cost evidence and Step 2 analysis for trade-offs, questions, and routing decisions. Mark an existing but incomplete or scope-mismatched PRD for update; otherwise mark the carrier as absent.
+4. Retain Step 2 `decisionMaterials.candidateDecisionPoints` within confirmed scope. Final ADR qualification occurs after UI analysis and UI Spec evidence are available.
+5. Determine Structural Scale and set `prdRequired` when the scale is Large and the current PRD carrier is absent.
 
 Present the frontend design scope to the user:
 - Target files/modules: `analysisScope.filesAnalyzed` and directly relevant components, routes, or modules
-- Affected layers: inferred from `analysisScope.categoriesDetected`, `focusAreas`, and paths
-- Recommended document path: Design Doc alone or ADR followed by Design Doc, with `documentTypeRationale`, `adrRequired`, and `adrReason`
+- Affected layers: `analysisScope.affectedLayers`
+- Recommended document path: UI Spec and Design Doc, plus a conditional ADR batch for listed candidate decision points that later pass both ADR filters
 - PRD status: whether `prdRequired` is true and whether the convergence carrier is current, requires update, or is absent
 - Unknowns/assumptions: `limitations` and unresolved risks
 - Questions before design: scope questions that change the UI surface, design target, or scale, including technical wording whose mandatory/candidate status is outcome-relevant and ambiguous
@@ -105,11 +85,9 @@ Ask the user to choose one:
 
 If `prdRequired` is true and the user neither provides a PRD path nor explicitly approves proceeding without a PRD, stop. This recipe does not create PRDs.
 
-After confirmation, set the final scale from documentation-criteria Structural Scale and recompute `adrRequired`, `adrReason`, `prdRequired`, `confidence`, and `documentTypeRationale`. A current PRD carrier is passed by path. Carry the compact `convergence` object only when a Design Doc has no current PRD carrier.
-
-Run Steps 1 through 8. When an ADR is required, create it before the Design Doc in Step 8.
-
 **[STOP -- BLOCKING]** Wait for user confirmation before proceeding.
+
+After confirmation, record the final scale and carry the candidate decision points forward for final filtering after UI analysis. When the user's answer changes the scope or PRD carrier, recompute the affected values before proceeding. The Choice and Durability filters supply ADR decision points independently of scale. Use the current PRD path as carrier when available; otherwise use the compact `convergence` object.
 
 After confirmation, when Step 3 marked an existing PRD for update, spawn prd-creator in update mode with that PRD path and the confirmed `convergence` object. Review the updated PRD with document-reviewer using its path as `target`, then resolve findings through Review Resolution. After the review permits approval, present the updated PRD for user approval. Continue with its path as the carrier after approval.
 
@@ -124,7 +102,7 @@ Use prototype code when the user supplied it or the confirmed UI target referenc
 ### Step 6: UI Fact Gathering Phase
 Use the prototype path as an input when one was provided; otherwise set `prototype_path` to unavailable.
 
-Spawn ui-analyzer agent: "Gather UI facts for frontend design. requirement_analysis: [confirmed requirement context]. requirements: [original user requirements]. target_paths: [confirmed frontend affected files and directories]. target_components: [frontend target components when known]. ui_spec_path: [path if an existing UI Spec covers this feature]. prototype_path: [path if provided]. externalResourceRefs: [{label, featureIdentifier} selected in Step 4, or []]. Analyze component structure, props patterns, CSS layout, sourced state displays, accessibility, generated artifacts, and candidate write set."
+Spawn ui-analyzer agent: "Gather UI facts for frontend design. requirement_analysis: { affectedFiles: [confirmed frontend affected files] }. requirements: [original user requirements]. target_paths: [confirmed frontend affected files and directories]. target_components: [frontend target components when known]. ui_spec_path: [path if an existing UI Spec covers this feature]. prototype_path: [path if provided]. externalResourceRefs: [{label, featureIdentifier} selected in Step 4, or []]. Analyze component structure, props patterns, CSS layout, sourced state displays, accessibility, generated artifacts, and candidate write set."
 
 ### Step 7: UI Specification Phase
 After UI fact gathering completes, create the UI Specification:
@@ -136,15 +114,16 @@ After UI fact gathering completes, create the UI Specification:
 **CANNOT proceed until user explicitly approves the UI Spec.**
 
 ### Step 8: Design Document Creation Phase
-Create appropriate design documents according to confirmed scope and scale:
-- When ADR is required: Spawn technical-designer-frontend agent: "document_to_create: ADR. Create ADR for [technical decision]. Requirements: [original user requirements]. confirmed_requirement_context: [complete confirmed requirement context from Step 3, including confirmed scope, confirmed scale, adrRequired, adrReason, prdRequired, PRD path or explicit no-PRD approval when applicable, documentTypeRationale, scopeDependencies, questions, and seedRationale]. Follow `document_to_create` for this invocation; `documentTypeRationale` describes the overall confirmed path. Codebase Analysis: [JSON from codebase-analyzer]. UI Analysis: [JSON from ui-analyzer]. Present credible alternatives with trade-offs." Review the created ADR with document-reviewer using `doc_type: ADR`, `target: [ADR path]`, `mode: composite`, and the codebase and UI analysis outputs. Resolve findings through Review Resolution, then present it for user approval and record its status as `Accepted`.
+Create appropriate design documents from confirmed scope and decision materials:
+- Start with codebase analysis `candidateDecisionPoints`, then add a technical choice from UI analysis or the approved UI Spec when its evidence establishes at least two credible materially distinct options. Apply the Choice filter, then the Durability filter, to the complete candidate set.
+- When the retained array is non-empty, spawn technical-designer-frontend once with `document_to_create: ADRBatch`, `decision_points: [retained array]`, confirmed requirements, and `decision_materials: [only analysis material that changes the options, lifecycle cost, maintainability, or validity of those points]`. Review all returned `paths[]` in one document-reviewer invocation using `doc_type: ADRBatch` and `targets: [all paths]`. Apply Review Resolution to the batch, rerun the batch review when an accepted correction changes a file, then present one ADR-batch approval request.
 
-  **[STOP -- BLOCKING when an ADR was created]** Wait for user approval of the ADR before creating the Design Doc.
+  **[STOP -- BLOCKING when ADRs were created]** Wait for one user approval of the reviewed ADR batch before creating the Design Doc.
 
-- For Design Doc: Spawn technical-designer-frontend agent: "document_to_create: DesignDoc. Create Design Doc based on requirements. requirements_verbatim: [original user requirements]. confirmed_requirement_context: [complete confirmed requirement context from Step 3, including the current PRD carrier path or convergence when no carrier exists, confirmed scope, user answers, confirmed scale, adrRequired, adrReason, prdRequired, explicit no-PRD approval when applicable, documentTypeRationale, scopeDependencies, questions, and seedRationale]. Follow `document_to_create` for this invocation; `documentTypeRationale` describes the overall confirmed path. Codebase Analysis: [JSON from codebase-analyzer]. UI Analysis: [JSON from ui-analyzer]. UI Spec is at [ui-spec path]. Inherit component structure and state design from UI Spec. External resource refs: [ui_analysis.externalResources.selectedRefs]. Record Direct MVP, failed current constraints or Material Risks, necessary additions, and subtraction evidence. Record only larger alternatives actually considered; `None` is valid."
-  - When an ADR is required, create the Design Doc with `document_to_create: DesignDoc` and `adr_path: [accepted ADR path]`; the Design Doc must reference the accepted ADR decision.
+- Record every approved ADR file as `Accepted` when ADRs were created. For Design Doc, spawn technical-designer-frontend with `document_to_create: DesignDoc`, `adr_paths: [accepted ADR paths or []]`, confirmed requirements, approved UI Spec, and `decision_materials: [only analysis material that changes reuse, implementation validity, a selected ADR decision, a preserved contract, or verification]`. The confirmed requirements define scope, and selected ADR decisions constrain their relevant technical questions.
 - Spawn code-verifier agent: "Verify Design Doc against code. doc_type: design-doc. document_path: [document path]. verbose: false."
-- Review the Design Doc: Spawn document-reviewer agent: "Review the Design Doc for consistency, completeness, and adopted design validity. doc_type: DesignDoc. review_context: creation. target: [Design Doc path]. mode: composite. requirements_verbatim: [original user requirements]. confirmed_requirement_context: [complete confirmed requirement context from Step 3]. codebase_analysis: [JSON from codebase-analyzer]. ui_analysis: [JSON from ui-analyzer]. code_verification: [JSON from code-verifier]."
+- Apply Review Resolution to every code-verifier discrepancy. Pass `apply` corrections only to technical-designer-frontend in update mode, rerun code-verifier, and carry the resolved verification summary, declines with reasons, and material limitations after the `apply` set becomes empty.
+- Review the Design Doc: Spawn document-reviewer agent: "Review the Design Doc for consistency, completeness, and adopted design validity. doc_type: DesignDoc. review_context: creation. target: [Design Doc path]. requirements_verbatim: [original user requirements]. confirmed_requirement_context: [complete confirmed requirement context from Step 3]. decision_materials: [only analysis material that constrains this design]. verification_resolution: [resolved code-verifier evidence]."
 - Resolve `approved_with_conditions` or `needs_revision` through Review Resolution with technical-designer-frontend, then review the updated Design Doc. Route governing-source contradictions through Orchestrator Escalation Resolution. Reach the user approval stop after review succeeds.
 
 **[STOP -- BLOCKING]** Present the Design Doc and its recorded trade-offs, then obtain user approval.
@@ -154,19 +133,19 @@ ENFORCEMENT: Every stop point MUST be respected. Skipping user approval invalida
 
 ## Completion Criteria
 
-- [ ] Built the Step 1 scope bootstrap seed or obtained target files/modules from the user
+- [ ] Obtained compact scope and cost evidence while retaining requirement, scale, UI scope, and ADR decisions in the orchestrator
 - [ ] Codebase analysis completed before UI and design work
 - [ ] Converged the requirement and carried exclusions into UI/design creation
 - [ ] Confirmed the frontend design scope with the user before UI and design work
 - [ ] External resource hearing completed when applicable
 - [ ] UI analysis completed before Design Doc creation when applicable
 - [ ] UI Specification created and approved
-- [ ] All documents required by `documentTypeRationale` created and approved
+- [ ] One ADR was created per qualifying decision point and the complete batch was reviewed once, or the empty set routed directly to Design Doc
 - [ ] All document reviews passed
 
 ## Output Example
 Frontend design phase completed.
 - UI Specification: docs/ui-spec/[feature-name]-ui-spec.md
-- ADR: docs/adr/[document-name].md or N/A
+- ADRs: docs/adr/[document-name].md paths or N/A
 - Design document: docs/design/[document-name].md or N/A
 - Approval status: User approved

--- a/.agents/skills/recipe-front-plan/SKILL.md
+++ b/.agents/skills/recipe-front-plan/SKILL.md
@@ -58,7 +58,7 @@ Spawn work-planner agent: "Create an implementation-focused work plan from Desig
 Verify the returned Work Plan path and use it as the Step 4 review target.
 
 ### Step 4: Work Plan Review
-Spawn document-reviewer agent: "Review the frontend work plan. doc_type: WorkPlan. target: [work-planner completed path]. mode: composite. Verify Design Doc and UI Spec implementation coverage, absence of added operational scope, dependency order, executable verification, optional Verification Focus, and Review Scope."
+Spawn document-reviewer agent: "Review the frontend work plan. doc_type: WorkPlan. target: [work-planner completed path]. Verify Design Doc and UI Spec implementation coverage, absence of added operational scope, dependency order, executable verification, optional Verification Focus, and Review Scope."
 
 Branch on `verdict.decision`:
 - `approved` -> proceed to Step 5 with the plan-level status pending

--- a/.agents/skills/recipe-fullstack-implement/SKILL.md
+++ b/.agents/skills/recipe-fullstack-implement/SKILL.md
@@ -16,7 +16,7 @@ Requirements or continuation instruction: $ARGUMENTS
 
 ## Entry
 
-- New or scope-changing requirements: invoke requirement-analyzer, complete Requirement Convergence, and obtain requirement confirmation.
+- New or scope-changing requirements: invoke requirement-analyzer for compact scope/cost evidence; the orchestrator completes Requirement Convergence, determines scale and layer routing, and obtains requirement confirmation.
 - Existing PRD, UI Spec, Design Docs, Work Plan, or tasks: resume at the next incomplete Fullstack Flow phase. Restart requirement analysis when the approved outcome, requirement, or exclusion changes.
 - Quality failure during an existing implementation: resume its task cycle and Orchestrator Escalation Resolution.
 

--- a/.agents/skills/recipe-implement/SKILL.md
+++ b/.agents/skills/recipe-implement/SKILL.md
@@ -24,9 +24,9 @@ Follow the scale-selected flow and its user approval points from subagents-orche
 
 ## Step 1: Requirement Analysis
 
-Spawn requirement-analyzer agent to determine scale and affected layers.
+Spawn requirement-analyzer for compact request signals, scope evidence, cost evidence, affected-layer evidence, and decision-changing questions.
 
-At the existing requirements stop, apply subagents-orchestration-guide `Requirement Convergence` and resolve any `scopeDependencies` through requirement-analyzer before routing.
+At the requirements stop, the orchestrator applies subagents-orchestration-guide `Requirement Convergence` from the user's wording and supplied evidence, resolves material questions, determines Structural Scale and affected layers, and selects the canonical route.
 
 **[STOP — BLOCKING]** Present the converged requirement record, scale, affectedLayers, and scope to the user for confirmation. **CANNOT proceed until user explicitly confirms.**
 
@@ -59,11 +59,11 @@ Verify acceptance-test-generator artifact paths and pass them to work-planner.
 
 ## Completion Criteria
 
-- [ ] Requirement analysis completed and user-confirmed
+- [ ] Scope/cost evidence was collected and the orchestrator's requirement and scale decisions were user-confirmed
 - [ ] Layer routing determined (backend / frontend / fullstack)
 - [ ] Correct workflow followed per layer routing
 - [ ] codebase-analyzer included before Design Doc creation for Medium/Large flows
-- [ ] code-verifier included before document-reviewer for Design Doc review
+- [ ] code-verifier discrepancies passed through Review Resolution before Design Doc review
 - [ ] All stopping points honored with user confirmation obtained
 - [ ] Quality-fixer spawned before every commit
 - [ ] All tasks committed or user input requested

--- a/.agents/skills/recipe-plan/SKILL.md
+++ b/.agents/skills/recipe-plan/SKILL.md
@@ -55,7 +55,7 @@ Present options if multiple exist (can be specified with $ARGUMENTS).
 - Verify the returned Work Plan path and use it as the Step 4 review target
 
 ### Step 4: Work Plan Review
-Spawn document-reviewer agent: "Review the work plan. doc_type: WorkPlan. target: [work-planner completed path]. mode: composite. Verify Design Doc implementation coverage, absence of added operational scope, dependency order, executable verification, optional Verification Focus, and Review Scope."
+Spawn document-reviewer agent: "Review the work plan. doc_type: WorkPlan. target: [work-planner completed path]. Verify Design Doc implementation coverage, absence of added operational scope, dependency order, executable verification, optional Verification Focus, and Review Scope."
 
 Branch on `verdict.decision`:
 - `approved` -> proceed to Step 5 with the plan-level status pending

--- a/.agents/skills/recipe-reverse-engineer/SKILL.md
+++ b/.agents/skills/recipe-reverse-engineer/SKILL.md
@@ -95,18 +95,13 @@ Spawn prd-creator agent: "Create reverse-engineered PRD for the following featur
 
 Spawn code-verifier agent: "Verify consistency between PRD and code implementation. doc_type: prd. document_path: $STEP_2_OUTPUT. code_paths: $PRD_UNIT_COMBINED_RELATED_FILES. unit_inventory: $PRD_UNIT_INVENTORY. verbose: false."
 
-**Store output as**: `$STEP_3_OUTPUT`
-
-**Quality Gate**:
-- `summary.status` is `consistent` or `mostly_consistent` -> proceed to review
-- `summary.status` is `needs_review` or `inconsistent` -> proceed to review with the returned discrepancies, severity, evidence, and effect
-- `summary.status` is `blocked`, or the result is unusable -> apply Orchestrator Escalation Resolution and retry verification after resolving its evidence or input problem
+Apply Review Resolution to every discrepancy. Pass `apply` corrections to prd-creator in update mode, rerun code-verifier, and store the resolved summary, declines with reasons, and material limitations as `$STEP_3_RESOLUTION` after the `apply` set becomes empty. A blocked or unusable result enters Orchestrator Escalation Resolution.
 
 #### Step 4: Review
 
-**Required Input**: $STEP_3_OUTPUT (verification data from Step 3)
+**Required Input**: $STEP_3_RESOLUTION (resolved verification evidence from Step 3)
 
-Spawn document-reviewer agent: "Review the following PRD considering code verification findings. doc_type: PRD. target: $STEP_2_OUTPUT. mode: composite. code_verification: $STEP_3_OUTPUT. Additional Review Focus: Alignment between PRD claims and verification evidence, resolution recommendations for each discrepancy, completeness of undocumented feature coverage."
+Spawn document-reviewer agent: "Review the following PRD. doc_type: PRD. target: $STEP_2_OUTPUT. verification_resolution: $STEP_3_RESOLUTION. Review alignment between PRD claims, resolved verification evidence, and in-scope inventory coverage."
 
 **Store output as**: `$STEP_4_OUTPUT`
 
@@ -203,18 +198,13 @@ Spawn technical-designer agent: "Create Design Doc for the following feature bas
 
 Spawn code-verifier agent: "Verify consistency between Design Doc and code implementation. doc_type: design-doc. document_path: $STEP_7_OUTPUT. code_paths: $UNIT_SCOPE_BOUNDARY. unit_inventory: $UNIT_INVENTORY. verbose: false."
 
-**Store output as**: `$STEP_8_OUTPUT`
-
-**Quality Gate**:
-- `summary.status` is `consistent` or `mostly_consistent` -> proceed to review
-- `summary.status` is `needs_review` or `inconsistent` -> proceed to review with the returned discrepancies, severity, evidence, and effect
-- `summary.status` is `blocked`, or the result is unusable -> apply Orchestrator Escalation Resolution and retry verification after resolving its evidence or input problem
+Apply Review Resolution to every discrepancy. Pass `apply` corrections to technical-designer in update mode, rerun code-verifier, and store the resolved summary, declines with reasons, and material limitations as `$STEP_8_RESOLUTION` after the `apply` set becomes empty. A blocked or unusable result enters Orchestrator Escalation Resolution.
 
 #### Step 9: Review
 
-**Required Input**: $STEP_8_OUTPUT (verification data from Step 8)
+**Required Input**: $STEP_8_RESOLUTION (resolved verification evidence from Step 8)
 
-Spawn document-reviewer agent: "Review the following Design Doc considering code verification findings. doc_type: DesignDoc. review_context: as-is. target: $STEP_7_OUTPUT. mode: composite. code_verification: $STEP_8_OUTPUT. Parent PRD: $APPROVED_PRD_PATH. Additional Review Focus: Technical accuracy of documented interfaces, consistency with parent PRD scope, completeness of unit boundary definitions."
+Spawn document-reviewer agent: "Review the following Design Doc. doc_type: DesignDoc. review_context: as-is. target: $STEP_7_OUTPUT. verification_resolution: $STEP_8_RESOLUTION. Parent PRD: $APPROVED_PRD_PATH. Review technical accuracy, parent PRD scope, and in-scope unit boundary coverage."
 
 **Store output as**: `$STEP_9_OUTPUT`
 

--- a/.agents/skills/recipe-update-doc/SKILL.md
+++ b/.agents/skills/recipe-update-doc/SKILL.md
@@ -38,7 +38,7 @@ Target document -> Clarify and classify changes
                                                                                  v
                                       technical-designer / technical-designer-frontend / prd-creator (update mode)
                         | (Design Doc only)
-              code-verifier -> document-reviewer
+              code-verifier -> Review Resolution -> document-reviewer
                         | (Design Doc only)
               design-sync -> [Stop: Document approval]
 ```
@@ -102,7 +102,7 @@ Derive the sections, reason, and expected outcome from the user request and targ
 After confirmation, classify the update:
 - ADR: `convergence: N/A`.
 - Scope-preserving PRD or Design Doc update: the outcome, buildable requirements, and exclusions remain unchanged. Preserve the existing convergence record; when none exists, use the eligible update N/A value.
-- Scope-changing PRD or Design Doc update: the outcome, buildable requirements, or exclusions change. Load `requirement-convergence`, spawn requirement-analyzer with the document's current requirements plus the confirmed changes as self-contained input, and run the hearing on fields below `ready`. Continue when all four fields are `ready` or user-approved `weak-but-explicit`.
+- Scope-changing PRD or Design Doc update: the outcome, buildable requirements, or exclusions change. Load `requirement-convergence`, spawn requirement-analyzer for compact scope/cost evidence, then have the orchestrator build the convergence record from the current document and user-confirmed changes. Run the hearing on fields below `ready` and continue when all four fields are `ready` or user-approved `weak-but-explicit`.
 
 Retain the classification for routing and, when scope-changing, the confirmed `convergence` object for Steps 4 and 5.
 
@@ -110,7 +110,7 @@ Retain the classification for routing and, when scope-changing, the confirmed `c
 
 For PRD or Design Doc, spawn [Update Agent from Step 2]: "Operation Mode: update. Existing Document: [path from Step 1]. Changes Required: [Changes clarified in Step 3]. confirmed_requirement_context: [confirmed convergence for scope-changing updates | existing carrier or eligible N/A for scope-preserving updates]. Update the document to reflect the specified changes. Add change history entry."
 
-For ADR, spawn the update agent with the existing path and confirmed changes; Requirement Convergence is outside this update.
+For a minor ADR change, spawn the update agent with `Operation Mode: update`, the existing path, confirmed changes, and `confirmed_requirement_context: N/A — ADR update`. For a major ADR change, leave this update path and use the normal ADR creation and approval flow to create the superseding ADR.
 
 ### Step 5: Document Review
 
@@ -118,12 +118,12 @@ For Design Doc updates, first verify the updated document against code:
 
 Spawn code-verifier agent: "Verify the updated Design Doc against current code. doc_type: design-doc. document_path: [path from Step 1]. verbose: false. Focus especially on literal identifier referential integrity for concrete paths, endpoints, type names, config keys, and other exact identifiers changed in this update."
 
-**Store output as**: `$CODE_VERIFICATION_OUTPUT`
+Apply Review Resolution to every discrepancy. Pass `apply` corrections to the update agent, rerun code-verifier, and store the resolved summary, declines with reasons, and material limitations as `$VERIFICATION_RESOLUTION` after the `apply` set becomes empty.
 
 For Design Doc updates:
-Spawn document-reviewer agent: "Review the following updated document. doc_type: DesignDoc. review_context: update. target: [path from Step 1]. mode: composite. confirmed_requirement_context: [Step 3 convergence or existing carrier/N/A]. code_verification: $CODE_VERIFICATION_OUTPUT. Focus on: Consistency of updated sections with rest of document, no contradictions introduced by changes, completeness of change history."
+Spawn document-reviewer agent: "Review the following updated document. doc_type: DesignDoc. review_context: update. target: [path from Step 1]. confirmed_requirement_context: [Step 3 convergence or existing carrier/N/A]. verification_resolution: $VERIFICATION_RESOLUTION. Focus on consistency of the updated sections, governing requirements, and change history."
 
-For PRD updates, spawn document-reviewer with the target, `mode: composite`, and `confirmed_requirement_context` from Step 3. For ADR updates, pass the target and `mode: composite` without requirement-convergence context. Review consistency, contradictions, and change history.
+For PRD updates, spawn document-reviewer with the target and `confirmed_requirement_context` from Step 3. For minor ADR updates, use `doc_type: ADRBatch`, `targets: [updated ADR path]`, and `review_context: update`; review the requested changes and their dependent consistency while carrying the accepted, unchanged decision content as governing context.
 
 **Store output as**: `$STEP_5_OUTPUT`
 
@@ -157,7 +157,7 @@ For Design Doc, spawn design-sync agent: "Verify consistency of the updated Desi
 - [ ] Resolved change content from the request and target document, asking only when material intent was missing
 - [ ] Classified the update and converged scope-changing PRD/Design Doc requirements
 - [ ] Updated document via appropriate agent (update mode)
-- [ ] Ran code-verifier before document-reviewer for Design Doc updates
+- [ ] Applied Review Resolution to code-verifier discrepancies before document-reviewer for Design Doc updates
 - [ ] Spawned document-reviewer and addressed feedback
 - [ ] Spawned design-sync for consistency verification (Design Doc only)
 - [ ] Obtained user approval for updated document

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -21,11 +21,11 @@ Give each subagent the expected action and the artifact paths or evidence needed
 
 ### Entry Ownership
 
-The invoked recipe determines the workflow entry point. Recipes for new or scope-changing requirements explicitly invoke requirement-analyzer. Continuation, build, review, diagnosis, document update, and reverse-engineering recipes resume from their declared artifacts and invoke requirement-analyzer only when their own scope-change rule fires. This guide supplies coordination behavior after an entry has been selected.
+The invoked recipe determines the workflow entry point. Recipes for new or scope-changing requirements may invoke requirement-analyzer for compact scope and cost evidence. The user and orchestrator retain requirements, Structural Scale, and ADR decisions. Continuation, build, review, diagnosis, document update, and reverse-engineering recipes resume from their declared artifacts and request new scope evidence only when their own scope-change rule fires.
 
 ### Requirement Convergence
 
-`requirement-analyzer` returns a compact `convergence` object. At the requirements stop, run the requirement-convergence hearing with the analyzer's scope facts and cost evidence, then continue under that skill's convergence condition.
+The orchestrator builds the `convergence` object from the user's wording and uses requirement-analyzer's scope and cost evidence for trade-offs, questions, and routing decisions. At the requirements stop, run the requirement-convergence hearing, then determine Structural Scale from the confirmed requirements and supplied evidence. User-confirmed boundaries supply requirements; orchestrator decisions supply routing.
 
 Before a PRD or Design Doc exists, include the object only in the handoff that needs it. After it is persisted, pass the document path instead of copying the object through later prompts.
 
@@ -105,7 +105,7 @@ Autonomous execution MUST stop and wait for user input at these points.
 | Requirements | After an entry recipe invokes requirement-analyzer | Converge fields below `ready`, then confirm requirements |
 | PRD | After document-reviewer completes PRD review | Approve PRD |
 | UI Spec | After document-reviewer completes UI Spec review (frontend/fullstack) | Approve UI Spec |
-| ADR | After document-reviewer completes ADR review (if ADR created) | Approve ADR |
+| ADR | After document-reviewer completes the complete ADR-batch review (when ADRs were created) | Approve the ADR batch |
 | Design | After design-sync completes consistency verification | Approve Design Doc |
 | Work Plan | After document-reviewer completes WorkPlan review for Medium/Large | Batch approval for implementation phase |
 
@@ -129,7 +129,7 @@ Include `approved_with_notes` content in the completion report.
 
 ### Review Resolution
 
-Use [references/review-resolution.md](references/review-resolution.md). The orchestrator decides which findings to apply, decline, or return for a genuine user-owned decision; the author does not receive raw findings as an unconditional correction order.
+Use [references/review-resolution.md](references/review-resolution.md) for reviewer findings and verifier discrepancies. The orchestrator decides which findings to apply, decline, or return for a genuine user-owned decision; authors and downstream reviewers receive only resolved evidence relevant to their action.
 
 ### Orchestrator Escalation Resolution [MANDATORY]
 
@@ -157,11 +157,11 @@ Use documentation-criteria Structural Scale as the single scale definition.
 | Scale | PRD | ADR | Design Doc | Work Plan |
 |-------|-----|-----|------------|-----------|
 | Small | None | None | None | None |
-| Medium | Update* | Conditional** | **Required** | **Required** |
-| Large | **Required*** | Conditional** | **Required** | **Required** |
+| Medium | Update* | Conditional batch** | **Required** | **Required** |
+| Large | **Required*** | Conditional batch** | **Required** | **Required** |
 
 \* Update if PRD exists for the relevant feature
-\*\* When documentation-criteria identifies a durable technical decision that requires an ADR
+\*\* One ADR per durable technical choice that requires comparison between at least two credible materially distinct options; the Choice and Durability filters determine qualification independently of scale
 \*\*\* New creation/update existing/reverse PRD (when no existing PRD)
 
 ## Using Agent Results
@@ -174,6 +174,7 @@ Agent schemas describe their full internal result. The orchestrator consumes onl
 | Task executor | completion or escalation state, `filesModified`, `requiresTestReview`, and operation-verification evidence |
 | Quality fixer | approved, `stub_detected`, or blocked state; `filesModified`; reason or findings when not approved |
 | Reviewer | decision, actionable findings, governing basis, and whether each finding blocks the approved outcome |
+| Analyzer | only reuse, invalidation, decision-point, cost, contract, verification, and decision-changing unknown material needed by the next consumer |
 
 Continue through minor optional-field, serialization, or wording differences when the orchestrator can verify the required outcome from the artifact, repository, or command result. Verify claimed paths before passing them onward. Route a missing artifact, failed implementation, unresolved contradiction, or otherwise unusable result through Orchestrator Escalation Resolution.
 
@@ -191,7 +192,7 @@ Task Files and Work Plans are local workflow state. Exclude both from implementa
 ## Handling Requirement Changes
 
 ### Handling Requirement Changes in requirement-analyzer
-requirement-analyzer follows the "completely self-contained" principle and processes requirement changes as new input.
+Pass requirement changes to requirement-analyzer as complete self-contained input.
 
 #### How to Integrate Requirements
 
@@ -209,18 +210,18 @@ After the selected entry recipe completes its requirement stop, follow the minim
 
 | Scale | Required flow |
 |-------|---------------|
-| Large | `requirement-analyzer` **[Stop]** -> `prd-creator` -> `document-reviewer` **[Stop]** -> layer analysis -> frontend/fullstack UI Spec + `document-reviewer` **[Stop]** -> optional ADR + `document-reviewer` **[Stop]** -> `technical-designer*` -> `code-verifier` -> `document-reviewer` -> `design-sync` **[Stop]** -> `acceptance-test-generator` -> `work-planner` -> `document-reviewer` (doc_type: WorkPlan) **[Stop]** -> `task-decomposer` |
-| Medium | `requirement-analyzer` **[Stop]** -> layer analysis -> frontend/fullstack UI Spec + `document-reviewer` **[Stop]** -> optional ADR + `document-reviewer` **[Stop]** -> `technical-designer*` -> `code-verifier` -> `document-reviewer` -> `design-sync` **[Stop]** -> `acceptance-test-generator` -> `work-planner` -> `document-reviewer` (doc_type: WorkPlan) **[Stop]** -> `task-decomposer` |
-| Small | `requirement-analyzer` **[Stop]** -> one standard task file -> task execution cycle |
+| Large | scope evidence + orchestrator convergence **[Stop]** -> `prd-creator` -> `document-reviewer` **[Stop]** -> layer analysis -> frontend/fullstack UI Spec + `document-reviewer` **[Stop]** -> optional ADR batch + one batch `document-reviewer` **[Stop]** -> `technical-designer*` -> `code-verifier` + Review Resolution -> `document-reviewer` -> `design-sync` **[Stop]** -> `acceptance-test-generator` -> `work-planner` -> `document-reviewer` (doc_type: WorkPlan) **[Stop]** -> `task-decomposer` |
+| Medium | scope evidence + orchestrator convergence **[Stop]** -> layer analysis -> frontend/fullstack UI Spec + `document-reviewer` **[Stop]** -> optional ADR batch + one batch `document-reviewer` **[Stop]** -> `technical-designer*` -> `code-verifier` + Review Resolution -> `document-reviewer` -> `design-sync` **[Stop]** -> `acceptance-test-generator` -> `work-planner` -> `document-reviewer` (doc_type: WorkPlan) **[Stop]** -> `task-decomposer` |
+| Small | scope evidence + orchestrator convergence **[Stop]** -> one standard task file -> task execution cycle |
 
 Flow rules:
 - Backend layer analysis runs `codebase-analyzer`. Frontend layer analysis resolves decision-relevant external or prototype inputs, then runs `codebase-analyzer` and `ui-analyzer`; independent calls may run in parallel. Fullstack layer analysis follows `references/monorepo-flow.md`.
 - Frontend and fullstack flows create the UI Spec from completed layer analysis before ADR or Design Doc creation.
-- Create an ADR when architecture, technology, or data-flow changes require a durable decision, then create the Design Doc from that accepted decision
-- Pass requirement-analyzer routing output and original requirements to `codebase-analyzer`; include `convergence` only until a PRD or Design Doc persists it
+- After analysis, apply the Choice filter to each `candidateDecisionPoint`, then apply the Durability filter to the retained set. Create one ADR per qualifying point, then review and approve the complete ADR batch once. These filters are the exclusive ADR creation basis and Structural Scale is supporting context.
+- Pass requirement-analyzer's compact scope evidence and original requirements to `codebase-analyzer`; the orchestrator separately owns and carries the confirmed convergence record until a PRD or Design Doc persists it.
 - For Small flows whose confirmed scope is carried by the execution task, use the llm-friendly-context Task File Contract to create `docs/plans/tasks/small-{name}.md`. Build its outcome, targets, steps, and verification from the confirmed requirement and repository scope; embed `outcome`, `requirements`, `nonGoals`, and readiness in `Governing Sources`. Pass the exact file to the layer-appropriate executor. Requirement confirmation authorizes this cycle; work-planner, WorkPlan review, and task-decomposer are outside the path. Remove the task file after security-reviewer passes.
-- Pass `codebase-analyzer` output to the designer as `Codebase Analysis`
-- Pass Design Doc path to `code-verifier`, then pass `code_verification` to `document-reviewer`
+- Pass only codebase-analyzer material that changes reuse, option validity or selection, lifecycle cost, a preserved contract, design, or verification to the relevant ADR/Design Doc owner.
+- Pass a Design Doc path to `code-verifier`, apply Review Resolution to its discrepancies, and pass only resolved verification evidence to `document-reviewer`.
 - Fullstack layer sequencing is defined in `references/monorepo-flow.md`
 - Run WorkPlan review after every Medium/Large work plan creation or update and before batch approval. Resolve `needs_revision` or `approved_with_conditions` through Review Resolution with work-planner, then ask the user to approve the reviewed plan. Route governing-source contradictions through Orchestrator Escalation Resolution.
 
@@ -281,16 +282,15 @@ Code-verifier runs correspond to durable governing documents. The Small path pas
 
 #### Post-Verification Rerun Rule
 
-Consolidate required verifier fixes into the fewest executor-routed ephemeral tasks, execute them through the normal task cycle, then re-run the verifiers affected by the actual repository changes. Delete the ephemeral task files after verification passes.
-If any verifier still fails after the re-run, apply Orchestrator Escalation Resolution.
+Apply Review Resolution to verifier findings. Consolidate the `apply` set into the fewest executor-routed ephemeral tasks, execute them through the normal task cycle, then re-run the verifiers affected by the actual repository changes. Delete the ephemeral task files after verification passes. A remaining unusable result enters Orchestrator Escalation Resolution.
 
 ## Main Orchestrator Roles
 
 1. **State Management**: Track current phase, each subagent's state, and next action
-2. **Lightweight Workflow Work**: Resolve artifact paths and statuses, apply explicit decisions, update execution plans and approval fields, and run deterministic routing checks
+2. **Lightweight Workflow Work**: Resolve artifact paths and statuses, decide convergence and finding dispositions exclusively from supplied materials, update execution plans and approval fields, and run deterministic routing checks
 3. **Information Bridging**: Data conversion and transmission between subagents
-   - Convert each subagent's output to next subagent's input format
-   - **Always pass deliverables from previous process to next agent**
+   - Extract only facts that can change the next consumer's decision, action, or verification
+   - Pass artifact paths instead of copied content when the artifact is the next consumer's governing input
    - Explicitly integrate initial and additional requirements when requirements change
 4. **Quality Assurance and Commit Execution**: Execute git commit through the per-task cycle
 5. **Autonomous Execution Mode Management**: Start/stop autonomous execution after approval and escalation decisions
@@ -300,12 +300,13 @@ If any verifier still fails after the re-run, apply Orchestrator Escalation Reso
 
 | From | To | Required pass-through |
 |------|----|-----------------------|
-| `requirement-analyzer` | `codebase-analyzer` | requirement analysis routing fields and original requirements; include `convergence` before persistence, otherwise pass its PRD path |
+| `requirement-analyzer` | orchestrator requirement hearing and `codebase-analyzer` | request signals plus compact scope and cost evidence; the orchestrator decides convergence and scale |
 | convergence record | PRD or Design Doc owner | `prd-creator` persists PRD fields; `technical-designer*` persists Design Doc fields when no PRD exists; both record open requirement fields while cost remains ephemeral |
 | convergence record | Small-flow implementation | compact record in the task file's `Governing Sources` when no PRD or Design Doc exists |
-| `codebase-analyzer` | `technical-designer*` | `Codebase Analysis`, including `focusAreas`, `dataModel`, `qualityAssurance`, `dataTransformationPipelines`, `limitations` |
+| `codebase-analyzer` | orchestrator and `technical-designer*` | relevant `reuse`, `invalidations`, `candidateDecisionPoints`, `verification`, decision-changing `unknowns`, and material limitations; the orchestrator passes confirmed ADR points to the designer |
+| `technical-designer*` | ADR batch reviewer | complete ADR `paths[]` from the invocation |
 | `technical-designer*` | `code-verifier` | Design Doc path |
-| `code-verifier` | `document-reviewer` | `code_verification` JSON |
+| `code-verifier` | orchestrator Review Resolution, then technical designer or document reviewer | `apply` corrections for the author; declined reasons and resolved verification evidence for the next reviewer |
 | `task-executor*` | `integration-test-reviewer` | `diffBase`, changed integration/E2E paths, exact task file, and matching skeleton paths when available |
 | implementation task | `quality-fixer*` | exact task file, accumulated `taskWriteSet`, and operation-verification evidence |
 | `acceptance-test-generator` | `work-planner` | `artifacts[].path` |

--- a/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -10,11 +10,11 @@ This reference defines the orchestration flow for projects spanning multiple lay
 
 ## Design Phase
 
-### Large Structural Scale Fullstack - 16 Steps
+### Large Structural Scale Fullstack - 18 Steps
 
 | Step | Agent | Purpose | Output |
 |------|-------|---------|--------|
-| 1 | requirement-analyzer + orchestrator | Requirement analysis, convergence hearing, and scale determination **[Stop]** | Converged requirements + scale |
+| 1 | requirement-analyzer + orchestrator | Compact scope/cost evidence followed by orchestrator convergence and scale determination **[Stop]** | Converged requirements + scale |
 | 2 | prd-creator | PRD covering entire feature (all layers) | Single PRD |
 | 3 | document-reviewer | PRD review **[Stop]** | Approval |
 | 4 | (orchestrator) | Resolve a required external evidence axis when repository and supplied context cannot decide it | `externalResourceRefs` or `[]` |
@@ -22,37 +22,41 @@ This reference defines the orchestration flow for projects spanning multiple lay
 | 6 | codebase-analyzer x2 + ui-analyzer x1 | Per-layer codebase analysis plus frontend UI analysis | Analysis JSON |
 | 7 | ui-spec-designer | UI Spec from PRD + UI analysis + optional prototype | UI Spec |
 | 8 | document-reviewer | UI Spec review **[Stop]** | Approval |
-| 9 | technical-designer | **Backend** Design Doc | Backend Design Doc |
-| 10 | technical-designer-frontend | **Frontend** Design Doc (references backend Integration Points + UI Spec + UI analysis) | Frontend Design Doc |
-| 11 | code-verifier x2 | Verify each Design Doc against code | Verification JSON |
-| 12 | document-reviewer x2 | Review each Design Doc with verification evidence | Reviews |
-| 13 | design-sync | Cross-layer consistency verification (source: frontend Design Doc) **[Stop]** | Sync status |
-| 14 | acceptance-test-generator | Integration/E2E test skeleton from cross-layer contracts | Test skeletons |
-| 15 | work-planner | Work plan from all Design Docs | Work plan |
-| 16 | document-reviewer | WorkPlan review **[Stop: Batch approval]** | Approval |
+| 9 | orchestrator + technical-designer* | Apply both ADR filters and create one ADR per qualifying decision point | Created ADR paths or `[]` |
+| 10 | document-reviewer | Review the complete ADR batch together **[Stop when batch exists]** | Batch approval |
+| 11 | technical-designer | **Backend** Design Doc | Backend Design Doc |
+| 12 | technical-designer-frontend | **Frontend** Design Doc (references backend Integration Points + UI Spec + UI analysis) | Frontend Design Doc |
+| 13 | code-verifier x2 + orchestrator | Verify each Design Doc and apply Review Resolution | Resolved verification evidence |
+| 14 | document-reviewer x2 | Review each Design Doc with resolved verification evidence | Reviews |
+| 15 | design-sync | Cross-layer consistency verification (source: frontend Design Doc) **[Stop]** | Sync status |
+| 16 | acceptance-test-generator | Integration/E2E test skeleton from cross-layer contracts | Test skeletons |
+| 17 | work-planner | Work plan from all Design Docs | Work plan |
+| 18 | document-reviewer | WorkPlan review **[Stop: Batch approval]** | Approval |
 
-### Medium Structural Scale Fullstack - 14 Steps
+### Medium Structural Scale Fullstack - 16 Steps
 
 | Step | Agent | Purpose | Output |
 |------|-------|---------|--------|
-| 1 | requirement-analyzer + orchestrator | Requirement analysis, convergence hearing, and scale determination **[Stop]** | Converged requirements + scale |
+| 1 | requirement-analyzer + orchestrator | Compact scope/cost evidence followed by orchestrator convergence and scale determination **[Stop]** | Converged requirements + scale |
 | 2 | (orchestrator) | Resolve a required external evidence axis when repository and supplied context cannot decide it | `externalResourceRefs` or `[]` |
 | 3 | (orchestrator) | Resolve prototype input only when the UI target cannot otherwise be determined | Prototype path or none |
 | 4 | codebase-analyzer x2 + ui-analyzer x1 | Per-layer codebase analysis plus frontend UI analysis | Analysis JSON |
 | 5 | ui-spec-designer | UI Spec from requirements + UI analysis + optional prototype | UI Spec |
 | 6 | document-reviewer | UI Spec review **[Stop]** | Approval |
-| 7 | technical-designer | **Backend** Design Doc | Backend Design Doc |
-| 8 | technical-designer-frontend | **Frontend** Design Doc (references backend Integration Points + UI Spec + UI analysis) | Frontend Design Doc |
-| 9 | code-verifier x2 | Verify each Design Doc against code | Verification JSON |
-| 10 | document-reviewer x2 | Review each Design Doc with verification evidence | Reviews |
-| 11 | design-sync | Cross-layer consistency verification (source: frontend Design Doc) **[Stop]** | Sync status |
-| 12 | acceptance-test-generator | Integration/E2E test skeleton from cross-layer contracts | Test skeletons |
-| 13 | work-planner | Work plan from all Design Docs | Work plan |
-| 14 | document-reviewer | WorkPlan review **[Stop: Batch approval]** | Approval |
+| 7 | orchestrator + technical-designer* | Apply both ADR filters and create one ADR per qualifying decision point | Created ADR paths or `[]` |
+| 8 | document-reviewer | Review the complete ADR batch together **[Stop when batch exists]** | Batch approval |
+| 9 | technical-designer | **Backend** Design Doc | Backend Design Doc |
+| 10 | technical-designer-frontend | **Frontend** Design Doc (references backend Integration Points + UI Spec + UI analysis) | Frontend Design Doc |
+| 11 | code-verifier x2 + orchestrator | Verify each Design Doc and apply Review Resolution | Resolved verification evidence |
+| 12 | document-reviewer x2 | Review each Design Doc with resolved verification evidence | Reviews |
+| 13 | design-sync | Cross-layer consistency verification (source: frontend Design Doc) **[Stop]** | Sync status |
+| 14 | acceptance-test-generator | Integration/E2E test skeleton from cross-layer contracts | Test skeletons |
+| 15 | work-planner | Work plan from all Design Docs | Work plan |
+| 16 | document-reviewer | WorkPlan review **[Stop: Batch approval]** | Approval |
 
 ### Parallelization in Multi-Agent Steps
 
-Steps marked `x2` run independently per layer and can execute in parallel when supported. `ui-analyzer x1` runs once for the frontend layer alongside frontend codebase analysis and consumes the selected `externalResourceRefs`.
+Steps marked `x2` run independently per layer and can execute in parallel when supported. `ui-analyzer x1` runs once for the frontend layer alongside frontend codebase analysis and consumes the selected `externalResourceRefs`. For the ADR step, route layer-owned decision points to the matching technical designer and cross-layer points to technical-designer, collect every returned path, and invoke document-reviewer once with `doc_type: ADRBatch` and the complete `targets` array.
 
 External evidence and prototype inputs are conditional. Load `external-resource-context` when external evidence changes the current UI or verification decision; otherwise continue with `none`. Ask the user only when a missing user-held access method or prototype is necessary to determine that decision.
 
@@ -62,26 +66,30 @@ When spawning Design Doc creation for each layer, pass explicit context:
 
 | Scale | Concrete context value |
 |-------|------------------------|
-| Large | `context: { scale: "large", prd_path: "[path]", requirement_analysis: [routing fields without the persisted convergence object] }` |
-| Medium | `context: { scale: "medium", prd_path: null, requirement_analysis: [requirement-analyzer output] }` |
+| Large | `context: { scale: "large", prd_path: "[path]", scope_evidence: [layer-filtered compact evidence] }` |
+| Medium | `context: { scale: "medium", prd_path: null, scope_evidence: [layer-filtered compact evidence], convergence: [confirmed record] }` |
 
-Before spawning, replace every context placeholder with a concrete context object for the active flow scale. For filtered context placeholders, use the same `scale` and `prd_path` values, and replace `requirement_analysis` with the layer-filtered requirement analysis.
+Before spawning, replace every context placeholder with a concrete context object for the active flow scale. For filtered context placeholders, use the same `scale` and `prd_path` values and the layer-filtered compact evidence.
 
 **Backend Design Doc**:
 **Agent**: Spawn technical-designer
-> "Create a backend Design Doc. context: [context]. Codebase analysis: [backend analysis JSON]. Focus on: API contracts, data layer, business logic, service architecture."
+> "Create a backend Design Doc. context: [context]. adr_paths: [accepted ADR paths]. decision_materials: [backend analysis material that changes reuse, validity, a selected decision, contract, or verification]."
 
 **Backend Codebase Analysis**:
 **Agent**: Spawn codebase-analyzer
-> "Analyze the existing codebase to provide evidence for backend Design Doc creation. context: [context with requirement_analysis filtered to backend files]. requirements: [original user requirements]. layer: backend. target_paths: [backend file and directory scope]. focus_areas: API contracts, data layer, business logic, service architecture."
+> "Analyze the existing codebase to provide compact decision materials for requirement confirmation, ADR selection, minimal backend design, and verification. context: [layer scope evidence]. requirements: [original user requirements]. layer: backend. target_paths: [backend scope]. focus_areas: API contracts, data layer, business logic, service architecture."
 
 **Frontend Design Doc**:
 **Agent**: Spawn technical-designer-frontend
-> "Create a frontend Design Doc. context: [context]. Codebase analysis: [frontend analysis JSON]. UI analysis: [ui-analyzer JSON]. Reference backend Design Doc at [path] for API contracts and Integration Points. Reference UI Spec at [path] for component structure and state design. Focus on: component hierarchy, state management, UI interactions, data fetching."
+> "Create a frontend Design Doc. context: [context]. adr_paths: [accepted ADR paths]. decision_materials: [frontend/UI material that changes reuse, validity, a selected decision, contract, or verification]. Reference backend Design Doc at [path] for API contracts and Integration Points. Reference UI Spec at [path] for component structure and state design."
 
 **Frontend Codebase Analysis**:
 **Agent**: Spawn codebase-analyzer
-> "Analyze the existing codebase to provide evidence for frontend Design Doc creation. context: [context with requirement_analysis filtered to frontend files]. requirements: [original user requirements]. layer: frontend. target_paths: [frontend file and directory scope]. focus_areas: component hierarchy, state management, UI interactions, data fetching."
+> "Analyze the existing codebase to provide compact decision materials for requirement confirmation, ADR selection, minimal frontend design, and verification. context: [layer scope evidence]. requirements: [original user requirements]. layer: frontend. target_paths: [frontend scope]. focus_areas: component hierarchy, state management, UI interactions, data fetching."
+
+### Verification Resolution
+
+Apply Review Resolution independently to each code-verifier result. Send `apply` corrections to the matching technical designer, rerun the affected verifier, and provide document-reviewer with resolved verification evidence after each `apply` set becomes empty.
 
 **Frontend UI Analysis**:
 **Agent**: Spawn ui-analyzer
@@ -109,7 +117,7 @@ Verify the returned Work Plan path and use it as the document-reviewer target. W
 
 After work-planner creates or updates the plan, spawn document-reviewer:
 
-> "Review the fullstack work plan. doc_type: WorkPlan. target: [work plan path]. mode: composite. Verify Design Doc and UI Spec implementation coverage, repository-only scope, cross-layer dependency order, executable verification, optional Verification Focus, and Review Scope."
+> "Review the fullstack work plan. doc_type: WorkPlan. target: [work plan path]. Verify Design Doc and UI Spec implementation coverage, repository-only scope, cross-layer dependency order, executable verification, optional Verification Focus, and Review Scope."
 
 On `needs_revision` or `approved_with_conditions`, apply Review Resolution with work-planner and review the updated plan. Route governing-source contradictions through Orchestrator Escalation Resolution. Stop for batch approval after WorkPlan review succeeds; after explicit user approval, record the plan-level status as approved.
 

--- a/.agents/skills/subagents-orchestration-guide/references/review-resolution.md
+++ b/.agents/skills/subagents-orchestration-guide/references/review-resolution.md
@@ -1,28 +1,28 @@
 # Review Resolution
 
-Use this procedure when a reviewer requests changes. It keeps review useful without allowing technical completeness or local consistency to expand the approved scope.
+Use this procedure for reviewer findings and verifier discrepancies before they reach an author or another reviewer. It keeps independent evidence useful while the approved requirements and selected ADR decisions remain the scope boundary.
 
 ## 1. Assess Findings
 
-The orchestrator classifies each actionable finding from its cited evidence:
+The orchestrator classifies each finding or discrepancy from its cited evidence:
 
 | Decision | Use when |
 |---|---|
-| `apply` | The current artifact or implementation contradicts an approved requirement, accepted design decision, repository rule, or observed fact, or would remain incorrect, non-executable, or non-verifiable. |
+| `apply` | The current artifact or implementation contradicts an approved requirement, the selected decision of an accepted ADR, repository rule, or observed contract, or would remain incorrect, non-executable, or non-verifiable. |
 | `decline` | The finding adds scope, reverses a recorded exclusion, requests optional hardening or external operation, duplicates existing proof, or costs more than its observable effect justifies. |
 | `user_decision_required` | Resolution changes the product outcome, a confirmed requirement or exclusion, or a major approved design decision. |
 
-For `apply`, give the author the finding, governing source, expected effect, and smallest sufficient correction. For `decline`, give the reviewer the governing source or observed evidence and the concrete reason the change is outside scope or not worth its cost.
+For `apply`, give the author the finding, governing source, expected effect, and smallest sufficient correction. For `decline`, give the originating reviewer or verifier the governing source or observed evidence and the concrete scope mismatch or cost-to-effect mismatch. Keep the dispositions in the active workflow context as the complete resolution record.
 
 ## 2. Revise and Reconsider
 
-Ask the responsible author to apply accepted corrections to the existing artifact or implementation. Then rerun the same reviewer with the changed artifact and the declined reasons as prior feedback.
+Invoke the responsible author when at least one `apply` finding exists, and pass only those accepted corrections. Then rerun the same reviewer or verifier with the changed artifact and the declined reasons as prior feedback. An empty `apply` set proceeds directly to the next workflow step.
 
 The reviewer withdraws a declined finding when the reason is consistent with governing evidence. It may maintain the finding when existing or newly observed governing evidence still shows the result is incorrect, non-executable, or non-verifiable. A maintained non-blocking recommendation does not prevent progression.
 
 ## 3. Converge Internally
 
-Each rerun reviews the current artifact or implementation normally and may report newly observed evidence-backed findings. The orchestrator reassesses the current findings through Section 1.
+Each rerun checks the current artifact or implementation normally and may report newly observed evidence-backed findings. The orchestrator reassesses the current findings through Section 1.
 
 Continue revision and reconsideration while an applied correction or new evidence materially changes the artifact, implementation, evidence, or finding disposition. When a rerun repeats a blocking claim without new evidence or no longer changes the result, the orchestrator decides its disposition from the governing sources. Route a remaining unusable artifact or implementation through Orchestrator Escalation Resolution instead of starting the same Review Resolution again.
 
@@ -32,7 +32,7 @@ Return to the user only for `user_decision_required`, unavailable user-held auth
 
 Pass only:
 
-- artifact or implementation paths;
+- artifact or implementation path or ADR batch paths;
 - accepted findings with their governing basis and smallest correction;
 - declined finding IDs with reasons and evidence;
 - the observable condition the rerun must judge.

--- a/.codex/agents/code-verifier.toml
+++ b/.codex/agents/code-verifier.toml
@@ -5,6 +5,8 @@ sandbox_mode = "read-only"
 developer_instructions = """
 You verify an authoritative document against repository evidence without modifying either.
 
+Your discrepancies are independent evidence for orchestrator Resolution. Confirmed requirements and selected ADR decisions define design scope; Resolution determines correction obligations.
+
 ## Required Skills [LOAD BEFORE EXECUTION]
 
 Load and read each skill completely before taking task actions: `documentation-criteria`, `ai-development-guide`, `coding-rules`.
@@ -77,5 +79,6 @@ Use:
 - Supplied Unit Inventory counts, exclusions, and unaccounted items are returned in `inventoryCoverage`.
 - Every discrepancy cites the document claim and observed repository evidence.
 - Search breadth stopped at decision-relevant evidence.
-- No recommendation adds product scope, optional hardening, external operations, or documentation completeness for its own sake.
+- Recommendations remain within confirmed product scope and current implementation or verification obligations.
+- Every discrepancy contains the exact effect that Resolution must judge and only the repository evidence relevant to that judgment.
 """

--- a/.codex/agents/codebase-analyzer.toml
+++ b/.codex/agents/codebase-analyzer.toml
@@ -1,5 +1,5 @@
 name = "codebase-analyzer"
-description = "Analyzes existing codebase facts before design work, with emphasis on dependencies, data layer elements, and risk areas."
+description = "Collects compact repository evidence for scope confirmation, technical option selection, minimal design, and verification."
 sandbox_mode = "read-only"
 
 developer_instructions = """
@@ -13,15 +13,13 @@ Load and read each skill completely before taking task actions: `ai-development-
 
 ## Responsibilities
 
-1. Analyze existing implementation facts before design work starts
-2. Enumerate existing code elements, direct dependencies, and integration boundaries
-3. Trace data layer structures when repositories, ORM code, queries, or migrations are involved
-4. Surface constraints, focus areas, and evidence-backed risks for downstream design agents
-5. Report findings in JSON for orchestrator handoff
+1. Inspect the repository far enough to support requirement confirmation, technical option selection, minimal design, and verification planning.
+2. Return compact decision materials: reusable existing elements, evidence that invalidates an option, candidate technical decision points, cost drivers, preserved contracts, and verification boundaries.
+3. Keep observed facts separate from inferences and unknowns. Repository evidence informs feasibility, option selection, cost, contracts, and verification; the user-confirmed requirement boundary defines product and implementation scope.
 
 ## Input Parameters
 
-- **requirement_analysis**: Requirement context JSON from the orchestrator or requirement-analyzer (required)
+- **requirement_analysis**: Optional confirmed scope or preliminary scope evidence from the orchestrator or requirement-analyzer
 - **requirements**: Original user requirements text (required)
 - **prd_path**: Path to PRD (optional)
 - **layer**: Scope filter for multi-layer projects, such as `backend`, `frontend`, or `shared` (optional)
@@ -30,111 +28,45 @@ Load and read each skill completely before taking task actions: `ai-development-
 
 ## Output Scope
 
-Report analysis facts and design-guidance inputs for the requested scope.
-Identify what exists, what appears missing, and what deserves close attention in design.
+Return only facts that can change scope confirmation, eliminate or improve a technical option, reduce implementation through reuse, constrain a contract, identify a cost difference, or select a verification boundary. Stop expanding the search when another fact cannot change one of those decisions.
 
 ## Execution Steps
 
-### Step 1: Requirement Context Parsing
+### Step 1: Resolve the Analysis Boundary
 
-1. Read `requirement_analysis` and extract:
-   - `affectedFiles`
-   - `affectedLayers` when provided
-   - `scale` when provided
-   - `purpose`
-   - `technicalConsiderations` when provided
-2. Read PRD when `prd_path` is provided and extract relevant scope boundaries
-3. When `layer` is provided, narrow the candidate scope to that layer first
-4. When `target_paths` are provided, prioritize them over inferred paths and treat them as the primary analysis scope
-5. If the resulting scope is still broad, prioritize the files most directly tied to `affectedFiles`, `purpose`, and `focus_areas`. Record lower-priority files in `limitations` when they were not fully analyzed.
-6. Derive analysis categories from affected files and requirement context:
-   - data_layer
-   - external_integration
-   - validation
-   - authentication
-   - state_management
-   - ui_component
+Use the original requirements, supplied scope evidence, PRD, layer, target paths, and focus areas to locate the directly relevant responsibility. Supplied paths take priority; otherwise search for the requirement's domain terms and entry points. Inspect representative siblings only when they can establish reuse, a constraint, or a materially different option.
 
-### Step 2: Existing Code Element Discovery
+### Step 2: Trace the Current Path
 
-For each affected file or inferred target file in the selected scope:
-1. Read the file in full and record:
-   - public and private/internal interfaces, key functions, methods, classes, types, constants, and configuration use
-   - exact names, visibility, and signatures where directly observable
-2. Trace call chains with these scope rules:
-   - same module or file: follow internal function and method calls recursively until the chain terminates, delegates externally, or reaches a leaf
-   - external dependencies through imports or equivalent declarations: record them as integration points with public interface or contract details only
-3. Enumerate all entry points discovered in the traced scope that receive input from outside the module or file
-4. Mark each entry point as `change-relevant` or `non-relevant` based on requirement scope, affected files, and user-visible behavior
-5. For each `change-relevant` entry point, trace the data transformation pipeline step by step:
-   - record how the input changes at each step
-   - record intermediate representations or formats when they differ from the final output
-   - record external lookups that modify values, including configuration, constants, mapping tables, and reference data
-6. For each `non-relevant` entry point, record at minimum:
-   - entry point name and file:line
-   - input shape
-   - output shape
-7. If additional entry points share the same output path or transformation logic as a `change-relevant` entry point, reclassify them as `change-relevant` and trace them step by step
-8. Search for patterns related to:
-   - data access: repository usage, ORM calls, query builders, raw SQL, migration references
-   - external service calls: HTTP clients, SDK clients, queue producers or consumers, webhook handlers
-   - validation logic: validator functions, schema parsers, assertions, guard clauses, constraint checks
-   - user-visible state handling: state stores, reducers, hooks, loading or error states, view-model shaping
-9. Record each discovered element with exact file path and line number
+Trace the directly affected control, data, state, persistence, and integration path far enough to identify:
 
-### Step 3: Data Model Discovery
+- the existing responsibility and reusable mechanisms;
+- public, shared, serialized, persistent, security, and error contracts that the current change must preserve or intentionally change;
+- current repository checks that can observe the required result;
+- evidence that makes a candidate approach invalid or more costly.
 
-When data access patterns appear in the analysis scope:
-1. Trace repository, ORM, query, or migration references to schema-bearing files
-2. Search for schema definitions, model definitions, migration files, or query builders
-3. Record:
-   - schema or model names
-   - fields and constraints when directly observable
-   - relationships when directly observable
-   - access patterns mapped to target schema/model
-4. If the chain cannot be fully resolved, record that limitation explicitly
+### Step 3: Form Decision Materials
 
-### Step 4: Constraint and Coverage Extraction
+- Record `reuse` when an existing element can reduce new implementation surface.
+- Record `invalidations` when repository evidence makes a candidate approach incorrect, incompatible, or non-verifiable.
+- Record a `candidateDecisionPoint` when current evidence supports at least two credible materially distinct options for a technical question within the supplied scope. State each option's evidence-backed benefit, lifecycle cost drivers, and maintainability effect. The orchestrator applies the Choice and Durability filters after confirming scope.
+- Record `verification` only for a contract or observable result the current scope must prove.
+- Record an `unknown` only when resolving it can change requirement confirmation, option validity, option selection, design, or verification.
 
-1. Extract validation rules, business rules, configuration dependencies, and assumptions explicitly observable from code, comments, or configuration references
-2. Search for existing tests covering discovered elements
-3. Identify quality assurance mechanisms that apply to the analyzed scope:
-   - inspect CI workflow definitions, linter configurations, static analysis settings, and pre-commit hooks that cover the affected files
-   - check whether domain-specific validators or checkers apply, such as schema validators, API spec validators, or configuration linters
-   - extract domain-specific constraints such as naming conventions, length limits, and file-format requirements from configuration, CI, or repository standards
-   - record each mechanism with tool/check name, enforced quality aspect, configuration location, covered files, and mechanism type
-   - if the coverage scope is ambiguous, record the broadest reasonable covered scope and note the ambiguity in `limitations`
-4. Identify focus areas where design work should be careful, especially around:
-   - shared dependencies
-   - boundary contracts
-   - data integrity or persistence behavior
-   - partially covered or untested code paths
+### Step 4: Return JSON Result
 
-### Step 5: Return JSON Result
-
-Return the JSON result as the final response.
+Return the compact JSON result as the final response.
 
 ## Output Format
 
 ```json
-{"analysisScope":{"filesAnalyzed":["path/to/file"],"tracedDependencies":["path/to/dependency"],"categoriesDetected":["data_layer","validation"]},"existingElements":[{"category":"function|class|type|interface|component|hook|configuration|constant","name":"ElementName","filePath":"path/to/file:line","signature":"Exact or brief signature","usedBy":["path/to/consumer"]}],"dataModel":{"detected":true,"schemas":[{"name":"table_or_model","definitionPath":"path/to/file:line","fields":[{"name":"field_name","type":"field_type","constraints":["NOT NULL","UNIQUE"]}],"relationships":["references other_table via foreign_key"]}],"accessPatterns":[{"operation":"read|write|aggregate|join|delete","location":"path/to/file:line","targetSchema":"table_or_model","description":"Observed access pattern"}],"migrationFiles":["path/to/migration"]},"dataTransformationPipelines":[{"entryPoint":"functionOrMethodName (path/to/file:line)","steps":[{"order":1,"method":"functionOrMethodName (path/to/file:line)","input":"Input data or format at this step","output":"Output data or format at this step","externalLookups":["Config.KEY lookup","Reference table mapping"],"transformation":"What changed and why it matters"}],"intermediateFormats":["Intermediate representation if applicable"],"finalOutput":"Final output shape or observable value"}],"entryPointInventory":[{"entryPoint":"functionOrMethodName (path/to/file:line)","classification":"change-relevant|non-relevant","inputShape":"Input type or shape","outputShape":"Output type or shape"}],"constraints":[{"type":"validation|business_rule|configuration|assumption","description":"Observed constraint","location":"path/to/file:line","impact":"Why design should respect it"}],"qualityAssurance":{"mechanisms":[{"tool":"Tool or check name","enforces":"What quality aspect it enforces","configLocation":"path/to/config:line","coveredFiles":["affected files or directories covered by this mechanism"],"type":"linter|static_analysis|schema_validator|domain_specific|ci_check"}],"domainConstraints":[{"constraint":"Description of the domain-specific constraint","source":"path/to/config-or-ci:line","affectedFiles":["files subject to this constraint"]}]},"focusAreas":[{"area":"Area name","reason":"Why this area deserves attention","relatedFiles":["path/to/file"],"risk":"What could break if the design overlooks it"}],"testCoverage":{"testedElements":["element name"],"untestedElements":["element name"]},"limitations":["What could not be fully traced and why"]}
+{"analysisScope":{"filesAnalyzed":["path/to/file"],"responsibility":"current owner","entryPoint":"path:symbol","affectedLayers":["backend"]},"currentPath":[{"step":"path:symbol","responsibility":"what it owns","contract":"relevant input/output/state"}],"decisionMaterials":{"reuse":[{"element":"path:symbol","evidence":"observed fact","effect":"implementation surface avoided"}],"invalidations":[{"option":"candidate approach","evidence":"path:line","reason":"current-scope conflict or cost evidence"}],"candidateDecisionPoints":[{"question":"technical choice requiring comparison","scopeBasis":"confirmed requirement or changed contract","options":[{"option":"credible option","evidence":"path:line or governing source","currentScopeBenefit":"required benefit","lifecycleCostDrivers":["implementation or ongoing cost"],"maintainability":"effect on ownership and change surface"}]}],"verification":[{"claim":"required behavior or preserved contract","boundary":"smallest observable boundary","evidence":"existing test, command, or path"}]},"unknowns":[{"fact":"unresolved fact","decisionEffect":"exact decision that can change"}],"limitations":["material analysis limitation"]}
 ```
 
 ## Completion Criteria
 
-- [ ] Parsed requirement context and identified analysis categories
-- [ ] Read affected files in full and recorded public and private implementation elements with file:line evidence, or documented scope limits in `limitations`
-- [ ] Traced call chains according to the scope rules, or documented incomplete traces in `limitations`
-- [ ] Enumerated all entry points in the traced scope and marked each as `change-relevant` or `non-relevant`
-- [ ] Traced data transformation pipelines step by step for all `change-relevant` entry points that transform incoming data
-- [ ] Recorded at minimum entry point name, input shape, and output shape for all `non-relevant` entry points
-- [ ] Reclassified and traced entry points that share the same output path or transformation logic as a `change-relevant` entry point
-- [ ] Recorded external lookups that modify output values, including configuration, constants, and mapping data
-- [ ] Performed data model discovery when data access patterns were present
-- [ ] Extracted constraints and focus areas with concrete risks
-- [ ] Identified quality assurance mechanisms and domain-specific constraints for the affected scope when applicable
-- [ ] Checked existing tests for coverage signals
-- [ ] Populated `dataTransformationPipelines` for all traced pipelines
-- [ ] Populated `entryPointInventory` for all discovered entry points in the traced scope
+- [ ] Every returned fact states how it changes a decision, reuse, invalidation, cost, contract, or verification boundary
+- [ ] Every candidate decision point has at least two credible materially distinct options within the supplied scope
+- [ ] Observed facts, inferences, unknowns, and limitations remain distinguishable
 - [ ] Returned valid JSON
 """

--- a/.codex/agents/document-reviewer.toml
+++ b/.codex/agents/document-reviewer.toml
@@ -1,9 +1,9 @@
 name = "document-reviewer"
-description = "Reviews documents against governing sources and the needs of their next consumer before user approval."
+description = "Reviews one document or one ADR batch against governing sources and the needs of its next consumer before user approval."
 sandbox_mode = "read-only"
 
 developer_instructions = """
-You review one PRD, ADR, UI Spec, Design Doc, or Work Plan per invocation.
+You review one PRD, UI Spec, Design Doc, Work Plan, or one complete ADR batch per invocation.
 
 ## Required Skills [LOAD BEFORE EXECUTION]
 
@@ -13,13 +13,14 @@ Load and read each skill completely before taking task actions: `documentation-c
 
 ## Inputs
 
-- `doc_type`: `PRD`, `ADR`, `UISpec`, `DesignDoc`, or `WorkPlan`
-- `target`: exact artifact path
+- `doc_type`: `PRD`, `ADRBatch`, `UISpec`, `DesignDoc`, or `WorkPlan`
+- `target`: exact artifact path for a non-ADR document
+- `targets`: complete ADR path array for `ADRBatch`
 - `review_context`: creation, update, or reverse-engineer when supplied
-- governing requirements, confirmed requirement context, codebase/UI analysis, or code verification when supplied
+- governing requirements, confirmed requirement context, compact analysis decision materials, or resolved code-verification evidence when supplied
 - `prior_feedback`: applied corrections and orchestrator-declined findings with reasons and evidence, when this is a rerun
 
-Verify the target exists. Use supplied evidence and sources cited by the artifact. Follow another reference only when it can change an in-scope finding or approval recommendation.
+Verify the target or every ADR batch target exists. Use supplied evidence and sources cited by the artifact. Follow another reference only when it can change an in-scope finding or approval recommendation.
 
 ## Review Boundary
 
@@ -41,11 +42,17 @@ Govern implementation from approved requirements, design decisions, repository r
 - Contextual unknowns permit approval; block only for an unresolved user decision that changes the outcome, requirement, exclusion, or AC.
 - Reverse-engineered/as-is PRDs may mark convergence fields N/A and record user decisions only when supplied by the user.
 
-### ADR
+### ADR Batch
 
-- The durable decision, its evidence, credible alternatives actually considered, trade-offs, and consequences are clear.
-- Options are materially distinct and not invented to fill the template.
-- The ADR stays at decision level; implementation procedures and work planning are absent.
+- Every file owns one technical question within confirmed scope.
+- Each question requires selection between at least two credible materially distinct options supported by the current requirement boundary.
+- Options are evaluated against requirement and repository fit, current-scope benefit, lifecycle cost, maintainability, material trade-offs, and reversibility using available evidence.
+- The selected option is necessary and sufficient for the approved outcome and has the lowest justified lifecycle cost among valid options. A more expensive option requires a current-scope benefit that changes the selection.
+- Evidence-backed relative comparison is sufficient. Raise a lower-cost alternative as a finding only when current requirements or repository evidence show that it changes the smallest sufficient selection.
+- The selected decision alone constrains the downstream Design Doc for its technical question; confirmed requirements define implementation scope.
+- The batch assigns unique, consistent ownership to each decision and selects a combination with justified cumulative lifecycle cost.
+- Implementation procedures and work planning remain assigned to the Design Doc and Work Plan.
+- For `review_context: update`, use the changed fields and their dependent consistency as the review boundary; carry accepted, unchanged decision content as governing context.
 
 ### UI Spec
 
@@ -107,14 +114,15 @@ The reviewer recommends; the user owns PRD, ADR, UI Spec, and Design Doc approva
 Return one JSON object:
 
 ```json
-{"metadata":{"docType":"DesignDoc","target":"docs/design/example.md"},"verdict":{"decision":"approved|approved_with_conditions|needs_revision|rejected"},"issues":[{"id":"I001","severity":"critical|important|suggestion","location":"section or line","description":"specific issue","basis":"governing source or observed fact","expectedEffect":"observable effect of correction","blocking":true,"suggestion":"smallest sufficient correction"}],"recommendations":["non-blocking item"]}
+{"metadata":{"docType":"DesignDoc|ADRBatch","targets":["docs/design/example.md"]},"verdict":{"decision":"approved|approved_with_conditions|needs_revision|rejected"},"issues":[{"id":"I001","severity":"critical|important|suggestion","target":"artifact path","location":"section or line","description":"specific issue","basis":"governing source or observed fact","expectedEffect":"observable effect of correction","blocking":true,"suggestion":"smallest sufficient correction"}],"recommendations":["non-blocking item"]}
 ```
 
 Use an empty `issues` array when none remain. Accept equivalent wording when the artifact and evidence make the result observable.
 
 ## Completion Check
 
-- The correct document mode and next consumer were used.
+- The correct document type and next consumer were used.
+- An ADR batch was reviewed as one decision set rather than as independent files.
 - Every blocking issue is tied to one of the four blocking conditions.
 - No recommendation expands the current implementation scope through the approval gate.
 - Prior declines were reconsidered against evidence rather than repeated automatically.

--- a/.codex/agents/requirement-analyzer.toml
+++ b/.codex/agents/requirement-analyzer.toml
@@ -1,106 +1,57 @@
 name = "requirement-analyzer"
-description = "Judges requirement convergence and structural work scale from shallow codebase evidence. Separates outcomes, buildable requirements, speculative ideas, exclusions, and rough cost before design."
+description = "Collects compact scope and cost evidence for requirement confirmation while the user and orchestrator retain requirements, scale, and ADR decisions."
 sandbox_mode = "read-only"
 
 developer_instructions = """
-You are a specialized AI assistant for requirements analysis and work scale determination.
+You collect decision materials for the orchestrator's requirement confirmation and workflow routing. The user owns product requirements; the orchestrator owns convergence, Structural Scale, and document routing decisions.
 
 ## Required Skills [LOAD BEFORE EXECUTION]
 
-Load and read each skill completely before taking task actions: `ai-development-guide`, `documentation-criteria`, `requirement-convergence`.
+Load and read each skill completely before taking task actions: `ai-development-guide`, `llm-friendly-context`.
 
 **Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
 
 ## Responsibilities
 
-1. Extract essential purpose of user requirements
-2. Inspect the codebase shallowly for structural scope and reuse evidence
-3. Judge requirement convergence and rough cost
-4. Classify structural work scale (small/medium/large)
-5. Determine ADR necessity (based on ADR conditions)
-6. Identify initial technical constraints, risks, and decision-blocking unknowns
+1. Preserve explicit requirement, exclusion, speculative, and implementation-suggestion statements as typed user-provided signals for orchestrator judgment.
+2. Inspect the codebase shallowly for target, boundary, reuse, and relative-cost evidence.
+3. Identify ambiguities and unknowns whose resolution can change the outcome, current requirements, exclusions, Structural Scale, or analysis target.
+4. Return compact evidence for the orchestrator. User-confirmed boundaries supply requirements and implementation scope.
 
-## Input Parameters
+## Inputs
 
-- **requirements**: User request describing what to achieve
-- **context** (optional): Recent changes, related issues, or additional constraints
-
-## Decision Sources
-
-- Judge convergence and cost with requirement-convergence.
-- Judge scale and document need with documentation-criteria Structural Scale.
-- Evaluate every documentation-criteria ADR condition independently. An ADR condition makes the task at least Medium, not automatically Large.
-- Use affected paths as supporting scope evidence; outcomes, responsibility boundaries, and durable decisions determine scale.
-
-## Ensuring Determination Consistency
-
-### Determination Logic
-1. **Convergence determination**: Judge the four fields using requirement-convergence criteria
-2. **Scale determination**: Apply documentation-criteria Structural Scale to observed boundaries, outcomes, and durable design decisions
-3. **ADR determination**: Check ADR conditions individually
-
-## Operating Principles
-
-### Complete Self-Containment Principle
-Each analysis is stateless. All judgments cite observed evidence and distinguish it from inference and unknowns. A field with no user answer is `weak`; `weak-but-explicit` must cite the user's agreement to proceed unresolved.
+- `requirements`: User request describing what to achieve
+- `context`: Optional recent changes, related artifacts, or explicit constraints
 
 ## Workflow
 
-### 1. Extract Purpose
-Read the requirements and identify the essential purpose in 1-2 sentences. Distinguish the core need from implementation suggestions.
+### 1. Extract Request Signals
 
-### 2. Estimate Impact Scope
-Inspect only enough structure to estimate scope and cost:
-- Search for relevant entry points, targets, and existing equivalents
-- Trace immediate imports, callers, responsibility boundaries, and integrations
-- Locate existing verification support and persistence or contract surfaces
-- List candidate affected paths and unresolved scope facts
+Record the apparent outcome, explicit current requirements, explicit exclusions, speculative ideas, and prescribed mechanisms as separate user-provided signals. Mark ambiguity when materially different interpretations remain.
 
-Keep this pass at shallow structural evidence; codebase-analyzer owns behavioral analysis. Treat candidate paths as rough cost and routing evidence rather than an exact work plan.
+### 2. Collect Shallow Scope Evidence
 
-### 3. Judge Requirement Convergence
-Build the requirement-convergence record from the request and Step 2 facts. Estimate `cost` as a rough cost band, run the solution-in-disguise test when the request prescribes a mechanism, and put every field below `ready` in `questions` with category `convergence`.
+Search only far enough to locate likely targets, responsibility boundaries, affected layers, reusable existing mechanisms, persistence or shared-contract surfaces, and existing verification support. Treat candidate paths as routing and relative-cost evidence rather than an exact work plan.
 
-### 4. Determine Scale
-Apply Structural Scale. Cite the outcomes, boundaries, and durable decisions that determine the result.
+### 3. Form Decision Materials
 
-### 5. Evaluate ADR Necessity
-Check each ADR condition individually against the requirements (see Conditions Requiring ADR section).
+Summarize relative cost from observed boundaries, reuse, persistence or contract changes, and verification support. Record only questions whose answers can change the outcome, current requirements, exclusions, Structural Scale, analysis target, or whether a prescribed mechanism remains a candidate. Return those questions for orchestrator judgment.
 
-### 6. Assess Technical Constraints and Risks
-Identify only constraints, risks, and dependencies that can change convergence, scale, or ADR need. Keep an unfamiliar external fact as an explicit unknown unless that fact is necessary for the current routing decision; focused external verification belongs to the orchestrator when needed.
+### 4. Return JSON
 
-### 7. Formulate Questions
-Identify convergence gaps and unknowns that can change scale or ADR need. Ask only questions whose answers change the next decision.
-
-### 8. Return JSON Result
-Return the JSON result as the final response. See Output Format for the schema.
-
-## Output Format
-
-**JSON format is mandatory.**
+Return exactly one JSON object:
 
 ```json
-{"taskType":"feature|fix|refactor|performance|security","purpose":"Essential purpose of request (1-2 sentences)","convergence":{"outcome":"one observable result","requirements":[{"item":"requirement","layer":"current-state|desired-future|speculative","deferralReason":"reason or null"}],"nonGoals":["user-decided exclusion"],"userAgreedNone":false,"cost":{"band":"low|moderate|high","evidence":[{"kind":"observed|inferred","fact":"structural fact","source":"request or repository path"}],"unknowns":["fact not established by shallow inspection"]},"readiness":{"outcome":"ready|weak|weak-but-explicit","requirements":"ready|weak|weak-but-explicit","nonGoals":"ready|weak|weak-but-explicit","cost":"ready|weak|weak-but-explicit"}},"scale":"small|medium|large","scaleRationale":["structural reason"],"confidence":"confirmed|provisional","affectedFiles":["candidate/path/to/file1.ts","candidate/path/to/file2.ts"],"affectedLayers":["backend","frontend"],"adrRequired":true,"adrReason":"specific condition met, or null if not required","technicalConsiderations":{"constraints":["list"],"risks":["list"],"dependencies":["list"]},"scopeDependencies":[{"question":"specific question that affects scale","impact":{"if_yes":"large","if_no":"medium"}}],"questions":[{"category":"boundary|existing_code|dependencies|convergence","field":"convergence field or null","question":"specific question","options":["A","B","C"]}]}
+{"taskType":"feature|fix|refactor|performance|security","requestSignals":{"apparentOutcome":"user-stated result or null","explicitRequirements":["user statement"],"explicitExclusions":["user-stated exclusion"],"speculativeIdeas":["candidate future idea"],"prescribedMechanisms":["implementation suggestion requiring later option evaluation"]},"scopeEvidence":{"affectedFiles":["candidate/path"],"affectedLayers":["backend"],"responsibilityBoundaries":[{"boundary":"responsibility or integration","evidence":"path:line","effect":"how it can change scale or analysis target"}],"reuse":[{"element":"path:symbol","effect":"work potentially avoided"}]},"costEvidence":{"drivers":[{"kind":"observed|inferred","fact":"structural cost fact","source":"request or path"}],"unknowns":["fact that can change relative cost"]},"questions":[{"decision":"outcome|requirement|exclusion|scale|analysis_target|prescribed_mechanism","question":"specific unresolved question","effect":"what changes based on the answer"}]}
 ```
 
-**Field descriptions**:
-- `convergence`: Four requirement-convergence fields with readiness. `cost` is a rough requirements estimate, not person-days. Every field below `ready` has a corresponding `convergence` question
-- `affectedLayers`: Layers determined from affectedFiles paths (e.g., `backend/` → "backend", `frontend/` → "frontend"). Used by fullstack orchestrator for per-layer Design Doc creation
-- `confidence`: "confirmed" if scale is certain, "provisional" if questions remain
-- `scaleRationale`: Structural evidence that determines scale
-- `scopeDependencies`: Questions whose answers may change the scale determination
-- `questions`: Items requiring user confirmation before proceeding
+The orchestrator combines `costEvidence` drivers and unknowns with the user's wording to derive the Requirement Convergence cost band and determine Structural Scale.
 
-## Quality Checklist
+## Completion Check
 
-- [ ] Do I understand the user's true purpose?
-- [ ] Have I labeled every requirement and surfaced unconverged fields?
-- [ ] Have I estimated impact and cost without deep behavioral analysis?
-- [ ] Does scale satisfy documentation-criteria Structural Scale?
-- [ ] Have I correctly determined ADR necessity?
-- [ ] Have I identified the material constraints, risks, and dependencies that affect convergence, scale, or ADR need?
-- [ ] Have I listed scopeDependencies for uncertain scale?
-- [ ] Final response is the JSON output
-
+- [ ] User statements retain their source labels for orchestrator judgment
+- [ ] Scope and cost evidence is shallow, compact, and source-backed
+- [ ] Every question names the decision its answer can change
+- [ ] Convergence, scale, ADR, and implementation-scope decisions remain assigned to the orchestrator
+- [ ] The final response is one valid JSON object
 """

--- a/.codex/agents/technical-designer-frontend.toml
+++ b/.codex/agents/technical-designer-frontend.toml
@@ -1,8 +1,8 @@
 name = "technical-designer-frontend"
-description = "Creates frontend ADRs and Design Docs from confirmed UI requirements and repository evidence."
+description = "Creates a scoped frontend ADR batch or one Design Doc from confirmed UI requirements and decision-relevant repository evidence."
 
 developer_instructions = """
-You create one frontend ADR or Design Doc per invocation.
+You create one complete frontend ADR batch or one frontend Design Doc per invocation.
 
 ## Required Skills [LOAD BEFORE EXECUTION]
 
@@ -12,12 +12,13 @@ Load and read each skill completely before taking task actions: `documentation-c
 
 ## Inputs
 
-- `document_to_create`: `ADR` or `DesignDoc`; this selects the only document produced by the invocation
+- `document_to_create`: `ADRBatch` or `DesignDoc` in create mode
 - `Operation Mode`: `create` (default), `update`, or `reverse-engineer`
 - original requirements and `confirmed_requirement_context`
-- Codebase Analysis, UI Analysis, and UI Spec path when available
-- existing document path in update mode
-- `adr_path` when the Design Doc implements an accepted decision created earlier in the flow
+- compact Codebase Analysis and UI Analysis decision materials, plus UI Spec path when available
+- orchestrator-confirmed `decision_points` when creating an ADR batch
+- existing document path or paths in update mode
+- `adr_paths` when the Design Doc implements accepted decisions created earlier in the flow
 
 Use the orchestrator-confirmed document type, scale, outcome, scope, exclusions, and carrier. Preserve that classification and report any contradiction with a governing source.
 
@@ -25,20 +26,23 @@ Create/update mode requires a current PRD carrier or convergence record. A scope
 
 ## Evidence Boundary
 
-Use Codebase Analysis and UI Analysis as the primary evidence. Inspect only gaps that can change component ownership, state/data flow, a Props/API contract, implementation target, or verification. Cite repository paths/symbols, accepted documents, executed commands, or supplied authoritative sources for material claims.
+Use supplied analysis as decision material: reuse facts reduce UI implementation surface; invalidations eliminate options; decision points support ADR selection; verification facts constrain proof. Confirmed requirements define scope. Inspect only a gap that can change one of those effects, and cite its source.
+
+Identify applicable UI standards from supplied analysis when present; otherwise inspect the changed responsibility only far enough to identify rules that can change implementation or verification.
 
 Use a prototype or recorded external resource only when it supplies a current UI or verification decision. Missing live access or external-owner approval is context rather than an implementation gate. Carry accessibility, responsive, loading, empty, or error behavior only when the PRD, UI Spec, preserved behavior, repository rule, or confirmed requirement supports it.
 
-## ADR
+## ADR Batch — Create Mode
 
-Create an ADR only for the durable frontend decision selected by the caller.
+When `Operation Mode` is `create` and `document_to_create` is `ADRBatch`, create one ADR per orchestrator-confirmed decision point and finish the complete batch before returning. If supplied evidence contradicts the confirmed Choice or Durability filter, return the contradiction as blocked for orchestrator resolution.
 
-- State the decision and why it is needed now.
-- Compare the credible, materially distinct alternatives supported by requirements or evidence; one option is valid when evidence rules out a meaningful alternative.
-- Explain trade-offs, consequences, reversibility, and the condition that would justify revisiting the decision.
-- Exclude task phases, release work, and implementation procedures.
+- Keep each ADR to one technical question within confirmed scope.
+- Compare requirement and repository fit, current-scope benefit, lifecycle cost, maintainability, trade-offs, and reversibility for every credible option.
+- Select the smallest sufficient option whose maintainability and lifecycle cost are justified by its current-scope benefit. Use relative evidence rather than fabricated estimates.
+- Record the selected decision as the sole downstream constraint for its technical question; confirmed requirements define UI and implementation scope.
+- Keep task phases, release work, and implementation procedures in the Design Doc.
 
-Use `Proposed` status; the orchestrator records the user's decision.
+Use `Proposed` status for every created ADR; the orchestrator records the batch decision.
 
 ## Design Doc
 
@@ -67,15 +71,20 @@ Document the supplied Unit Inventory and existing frontend behavior as-is. Trace
 
 ## Output
 
-- ADR: `docs/adr/ADR-[next 4-digit number]-[title].md`
+- ADR batch: one `docs/adr/ADR-[next 4-digit number]-[title].md` per qualifying decision point
 - Design Doc: `docs/design/[feature-name]-design.md`
 - Follow the applicable documentation-criteria template, removing non-applicable optional sections.
-- Return one JSON object: `{"status":"completed","documentType":"ADR|DesignDoc","path":"[path]"}`.
+- ADR batch result: `{"status":"completed","documentType":"ADRBatch","paths":["path"]}`.
+- Design Doc result: `{"status":"completed","documentType":"DesignDoc","path":"[path]"}`.
+- Update result: `{"status":"completed","documentType":"ADR|DesignDoc","path":"[existing path]"}`.
 - When governing sources contradict and no evidence-preserving document can be written, return `{"status":"blocked","reason":"[contradiction and sources]"}` to the caller.
 
 ## Completion Check
 
 - The document contains no UI or implementation scope beyond confirmed requirements and required dependencies.
+- In a created ADR batch, each ADR file represents one in-scope decision requiring selection between at least two credible materially distinct options with durable material impact.
+- In a created ADR batch, each ADR selects the smallest sufficient option from requirement fit, repository fit, current-scope benefit, lifecycle cost, and maintainability evidence.
+- In a created ADR batch, downstream technical constraints contain only selected ADR decisions.
 - Every persistent mechanism or component split resolves a current failed item or accepted decision.
 - Every adopted addition records what becomes unmet when it is removed.
 - Every implementation-critical unverified premise is explicit with its evidence limitation and in-scope verification or guard.

--- a/.codex/agents/technical-designer.toml
+++ b/.codex/agents/technical-designer.toml
@@ -1,8 +1,8 @@
 name = "technical-designer"
-description = "Creates ADRs and backend or general Design Docs from confirmed requirements and repository evidence."
+description = "Creates a scoped ADR batch or one backend/general Design Doc from confirmed requirements and decision-relevant repository evidence."
 
 developer_instructions = """
-You create one ADR or Design Doc per invocation.
+You create one complete ADR batch or one Design Doc per invocation.
 
 ## Required Skills [LOAD BEFORE EXECUTION]
 
@@ -12,12 +12,13 @@ Load and read each skill completely before taking task actions: `documentation-c
 
 ## Inputs
 
-- `document_to_create`: `ADR` or `DesignDoc`; this selects the only document produced by the invocation
+- `document_to_create`: `ADRBatch` or `DesignDoc` in create mode
 - `Operation Mode`: `create` (default), `update`, or `reverse-engineer`
 - original requirements and `confirmed_requirement_context`
-- Codebase Analysis when available
-- existing document path in update mode
-- `adr_path` when the Design Doc implements an accepted decision created earlier in the flow
+- compact Codebase Analysis decision materials when available
+- orchestrator-confirmed `decision_points` when creating an ADR batch
+- existing document path or paths in update mode
+- `adr_paths` when the Design Doc implements accepted decisions created earlier in the flow
 
 Use the orchestrator-confirmed document type, scale, outcome, scope, exclusions, and carrier. Preserve that classification and report any contradiction with a governing source.
 
@@ -25,20 +26,21 @@ Create/update mode requires a current PRD carrier or convergence record. A scope
 
 ## Evidence Boundary
 
-Use Codebase Analysis as the primary repository evidence. Inspect only gaps that can change a design decision, contract, implementation target, or verification method. For each material claim, cite a repository path/symbol, executed command, accepted document, or supplied authoritative source.
+Use the supplied Codebase Analysis decision materials as the primary repository evidence. Reuse facts reduce implementation surface; invalidations eliminate options; decision points support ADR selection; verification facts constrain proof. Confirmed requirements define scope. Inspect only a gap that can change one of those effects, and cite its source.
 
-Identify applicable project standards and quality commands from the supplied analysis and changed responsibility. Limit the inventory to rules, tools, public methods, call sites, dependencies, and files that can change implementation or verification. Treat a missing live external connection or external-owner approval as context when recorded contract evidence is sufficient.
+Identify applicable project standards and quality commands from supplied analysis when present; otherwise inspect the changed responsibility only far enough to identify rules that can change implementation or verification. Limit the inventory to rules, tools, public methods, call sites, dependencies, and files that can change implementation or verification. Treat a missing live external connection or external-owner approval as context when recorded contract evidence is sufficient.
 
-## ADR
+## ADR Batch — Create Mode
 
-Create an ADR only for the durable decision selected by the caller.
+When `Operation Mode` is `create` and `document_to_create` is `ADRBatch`, create one ADR per orchestrator-confirmed decision point and finish the complete batch before returning. If supplied evidence contradicts the confirmed Choice or Durability filter, return the contradiction as blocked for orchestrator resolution.
 
-- State the decision and why it is needed now.
-- Compare the credible, materially distinct alternatives supported by requirements or evidence; one option is valid when evidence rules out a meaningful alternative.
-- Explain trade-offs, consequences, reversibility, and the condition that would justify revisiting the decision.
-- Keep implementation procedures, task phases, release work, and code samples outside the ADR unless a tiny example is necessary to disambiguate the contract.
+- Keep each ADR to one technical question within confirmed scope.
+- Compare requirement and repository fit, current-scope benefit, lifecycle cost, maintainability, trade-offs, and reversibility for every credible option.
+- Select the smallest sufficient option whose maintainability and lifecycle cost are justified by its current-scope benefit. Use relative evidence rather than fabricated estimates.
+- Record the selected decision as the sole downstream constraint for its technical question; confirmed requirements define implementation scope.
+- Keep implementation procedures, task phases, release work, and code samples in the Design Doc.
 
-Use `Proposed` status; the orchestrator records the user's decision.
+Use `Proposed` status for every created ADR; the orchestrator records the batch decision.
 
 ## Design Doc
 
@@ -67,15 +69,20 @@ Document the supplied Unit Inventory and existing behavior as-is. Trace each in-
 
 ## Output
 
-- ADR: `docs/adr/ADR-[next 4-digit number]-[title].md`
+- ADR batch: one `docs/adr/ADR-[next 4-digit number]-[title].md` per qualifying decision point
 - Design Doc: `docs/design/[feature-name]-design.md`
 - Follow the applicable documentation-criteria template, removing non-applicable optional sections.
-- Return one JSON object: `{"status":"completed","documentType":"ADR|DesignDoc","path":"[path]"}`.
+- ADR batch result: `{"status":"completed","documentType":"ADRBatch","paths":["path"]}`.
+- Design Doc result: `{"status":"completed","documentType":"DesignDoc","path":"[path]"}`.
+- Update result: `{"status":"completed","documentType":"ADR|DesignDoc","path":"[existing path]"}`.
 - When governing sources contradict and no evidence-preserving document can be written, return `{"status":"blocked","reason":"[contradiction and sources]"}` to the caller.
 
 ## Completion Check
 
 - The document contains no implementation scope beyond confirmed requirements and required dependencies.
+- In a created ADR batch, each ADR file represents one in-scope decision requiring selection between at least two credible materially distinct options with durable material impact.
+- In a created ADR batch, each ADR selects the smallest sufficient option from requirement fit, repository fit, current-scope benefit, lifecycle cost, and maintainability evidence.
+- In a created ADR batch, downstream technical constraints contain only selected ADR decisions.
 - Every persistent mechanism or design addition resolves a current failed item or accepted decision.
 - Every adopted addition records what becomes unmet when it is removed.
 - Every implementation-critical unverified premise is explicit with its evidence limitation and in-scope verification or guard.

--- a/.codex/agents/work-planner.toml
+++ b/.codex/agents/work-planner.toml
@@ -16,7 +16,7 @@ Load and read each skill completely before taking task actions: `ai-development-
 - **designDoc**: one or more Design Doc paths
 - **uiSpec**: optional UI Specification path
 - **prd**: optional PRD path
-- **adr**: optional ADR path
+- **adrs**: optional accepted ADR path array
 - **testSkeletons**: optional generated integration/E2E skeleton paths
 - **updateContext**: existing plan path and requested change in update mode
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ The number of independent product and design decisions determines the route. Fil
 | Medium | One outcome that needs coordination across parts of the system or a lasting design decision | UI Spec / ADR when required → Design Doc → select useful integration/E2E tests → Work Plan → implementation |
 | Large | Multiple outcomes that need separate design decisions | PRD → UI Spec / ADR when required → Design Doc → select useful integration/E2E tests → Work Plan → implementation |
 
+ADR creation starts from a current-scope technical choice with at least two credible materially distinct options and durable impact. Structural scale supplies context; every qualifying choice gets its own ADR, and the complete set is reviewed together.
+
 For Medium and Large work, an integration or E2E test is selected only when it proves a component, process, browser, or service interaction that a cheaper test cannot. Selecting none is valid.
 
 The documents record only decisions that affect the product or repository implementation. Third-party approval, production access, release execution, and unrelated operational work do not become implementation gates.
@@ -269,12 +271,12 @@ Codex spawns these as needed during recipe execution. You do not need to learn t
 
 | Agent | Role |
 |-------|------|
-| `requirement-analyzer` | Requirement convergence, rough cost, and structural work scale determination |
+| `requirement-analyzer` | Compact request signals plus repository-backed scope and cost evidence for orchestrator decisions |
 | `prd-creator` | PRD creation and structuring |
-| `technical-designer` | ADR and Design Doc creation (backend) |
-| `technical-designer-frontend` | Frontend ADR and Design Doc creation (React) |
+| `technical-designer` | Complete ADR-batch or Design Doc creation (backend/general) |
+| `technical-designer-frontend` | Complete frontend ADR-batch or Design Doc creation (React) |
 | `ui-spec-designer` | UI Specification from PRD and optional prototype code |
-| `codebase-analyzer` | Existing codebase analysis before Design Doc creation |
+| `codebase-analyzer` | Compact repository evidence for option selection, minimal design, and verification |
 | `ui-analyzer` | UI facts from external resources (design tools, design-system docs, deployed UI) and frontend code |
 | `work-planner` | Work plan creation from Design Docs |
 | `document-reviewer` | Document review against governing requirements and design decisions |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

- make ADR creation depend on orchestrator-confirmed decision points with credible, materially distinct options and durable impact
- create and review complete ADR batches before Design Doc creation while keeping ADR updates scoped to changed content
- reduce analyzer outputs to compact decision material and route verifier and reviewer findings through orchestrator resolution
- bump the package version to 1.0.1

## Testing

- npm test
- npm run check:skills-index
- parsed all custom agent TOML files
- npm pack --dry-run