### PR TITLE
feat: add reviewee judgment skill

### DIFF
--- a/.agents/skills/reviewee-judgment/SKILL.md
+++ b/.agents/skills/reviewee-judgment/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: reviewee-judgment
+description: "Evaluates received review results before they generate work by separating problems from proposed fixes and comparing responses in a fixed decision order. Use whenever review results may lead to artifact changes; does not produce reviews."
+---
+
+# Reviewee Judgment
+
+## Purpose and Value
+
+Treat review findings as evidence about an artifact, not as work orders. A finding can expose a real problem while proposing the wrong fix, the wrong owner, or a response whose cost exceeds its value.
+
+This skill prevents automatic finding-closure and automatic rejection from replacing product judgment. It preserves the requested outcome while favoring durable quality: maintainability for code, execution precision for prompts, and decision integrity for specifications. It also makes structural debt, verification limits, and user-owned tradeoffs visible before implementation begins.
+
+Apply, decline, reuse, and no change are candidates; none is the default. Justify the response from governing obligations, expected effect, durable quality, and total lifecycle cost in that order.
+
+Use this process before planning or performing changes derived from received review results. Success is an evidence-backed response to the underlying problems, not a larger change set or a higher count of closed findings.
+
+Its input is a completed set of review results. Producing review findings remains outside this skill's scope.
+
+The flow is: establish the outcome boundary, separate each problem from its proposed fix, group findings by underlying problem, locate the responsible cause, compare eligible responses in order, then recommend or execute within the granted authority.
+
+## Artifact Context
+
+Read the current artifact, the received findings, and the governing outcome, constraints, exclusions, and contracts. Mark material claims as observed, inferred, or unknown.
+
+Load the reference that matches each reviewed artifact:
+
+- Code, configuration, schema, or migration: [references/code.md](references/code.md)
+- Prompt, agent instruction, or skill content: [references/prompt.md](references/prompt.md)
+- Requirement, ADR, design document, plan, or other decision-carrying specification: [references/spec.md](references/spec.md)
+
+For mixed findings, load every matching reference and apply this core process once across the shared problem set.
+
+## Core Distinctions
+
+### Problem and Proposed Fix
+
+Extract the reported behavior, its evidence, and its consequence independently from the reviewer's proposed change. Evaluate the proposal only after the problem is confirmed and owned.
+
+### Same Problem and Similar Surface
+
+Group findings when they arise from the same responsibility, contract, decision, state transition, or causal rule. Similar wording, syntax, file shape, or patch mechanics alone does not establish the same problem.
+
+Search for other instances of the confirmed underlying problem. Apply a shared response only when the instances share the responsible cause; otherwise preserve their intentional differences.
+
+### Local Defect and Structural Defect
+
+A local defect is fully owned by one otherwise sound unit and can be corrected without retaining the same causal failure elsewhere.
+
+A structural defect is owned by a misplaced responsibility, contradictory contract, duplicated decision, or unnecessary mechanism. Repeated local edits do not resolve that owner.
+
+## Decision Order
+
+Evaluate candidates through these gates in order. A later gate cannot compensate for a failure at an earlier gate.
+
+1. **Outcome boundary**: Preserve the requested outcome, governing constraints, explicit exclusions, and compatibility obligations.
+2. **Finding validity**: Confirm the reported behavior and its material effect. Base validity on that evidence, and record the reviewer's priority and proposed fix separately as context.
+3. **Cause and ownership**: Identify the underlying problem and the artifact or responsibility that owns it.
+4. **Causal sufficiency**: Compare responses that resolve the owner, including subtraction, simplification, reuse, correction of an existing structure, redesign, and a local patch when each is applicable.
+5. **Durable quality**: Apply the matching reference's Quality Objective and Candidate Comparison. Prefer the candidate that improves the artifact's long-term quality without adding unnecessary concepts or parallel sources of truth.
+6. **Verification safety**: Determine whether the change and its affected boundaries can be proved safe with available evidence.
+7. **Lifecycle value**: Compare implementation, verification, migration, maintenance, execution risk, and retained-debt cost only among candidates that passed the earlier gates. When the artifact contradicts the requested outcome, a governing constraint, an explicit exclusion, or a compatibility obligation, or has materially incorrect, non-executable, or non-verifiable behavior at a required boundary, use lifecycle value to select a sufficient response while the correction remains required. For a discretionary improvement, establish benefit with evidence of an observable effect on the outcome, maintainability, execution precision, or decision integrity. Treat reviewer preference as context rather than benefit evidence. A small supported benefit is sufficient when the response is correspondingly cheap, safe, and keeps persistent surface unchanged.
+8. **Authority**: Execute only changes already authorized; surface product, architecture, compatibility, or scope decisions to the user.
+
+Establish causal sufficiency before cost can favor a response. A required correction remains required regardless of cost; cost ranks its sufficient responses. Once a discretionary response passes the causal, durable-quality, and verification gates, low cost favors applying it when its observable benefit is positive and its maintenance, verification, and execution risk remain immaterial. When the best structural response lacks adequate verification, retain it as the preferred target, state the exact proof needed to make it safe, and explain the debt carried by any executable interim response.
+
+These gates constrain the decision, not the route used to reach it. They require no fixed number of alternatives, separate decision artifact, or edit for every finding.
+
+## Resolution Method
+
+### 1. Normalize the Findings
+
+Separate these elements before accepting any proposed fix, consolidating repeated evidence across findings:
+
+- the supplied finding identifier, or the shortest source label needed for traceability;
+- the reported problem;
+- the supporting evidence and confidence;
+- the observable or downstream effect;
+- the proposed fix, if any;
+- the governing outcome or contract it may affect.
+
+### 2. Form Problem Groups
+
+Group findings by shared cause or owner. Keep independent findings separate even when their suggested fixes look alike. Add unreported instances only when evidence shows the same underlying problem.
+
+Preserve supplied finding identifiers within each group. For every source finding, record whether its reported problem is confirmed, unsupported, or unresolved. The group-level response resolves the shared problem without replacing these source assessments.
+
+### 3. Classify the Owner
+
+Classify each problem group by the responsibility that owns the cause. When evidence supports more than one layer, retain the causal chain and evaluate the highest owner whose correction can remove the downstream failures.
+
+- **New mechanism**: the recently introduced mechanism creates its own inconsistency or duplicates an existing responsibility. Compare removing or simplifying it, redesigning it at the owner, and using the existing structure before considering patches inside it.
+- **Existing structure**: the pre-existing responsibility, contract, or decision is the cause. Compare correcting that structure alone, correcting it before adding the requested behavior, and changing its ownership when justified.
+- **Local unit**: one otherwise sound unit owns the entire problem. A local correction is eligible when no instance of the same causal failure remains.
+- **No confirmed defect**: evidence does not establish an outcome-relevant problem. Decline the finding when the available evidence is sufficient, or request the material evidence needed to resolve it. End candidate comparison for this group because no confirmed cause is available to resolve.
+
+This classification selects candidates; it does not predetermine the answer. Structural change must earn its place through durable quality and verification safety, just as a patch must account for the debt it retains.
+
+### 4. Compare Complete Candidates
+
+Before selecting a response, test it against applicable causal alternatives that could change the decision: subtraction, reuse, correction of an existing owner, structural change, and a bounded patch. Expand the comparison only when evidence makes an alternative decision-relevant.
+
+The resulting comparison must make clear:
+
+- which cause it resolves;
+- which concepts, responsibilities, or constraints it adds or removes;
+- what same-problem instances remain;
+- what evidence proves the changed boundary;
+- what compatibility or migration work it requires;
+- what debt and future change cost it retains.
+
+Exclude speculative alternatives that do not map to evidence. The goal is a sufficient decision, not an architecture exercise.
+
+### 5. Choose a Disposition
+
+Assign one disposition to each problem group:
+
+- **apply**: the problem or improvement is confirmed and the selected response passed all gates. A required correction is apply when a sufficient, safe response passes the gates; lifecycle cost ranks the eligible responses. A discretionary improvement is apply when its observable benefit exceeds its total change cost. The Authority gate separately determines whether to recommend or execute it;
+- **decline**: evidence establishes no outcome-relevant problem or observable quality benefit, the finding is outside the outcome boundary or reverses an exclusion, or a discretionary improvement's maintenance, verification, or execution cost equals or exceeds its supported benefit;
+- **evidence required**: a material unknown could change finding validity, ownership, response selection, or verification. Pause changes for that problem group, continue independent groups, and report the exact evidence needed, its source when known, the decision it controls, and the condition for resuming;
+- **user decision required**: the preferred response changes an approved outcome, architecture, compatibility promise, or scope boundary.
+
+If an interim patch is the only safely executable response, label it as interim, describe the retained structural problem, and present the enabling work for the preferred response. The user decides whether that tradeoff is worth taking.
+
+### 6. Execute and Verify
+
+When changes are authorized, implement the selected response at the responsible owner and verify the affected boundary described by the applicable reference. Re-evaluate the original problem groups after verification; completion requires their observable causes to be resolved or explicitly dispositioned.
+
+## Response Contract
+
+Report decisions by underlying problem group rather than by comment count:
+
+```text
+Problem:
+Findings grouped:
+  - <finding ID or source label>: confirmed | unsupported | unresolved
+Evidence: observed | inferred | unknown
+Cause and owner:
+Decision-changing alternatives considered:
+Recommendation and disposition:
+Authority: recommend only | execute selected response
+Why it wins in the decision order:
+Retained debt or required proof:
+Required evidence and resume condition, if any:
+User decision, if any:
+```
+
+Keep the report proportional. Omit fields that have no material content, but always preserve the problem/fix separation, the causal owner, the alternatives that could change the decision, and any user-owned tradeoff.
+
+## Completion Check
+
+- Every accepted finding maps to a confirmed underlying problem and material effect.
+- Every supplied finding identifier remains traceable to its source assessment and problem group.
+- Required corrections were identified before lifecycle comparison, and lifecycle cost selected among their sufficient responses.
+- Every discretionary apply names its observable benefit to the outcome, maintainability, execution precision, or decision integrity.
+- Apply, decline, reuse, and no change each have evidence at the gates that determine the response.
+- Reviewer-proposed fixes were evaluated as candidates rather than inherited as requirements.
+- Same-problem instances were grouped by cause, not by surface similarity.
+- Candidate selection followed the fixed decision order without using cost to skip causal or quality analysis.
+- Disposition and execution authority are explicit and separate.
+- Patches state the debt they retain; structural changes state the proof and migration safety they require.
+- Artifact-specific quality and verification criteria came from the matching reference.
+- Evidence-required groups remain unchanged until their named resume condition is satisfied; independent groups may continue.
+- Other unknowns and user-owned decisions are explicit.
+- Completion is measured against outcomes and resolved causes, not the number of findings changed.

