### PR TITLE
Propagate scoped write authority to repository-writing subagents

### DIFF
--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -94,7 +94,9 @@ Spawn agents using natural language prompts. Provide clear context about what th
 
 ### Spawn Prompt Requirements
 
-- Each spawn prompt must name the target deliverable, input paths, and expected result. When invoking `task-executor*`, include the exact task file path, for example: `Execute the implementation task. Task file: docs/plans/tasks/[filename].md.`
+- Each spawn prompt must name the target deliverable, input paths, and expected result.
+- When the assigned action writes repository files, include: `The orchestrator has delegated this repository-writing task from the user's requested workflow. This invocation authorizes the repository writes required to produce or update the assigned deliverable within the supplied scope. Perform the writes and return the result.` The orchestrator applies any workflow review or approval gate to the returned artifact afterward.
+- When invoking `task-executor*`, also include the exact task file path, for example: `Execute the implementation task. Task file: docs/plans/tasks/[filename].md.`
 
 ## Explicit Stop Points [MANDATORY]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

- require spawn prompts for every repository-writing subagent to carry delegated write authority
- keep subsequent artifact review and approval gates owned by the orchestrator
- bump the package patch version to 1.0.4

## Motivation

Subagents run with isolated context and can otherwise treat repository writes as requiring a second user approval, even when the orchestrator has already delegated the requested workflow action. This applies to document authors such as technical-designer as well as implementation and quality agents.

## Verification

- npm test
- npm run check:skills-index
- git diff --check