--- a/.agents/skills/reviewee-judgment/agents/openai.yaml
+++ b/.agents/skills/reviewee-judgment/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Reviewee Judgment"
+  short_description: "Evaluate findings before changes"
+  default_prompt: "Use $reviewee-judgment to evaluate the received findings before deciding what work to perform."
+
+policy:
+  allow_implicit_invocation: true
+

--- a/.agents/skills/reviewee-judgment/references/code.md
+++ b/.agents/skills/reviewee-judgment/references/code.md
@@ -1,0 +1,60 @@
+# Code Review Findings
+
+## Quality Objective
+
+Optimize for maintainability at the responsibility that owns the behavior. A durable code response keeps contracts coherent, dependencies directional, state ownership clear, and future changes localized while preserving required behavior.
+
+## Evidence to Inspect
+
+Inspect only the paths needed to establish the cause and affected boundary:
+
+- the failing or questioned behavior and its callers;
+- the responsibility that owns the relevant rule or state;
+- public, serialized, persistent, generated, or integration contracts;
+- representative repository patterns with the same responsibility;
+- focused tests and broader regression evidence at changed boundaries;
+- migration, rollout, and rollback constraints when state or compatibility changes.
+
+Treat a reviewer's patch suggestion as evidence of intent, not repository authority.
+
+## Cause Tests
+
+Classify a code problem as structural when one or more observed failures originate from misplaced ownership, duplicated policy, contradictory contracts, invalid dependency direction, or an unnecessary abstraction. Similar functions or repeated syntax alone do not justify a shared abstraction.
+
+Classify it as local when the responsible unit and its contract remain sound after one bounded correction and no same-cause instance remains.
+
+For a newly introduced mechanism that produces internal contradictions, compare removing it, simplifying it, or routing the behavior through the existing owner. Patching each contradiction is eligible only when the mechanism itself remains the most maintainable owner.
+
+For a defective existing structure, compare:
+
+- refactoring the existing owner when that alone resolves the requested behavior;
+- refactoring it first and then adding the new behavior;
+- changing the responsibility or architecture when the current boundary cannot remain coherent;
+- a local or interim patch with its retained structural debt made explicit.
+
+## Candidate Comparison
+
+Compare code candidates using this sequence after the core outcome and validity gates:
+
+1. Does the change occur at the responsibility that owns the rule?
+2. Does it remove or reduce contradictory states, duplicated decisions, and parallel paths?
+3. Does it preserve or intentionally migrate external contracts?
+4. Does it localize the next likely change?
+5. Can the affected behavior, callers, data, and integration boundary be verified?
+6. Among candidates that satisfy the above, which has the best lifecycle value?
+
+A smaller diff is evidence of lower change volume, not evidence of better maintainability. A larger refactor is eligible when it is causally necessary and adequately protected.
+
+## Verification Safety
+
+Select proof from the changed boundary outward:
+
+- focused tests for the responsible rule;
+- contract or integration tests for changed consumers and providers;
+- migration checks for persisted or serialized state;
+- repository-required static, build, and regression checks.
+
+When current tests cannot protect a preferred structural change, identify the exact unprotected behavior and the proof needed. Keep the preferred response visible, compare the cost of adding that proof, and state what an interim patch leaves harder to maintain. Missing tests constrain safe execution; they do not convert a patch into the best design.
+
+Security, data-loss, and irreversible compatibility risks are hard safety boundaries. Escalate them even when the finding frames them as local cleanup.
+

--- a/.agents/skills/reviewee-judgment/references/prompt.md
+++ b/.agents/skills/reviewee-judgment/references/prompt.md
@@ -1,0 +1,53 @@
+# Prompt Review Findings
+
+## Quality Objective
+
+Optimize for reliable execution of the intended outcome across representative inputs. A durable prompt response keeps instructions coherent, places constraints at the boundary where they matter, preserves useful model freedom, and makes success observable.
+
+## Evidence to Inspect
+
+Inspect the complete instruction path that governs execution:
+
+- the requested outcome and user-owned decisions;
+- system, developer, skill, task, and generated instructions that reach the executor;
+- required inputs, outputs, consumers, and success evidence;
+- representative successful, failing, ambiguous, and boundary cases;
+- constraints that prevent material failure versus instructions that merely prescribe a route.
+
+When execution evidence is available, use it as the primary basis for prompt quality.
+
+## Cause Tests
+
+Group prompt findings when they share the same missing boundary, conflicting priority, undefined decision owner, hidden input, or unverifiable success condition. Similar phrases or the same proposed rewrite do not establish the same problem.
+
+Classify a problem as structural when instructions create contradictory priorities, distribute one decision across multiple authorities, or add procedural constraints that generate work without protecting the outcome.
+
+Classify it as local when one bounded instruction is ambiguous or incorrect and the surrounding priority, authority, and execution path remain coherent after correction.
+
+For a newly introduced instruction mechanism that creates inconsistency, compare removing it, consolidating it into the existing authority, or rewriting the governing boundary before adding more exceptions.
+
+For a defective existing prompt structure, compare correcting the existing authority alone, correcting it before adding new behavior, and moving the decision to the layer that has the required context.
+
+## Candidate Comparison
+
+Compare prompt candidates using this sequence after the core outcome and validity gates:
+
+1. Does the instruction live at the boundary that owns the decision?
+2. Are priorities, authority, and success conditions coherent across the full instruction path?
+3. Does it constrain the failure mode while leaving reversible execution choices flexible?
+4. Does it remove duplicated rules, exception chains, and work-generating procedure?
+5. Can representative executions distinguish success from plausible-looking failure?
+6. Among candidates that satisfy the above, which has the best lifecycle value?
+
+A short wording patch is sufficient only when the causal instruction structure remains sound. Additional detail is valuable only when it resolves outcome-relevant ambiguity, protects a material boundary, or supplies evidence needed by the executor.
+
+## Verification Safety
+
+Verify the changed instruction against representative execution paths rather than checking text presence alone. When execution is available, include a fresh run without conversational steering and the reported failure mode. Add these paths when they protect a decision-relevant boundary:
+
+- the ordinary successful path;
+- a same-problem variant with different surface wording;
+- a boundary case where the model should escalate, abstain, or preserve user authority;
+- downstream output shape and evidence required by the real consumer.
+
+When deterministic evaluation is unavailable, state the expected observable behavior, run the strongest representative checks available, and label residual uncertainty. Judge a prompt fixed from representative execution results that demonstrate the intended behavior. Treat completed textual edits as change evidence rather than execution evidence.

--- a/.agents/skills/reviewee-judgment/references/spec.md
+++ b/.agents/skills/reviewee-judgment/references/spec.md
@@ -1,0 +1,57 @@
+# Specification Review Findings
+
+## Quality Objective
+
+Optimize for decision integrity across downstream consumers. A durable specification response preserves the product outcome, makes decision ownership and exclusions explicit, maintains one authoritative source for each decision, and lets implementation proceed without guessing.
+
+This reference applies to requirements, PRDs, ADRs, design documents, UI specifications, work plans, task files, and other decision-carrying artifacts.
+
+## Evidence to Inspect
+
+Inspect the smallest decision chain that can establish the problem:
+
+- the governing requirement, approved decision, and explicit non-goals;
+- the artifact responsible for the disputed decision;
+- upstream sources and downstream artifacts or executors that consume it;
+- repository or product evidence cited by the decision;
+- acceptance, rollout, compatibility, and verification obligations.
+
+Document hierarchy is not automatic decision authority. Determine which artifact actually owns the decision under review.
+
+## Cause Tests
+
+Group specification findings when they share the same missing decision, contradictory source of truth, unowned tradeoff, invalid assumption, or broken downstream contract. Similar headings, wording, or template omissions alone do not establish the same problem.
+
+Classify a problem as structural when one decision is duplicated across artifacts, a downstream document silently changes an upstream outcome, or responsibilities between product, design, planning, and implementation are unclear.
+
+Classify it as local when one authoritative statement is incomplete or incorrect and correcting it restores a coherent downstream chain without moving the decision.
+
+For a newly introduced artifact or section that creates inconsistency, compare removing it, merging its unique decision into the existing authority, or redefining its consumer contract before adding cross-document patches.
+
+For a defective existing decision structure, compare correcting the authoritative source alone, propagating an intentional revision to consumers, and changing ownership when the current artifact lacks the evidence or authority to decide.
+
+## Candidate Comparison
+
+Compare specification candidates using this sequence after the core outcome and validity gates:
+
+1. Does the change occur in the artifact that owns the decision?
+2. Does it preserve or explicitly revise the approved outcome and exclusions?
+3. Does it eliminate conflicting sources of truth and hidden assumptions?
+4. Can downstream consumers execute without inventing product or architecture decisions?
+5. Can acceptance and verification evidence prove the revised decision chain?
+6. Among candidates that satisfy the above, which has the best lifecycle value?
+
+Adding another document or section is eligible only when it has a distinct durable consumer and decision responsibility. A local wording patch is sufficient only when no contradictory decision remains upstream or downstream.
+
+## Verification Safety
+
+Verify the changed decision from source to consumer:
+
+- trace each revised decision to its governing outcome and evidence;
+- inspect affected downstream artifacts for contradiction or stale assumptions;
+- confirm that acceptance criteria observe the intended result;
+- identify product, architecture, compatibility, or scope decisions that remain user-owned;
+- state unresolved evidence needs without filling them with plausible prose.
+
+When a broad rewrite is preferable but downstream impact is uncertain, name the affected consumers and the proof needed before propagation. If an interim clarification is used, state which conflicting authority or deferred decision remains.
+

--- a/.agents/skills/task-analyzer/references/skills-index.yaml
+++ b/.agents/skills/task-analyzer/references/skills-index.yaml
@@ -61,6 +61,28 @@ skills:
     references:
       - "references/frontend.md"
 
+  reviewee-judgment:
+    skill: "reviewee-judgment"
+    tags: [review-feedback, reviewee, findings, decision-making, root-cause, maintainability, prompt-quality, specification-quality, roi, over-implementation]
+    typical-use: "Evaluating received findings before they generate implementation or revision work"
+    size: medium
+    key-references:
+      - "Received review findings"
+      - "Governing outcome and contracts"
+      - "Artifact-specific verification evidence"
+    sections:
+      - "Purpose and Value"
+      - "Artifact Context"
+      - "Core Distinctions"
+      - "Decision Order"
+      - "Resolution Method"
+      - "Response Contract"
+      - "Completion Check"
+    references:
+      - "references/code.md"
+      - "references/prompt.md"
+      - "references/spec.md"
+
   documentation-criteria:
     skill: "documentation-criteria"
     tags: [documentation, decision-making, adr, prd, design-doc, ui-spec, work-plan, templates, planning, process, scale-assessment]

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Recipes load the repository-aware guidance required for the current task. You ra
 | `coding-rules` | Code quality, function design, error handling, refactoring |
 | `testing` | Proportionate TDD, observable proof selection, test integrity, and repository-required verification |
 | `ai-development-guide` | Evidence-backed root cause, proportionate impact analysis, and applicable quality assurance |
+| `reviewee-judgment` | Evidence-backed evaluation of received findings before they generate revision work |
 | `documentation-criteria` | Document creation rules and templates (PRD, ADR, Design Doc, Work Plan) |
 | `requirement-convergence` | Outcome, requirement layers, user-decided exclusions, and rough cost before design |
 | `implementation-approach` | Direct MVP, evidence-backed expansion, subtraction, slicing, and verification boundary |
@@ -331,6 +332,7 @@ your-project/
 │   ├── coding-rules/         # Foundational guidance
 │   ├── testing/
 │   ├── ai-development-guide/
+│   ├── reviewee-judgment/
 │   ├── documentation-criteria/
 │   ├── requirement-convergence/
 │   ├── implementation-approach/

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -152,8 +152,8 @@ function readUpdateHistory(sourceDir, installedVersion, targetVersion) {
           2
         );
       }
-      if (operation.type === "add" || operation.type === "delete") {
-        assertSafeRelativePath(operation.path, operation.type);
+      if (operation.type === "delete") {
+        assertSafeRelativePath(operation.path, "delete");
       } else if (operation.type === "move") {
         assertSafeRelativePath(operation.from, "move source");
         assertSafeRelativePath(operation.to, "move destination");
@@ -411,10 +411,6 @@ function planUpdate({ installation, installedHashes, version, files, changes }) 
 
   for (const change of changes) {
     for (const operation of change.operations) {
-      if (operation.type === "add") {
-        continue;
-      }
-
       if (operation.type === "delete") {
         const deleted = resolveHistoryPath(installation, operation.path);
         if (!deleted) continue;

--- a/bin/update-history.json
+++ b/bin/update-history.json
@@ -7,10 +7,6 @@
           "type": "move",
           "from": ".agents/skills/documentation-criteria/references/task-template.md",
           "to": ".agents/skills/llm-friendly-context/references/task-template.md"
-        },
-        {
-          "type": "add",
-          "path": ".agents/skills/subagents-orchestration-guide/references/review-resolution.md"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Task-oriented agentic coding framework for OpenAI Codex CLI — skills, recipes, and subagents for structured development workflows",
   "license": "MIT",
   "author": "Shinsuke Kagawa",

--- a/scripts/tests/cli.test.js
+++ b/scripts/tests/cli.test.js
@@ -264,24 +264,6 @@ test("preserves an untracked legacy move source and installs the current destina
   );
 });
 
-test("treats an add history entry for an already managed path as idempotent", () => {
-  const cwd = makeTemporaryDirectory("codex-workflows-project");
-  const managedPath = ".codex/agents/example.toml";
-  const packageFixture = createPackageFixture({
-    version: "2.0.0",
-    files: { [managedPath]: "package v2\n" },
-    changes: [
-      { version: "2.0.0", operations: [{ type: "add", path: managedPath }] },
-    ],
-  });
-  writeInstalledFixture({ cwd, version: "1.0.0", files: { [managedPath]: "package v1\n" } });
-
-  const result = runCli(["update"], { cwd, cliPath: packageFixture.cliPath });
-
-  assert.equal(result.status, 0, result.stderr);
-  assert.equal(fs.readFileSync(path.join(cwd, managedPath), "utf8"), "package v2\n");
-});
-
 test("moves a locally modified managed file to its current path without overwriting it", () => {
   const cwd = makeTemporaryDirectory("codex-workflows-project");
   const oldPath = ".agents/skills/example/old.md";
@@ -353,7 +335,7 @@ test("maps project history paths to user-scoped installation paths", () => {
   );
 });
 
-test("removes retired managed files and installs additions without touching unrelated files", () => {
+test("removes retired managed files and automatically installs additions without touching unrelated files", () => {
   const cwd = makeTemporaryDirectory("codex-workflows-project");
   const deletedPath = ".codex/agents/retired.toml";
   const addedPath = ".codex/agents/new.toml";
@@ -364,10 +346,7 @@ test("removes retired managed files and installs additions without touching unre
     changes: [
       {
         version: "2.0.0",
-        operations: [
-          { type: "delete", path: deletedPath },
-          { type: "add", path: addedPath },
-        ],
+        operations: [{ type: "delete", path: deletedPath }],
       },
     ],
   });


### PR DESCRIPTION
## Summary

- Add a portable `reviewee-judgment` skill that evaluates received findings before they generate implementation work.
- Separate reported problems from proposed fixes and compare responses through causal, quality, safety, lifecycle-value, and authority gates.
- Add artifact-specific guidance for code, prompts, and specifications, plus skill discovery metadata and README entries.
- Simplify update history to record moves and deletions while discovering new files automatically.
- Bump the package version from 1.0.4 to 1.1.0.

## Design

- Keep the skill self-contained and implicitly selectable so it also applies to reviews received outside recipe workflows.
- Treat required correctness fixes separately from discretionary improvements, while allowing cheap, safe improvements with observable value.
- Preserve existing user files: identical new paths are adopted, while differing content remains an update conflict.

## Verification

- `npm run check:skills-index`
- `npm test`
- `npm pack --dry-run`
- YAML and whitespace validation