### PR TITLE
Simplify workflow boundaries and review decisions

### DIFF
--- a/.agents/skills/documentation-criteria/SKILL.md
+++ b/.agents/skills/documentation-criteria/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation-criteria
-description: "Documentation creation criteria for PRD, ADR, Design Doc, UI Spec, and Work Plan with templates. Use when: creating or reviewing technical documents, determining which documents are required, or following document templates."
+description: "Determines which PRD, ADR, UI Spec, Design Doc, and Work Plan a change requires and where each document lives. Use when deciding documentation scope or creating or reviewing one of these artifacts."
 ---
 
 # Documentation Creation Criteria
@@ -43,7 +43,7 @@ A qualifying ADR decision point sets the floor at Medium because it creates a du
 
 ## ADR Creation Conditions
 
-Apply both filters in order for each technical topic within the confirmed implementation scope:
+First check accepted ADRs that govern the changed responsibility. Then apply both filters in order for each technical topic within the confirmed implementation scope:
 
 1. **Choice requires judgment** — current requirements, accepted decisions, and representative repository patterns support at least two credible materially distinct options whose selection requires comparison.
 2. **Decision is durable** — choosing among those options materially changes a responsibility, dependency direction, shared contract, persistence model, technology dependency, reversibility, or lifecycle cost that future work must understand or preserve.
@@ -61,55 +61,17 @@ Qualifying durable choices include:
 
 A local contract, data-flow, state, or component change that follows an accepted design, has one evident repository-supported implementation, or remains cheaply reversible belongs in the Design Doc. Counts of files, consumers, nesting levels, states, steps, and Structural Scale remain supporting evidence rather than ADR criteria.
 
-## Detailed Document Definitions
+## What Each Document Fixes
 
-### PRD (Product Requirements Document)
-**Purpose**: Define business requirements and user value
-**Scope**: Binding product requirements and non-binding Product Context. Binding content includes the converged outcome, MVP requirements, acceptance criteria with sequential IDs, and user-decided exclusions. Product Context may record business value, user value, UX evidence, success signals, and feasibility or rough-effort evidence as `user-provided`, `observed`, `inferred`, or `unknown`. Unknown context does not block implementation unless the user must decide it to define the outcome or an acceptance criterion. Technical implementation details belong in Design Doc, technical decision rationale in ADR, and implementation phases or task breakdown belong in Work Plan.
+Each document fixes one class of decision needed by its downstream consumer. The decision matrix determines whether the document is required; the applicable template defines its content.
 
-### ADR (Architecture Decision Record)
-**Purpose**: Record technical decision rationale and background
-**Scope**: One qualifying technical decision point, its credible alternatives, requirement and repository fit, current-scope benefit, lifecycle cost, maintainability, selected necessary-and-sufficient option, consequences, and reconsideration conditions. An ADR narrows the technical solution space; the confirmed requirements remain the product and implementation scope. Implementation procedures and code examples belong in Design Doc, while schedule and resource assignments belong in Work Plan.
-
-### UI Specification
-**Purpose**: Define UI structure, screen transitions, component decomposition, and interaction design
-**Scope**: Screen list and transitions, component state x display matrix, component decomposition, interaction definitions, AC traceability, existing component reuse map, visual acceptance criteria, and accessibility requirements only. Technical implementation and API contracts belong in Design Doc, test implementation belongs in generated test skeletons, and schedule belongs in Work Plan.
-
-### Design Document
-**Purpose**: Define technical implementation methods in detail
-**Scope**: Existing repository evidence, technical approach, applicable dependencies and constraints, interface and contract definitions, data flow, acceptance criteria, change surface, and verification strategy. Include deployment, migration, feature-flag, or measurement design only when it changes repository implementation or an acceptance criterion. External approval, production access, release execution, and organizational operation are context rather than implementation gates. Technology selection rationale belongs in ADR, schedule and assignments belong in Work Plan, and detailed test strategy or case selection belongs in generated test skeletons.
-
-**Required Structural Elements**:
-- Existing repository evidence that constrains implementation decisions
-- Technical approach and implementation approach decision
-- Change surface and applicable interface/contract definitions
-- Applicable standards with explicit/implicit classification
-- Verification Strategy
-  - Correctness proof method
-  - Early verification point
-  - Minimal form allowed for low-risk or self-evident changes: concise entries or explicit `N/A` with rationale
-    Low-risk: one reversible change following an existing pattern with no external contract, integration, or data-flow changes
-    Self-evident: internal-only refactoring with identical observable inputs and outputs
-
-### Work Plan
-**Purpose**: Implementation task management and progress tracking
-**Scope**: Repository implementation outcomes from approved Design Docs, task dependencies, source section and acceptance-criteria references, executable verification, optional task-level false-green focus, and progress tracking only. The Work Plan references governing documents instead of reproducing their design details.
-
-**Phase Division Criteria**:
-
-- Follow the implementation approach and dependency order selected by the Design Doc
-- Group implementation, tests, repository configuration, wiring, and documentation that reach the same observable verification point
-- Put the Design Doc's early verification point in the earliest applicable phase
-- Verify each task against its cited acceptance criteria
-
-## Creation Process [MANDATORY]
-
-**STEP 1**: **Problem Analysis** — Determine Structural Scale, applicable documents, and candidate technical decision points
-**STEP 2**: **ADR Choice Check when candidates exist** — Retain in-scope topics whose selection requires comparison between at least two credible materially distinct options and has durable impact
-**STEP 3**: **Creation** — Create each applicable document from its template; complete every qualifying ADR file before ADR review
-**STEP 4**: **Approval** — Review applicable artifacts and obtain user approval; supply the complete ADR path set to one review and one approval request
-
-**ENFORCEMENT**: Begin implementation when the documents required for the relevant scale are approved.
+| Document | Decision it fixes | Consumer and effect when missing |
+|----------|-------------------|----------------------------------|
+| PRD | Confirmed product outcome, requirements, acceptance criteria, and exclusions | Design and test selection would have to infer product scope |
+| ADR | One qualifying durable technical choice and the alternatives it resolves | Design and future changes could not distinguish an accepted decision from a local implementation choice |
+| UI Spec | Approved UI structure, states, interactions, and visual acceptance | Frontend design and implementation would have to infer user-interface decisions |
+| Design Doc | Repository-grounded implementation approach, contracts, change surface, and verification strategy | Planning and implementation would have to make technical design decisions locally |
+| Work Plan | Implementation outcome order, dependencies, and executable verification | Task decomposition and execution would have to choose sequencing and proof boundaries locally |
 
 ## Storage Locations
 
@@ -123,24 +85,3 @@ A local contract, data-flow, state, or component change that follows an accepted
 
 ## ADR Status
 `Proposed` -> `Accepted` -> `Deprecated`/`Superseded`/`Rejected`
-
-## AI Automation Rules [MANDATORY]
-- Apply the Choice filter before the Durability filter and independently from Structural Scale
-- Check existing ADRs that govern the changed responsibility
-- Create one ADR per decision point that passes both filters, then review the complete batch together
-
-## Diagram Requirements
-
-| Document | Required Diagrams | Purpose |
-|----------|------------------|---------|
-| PRD | User journey or scope boundary when prose does not make the relationship clear | Clarify a material experience or scope relationship |
-| ADR | Option comparison when option relationships are not clear in the table | Visualize trade-offs |
-| UI Spec | Screen transition or component tree when the material interaction or hierarchy remains unclear in prose/tables | Clarify screen flow and structure |
-| Design Doc | Architecture or data flow when the changed relationships are not clear in prose/tables | Understand technical structure |
-| Work Plan | Task dependency when order is not evident | Clarify implementation order |
-
-## Common ADR Relationships
-1. **At creation**: Identify common technical areas, reference existing common ADRs
-2. **When missing**: Consider creating necessary common ADRs
-3. **Design Doc**: Specify common ADRs in "Prerequisite ADRs" section
-4. **Compliance check**: Verify design aligns with common ADR decisions

--- a/.agents/skills/documentation-criteria/references/plan-template.md
+++ b/.agents/skills/documentation-criteria/references/plan-template.md
@@ -67,7 +67,3 @@ Use the implementation approach and dependency order from the Design Doc. Each p
 - [ ] Dependencies permit execution in the listed order
 - [ ] Verification is executable from repository artifacts or the task's own output
 - [ ] Task verification passes and the cited acceptance criteria are satisfied
-
-## Progress Notes
-
-[Record execution-relevant discoveries only when they change task order, scope, or verification.]

--- a/.agents/skills/recipe-design/SKILL.md
+++ b/.agents/skills/recipe-design/SKILL.md
@@ -123,7 +123,7 @@ Spawn document-reviewer agent: "Review the Design Doc for consistency, completen
 
 Route the result before consistency verification:
 - `approved`: continue
-- `approved_with_conditions` or `needs_revision`: apply Review Resolution with the creating technical-designer, then review the updated document
+- `needs_revision`: apply Review Resolution with the creating technical-designer, then review the updated document
 - `rejected`: apply Orchestrator Escalation Resolution. Continue after an evidence-based self-resolution; ask the user only when that procedure reaches a user-decision condition
 
 ### Step 7: Consistency Verification

--- a/.agents/skills/recipe-front-design/SKILL.md
+++ b/.agents/skills/recipe-front-design/SKILL.md
@@ -108,7 +108,7 @@ Spawn ui-analyzer agent: "Gather UI facts for frontend design. requirement_analy
 After UI fact gathering completes, create the UI Specification:
 - Spawn ui-spec-designer agent: "Create UI Spec [from PRD at [path] if PRD exists; read its binding requirements and only Product Context entries they explicitly cite]. Requirements: [original user requirements]. Confirmed scope and convergence exclusions: [Step 3 confirmed scope, nonGoals, and speculative requirements]. Codebase analysis: [JSON from codebase-analyzer]. UI analysis: [JSON from ui-analyzer]. [Prototype code is at [user-provided path]. Place prototype in docs/ui-spec/assets/{feature-name}/ | Prototype path unavailable; proceed from PRD/requirements and UI analysis.] External resource refs: [ui_analysis.externalResources.selectedRefs]."
 - Spawn document-reviewer agent: "doc_type: UISpec target: [ui-spec path] Review for consistency and completeness"
-- Resolve `approved_with_conditions` or `needs_revision` through Review Resolution with ui-spec-designer, then review the updated UI Spec. Route governing-source contradictions through Orchestrator Escalation Resolution before the user approval stop.
+- Resolve `needs_revision` through Review Resolution with ui-spec-designer, then review the updated UI Spec. Route governing-source contradictions through Orchestrator Escalation Resolution before the user approval stop.
 
 **[STOP -- BLOCKING]** Present UI Spec for user approval.
 **CANNOT proceed until user explicitly approves the UI Spec.**
@@ -124,7 +124,7 @@ Create appropriate design documents from confirmed scope and decision materials:
 - Spawn code-verifier agent: "Verify Design Doc against code. doc_type: design-doc. document_path: [document path]. verbose: false."
 - Apply Review Resolution to every code-verifier discrepancy. Pass only the `apply` discrepancies to technical-designer-frontend in update mode, rerun code-verifier, and carry the resolved verification summary, declines with reasons, and material limitations after the `apply` set becomes empty.
 - Review the Design Doc: Spawn document-reviewer agent: "Review the Design Doc for consistency, completeness, and adopted design validity. doc_type: DesignDoc. review_context: creation. target: [Design Doc path]. requirements_verbatim: [original user requirements]. confirmed_requirement_context: [complete confirmed requirement context from Step 3]. decision_materials: [only analysis material that constrains this design]. verification_resolution: [resolved code-verifier evidence]."
-- Resolve `approved_with_conditions` or `needs_revision` through Review Resolution with technical-designer-frontend, then review the updated Design Doc. Route governing-source contradictions through Orchestrator Escalation Resolution. Reach the user approval stop after review succeeds.
+- Resolve `needs_revision` through Review Resolution with technical-designer-frontend, then review the updated Design Doc. Route governing-source contradictions through Orchestrator Escalation Resolution. Reach the user approval stop after review succeeds.
 
 **[STOP -- BLOCKING]** Present the Design Doc and its recorded trade-offs, then obtain user approval.
 **CANNOT proceed until user explicitly approves the design document.**

--- a/.agents/skills/recipe-front-plan/SKILL.md
+++ b/.agents/skills/recipe-front-plan/SKILL.md
@@ -62,7 +62,7 @@ Spawn document-reviewer agent: "Review the frontend work plan. doc_type: WorkPla
 
 Branch on `verdict.decision`:
 - `approved` -> proceed to Step 5 with the plan-level status pending
-- `approved_with_conditions` or `needs_revision` -> apply Review Resolution with work-planner, then review the updated plan
+- `needs_revision` -> apply Review Resolution with work-planner, then review the updated plan
 - `rejected` -> apply Orchestrator Escalation Resolution using the cited governing sources
 
 ### Step 5: Plan Approval

--- a/.agents/skills/recipe-front-review/SKILL.md
+++ b/.agents/skills/recipe-front-review/SKILL.md
@@ -31,7 +31,7 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 ## Execution Flow
 
 ### 1. Prerequisite Check
-Identify the Design Doc in `docs/design/`. Resolve the review base from an explicitly supplied revision or the repository's default branch, and use its merge-base with `HEAD`. Derive `$STEP_1_FILES` as the paths changed from that base through the current repository state, including committed, staged, unstaged, and untracked changes, whose change implements or verifies the Design Doc. Exclude the governing documents and task or plan artifacts used by this recipe. If the review base cannot be resolved, request the exact base instead of silently narrowing the review to the working tree.
+Identify the Design Doc in `docs/design/`. Derive `$STEP_1_FILES` as the complete change set for the current work from repository history, tracking state, and the working tree. Include committed, staged, unstaged, and untracked paths, and pass the complete set unchanged to both reviewers.
 If a single active work plan is explicitly provided or unambiguously resolved for that Design Doc, read its `Review Scope` line. Otherwise set `Work Plan: none` and `Review Scope: none`; do not infer.
 
 **[STOP -- BLOCKING]** If no Design Doc or implementation files found, notify user and halt.
@@ -45,7 +45,7 @@ Spawn code-reviewer agent: "Validate Design Doc compliance for [design-doc-path]
 ### 3. Execute security-reviewer
 Spawn security-reviewer with `governingDocuments: [{type: "design-doc", path: [path]}]` and `implementationFiles: $STEP_1_FILES`.
 
-**Store output as**: `$STEP_3_OUTPUT` and `$STEP_1_FILES` (the initial file list)
+**Store output as**: `$STEP_3_OUTPUT`
 
 ### 4. Verdict and Response
 

--- a/.agents/skills/recipe-front-review/SKILL.md
+++ b/.agents/skills/recipe-front-review/SKILL.md
@@ -31,19 +31,19 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 ## Execution Flow
 
 ### 1. Prerequisite Check
-Identify the Design Doc in docs/design/ and check implementation files changed from the default branch (detect via `git symbolic-ref refs/remotes/origin/HEAD` or fall back to current branch diff).
+Identify the Design Doc in `docs/design/`. Resolve the review base from an explicitly supplied revision or the repository's default branch, and use its merge-base with `HEAD`. Derive `$STEP_1_FILES` as the paths changed from that base through the current repository state, including committed, staged, unstaged, and untracked changes, whose change implements or verifies the Design Doc. Exclude the governing documents and task or plan artifacts used by this recipe. If the review base cannot be resolved, request the exact base instead of silently narrowing the review to the working tree.
 If a single active work plan is explicitly provided or unambiguously resolved for that Design Doc, read its `Review Scope` line. Otherwise set `Work Plan: none` and `Review Scope: none`; do not infer.
 
 **[STOP -- BLOCKING]** If no Design Doc or implementation files found, notify user and halt.
 **CANNOT proceed without both a Design Doc and implementation files.**
 
 ### 2. Execute code-reviewer
-Spawn code-reviewer agent: "Validate Design Doc compliance for [design-doc-path]. Work Plan: [resolved work plan path or none]. Review Scope: [literal Review Scope value or none]. Implementation files: [git diff file list]. Review mode: full. Return structured JSON report per your Output Format specification."
+Spawn code-reviewer agent: "Validate Design Doc compliance for [design-doc-path]. Work Plan: [resolved work plan path or none]. Review Scope: [literal Review Scope value or none]. Implementation files: [$STEP_1_FILES]. Review mode: full. Return structured JSON report per your Output Format specification."
 
 **Store output as**: `$STEP_2_OUTPUT`
 
 ### 3. Execute security-reviewer
-Spawn security-reviewer with `governingDocuments: [{type: "design-doc", path: [path]}]` and `implementationFiles: [file list from git diff in Step 1]`.
+Spawn security-reviewer with `governingDocuments: [{type: "design-doc", path: [path]}]` and `implementationFiles: $STEP_1_FILES`.
 
 **Store output as**: `$STEP_3_OUTPUT` and `$STEP_1_FILES` (the initial file list)
 

--- a/.agents/skills/recipe-plan/SKILL.md
+++ b/.agents/skills/recipe-plan/SKILL.md
@@ -59,7 +59,7 @@ Spawn document-reviewer agent: "Review the work plan. doc_type: WorkPlan. target
 
 Branch on `verdict.decision`:
 - `approved` -> proceed to Step 5 with the plan-level status pending
-- `approved_with_conditions` or `needs_revision` -> apply Review Resolution with work-planner, then review the updated plan
+- `needs_revision` -> apply Review Resolution with work-planner, then review the updated plan
 - `rejected` -> apply Orchestrator Escalation Resolution using the cited governing sources
 
 ### Step 5: Plan Approval

--- a/.agents/skills/recipe-reverse-engineer/SKILL.md
+++ b/.agents/skills/recipe-reverse-engineer/SKILL.md
@@ -114,7 +114,7 @@ If `verdict.decision` is `rejected`, apply Orchestrator Escalation Resolution. C
 
 #### Unit Completion
 
-- [ ] `verdict.decision` is `approved` or `approved_with_conditions`
+- [ ] `verdict.decision` is `approved`
 - [ ] Human review passed (if enabled in Step 0)
 
 **Next**: Proceed to next unit. After all units -> Phase 2.
@@ -217,7 +217,7 @@ If `verdict.decision` is `rejected`, apply Orchestrator Escalation Resolution. C
 
 #### Unit Completion
 
-- [ ] `verdict.decision` is `approved` or `approved_with_conditions`
+- [ ] `verdict.decision` is `approved`
 - [ ] Human review passed (if enabled in Step 0)
 
 **Next**: Proceed to next unit. After all units -> Final Report.

--- a/.agents/skills/recipe-reverse-engineer/SKILL.md
+++ b/.agents/skills/recipe-reverse-engineer/SKILL.md
@@ -109,12 +109,11 @@ If `verdict.decision` is `rejected`, apply Orchestrator Escalation Resolution. C
 
 #### Step 5: Revision (conditional)
 
-- If `verdict.decision` is `approved_with_conditions` or `needs_revision`, apply Review Resolution with prd-creator, then retain the review of the updated artifact as the current review.
+- If `verdict.decision` is `needs_revision`, apply Review Resolution with prd-creator, then retain the review of the updated artifact as the current review.
 - After the applicable revision bullets complete, continue to Unit Completion.
 
 #### Unit Completion
 
-- [ ] `verdict.decision` is `approved`
 - [ ] Human review passed (if enabled in Step 0)
 
 **Next**: Proceed to next unit. After all units -> Phase 2.
@@ -212,12 +211,11 @@ If `verdict.decision` is `rejected`, apply Orchestrator Escalation Resolution. C
 
 #### Step 10: Revision (conditional)
 
-- If `verdict.decision` is `approved_with_conditions` or `needs_revision`, apply Review Resolution with technical-designer, then retain the review of the updated artifact as the current review.
+- If `verdict.decision` is `needs_revision`, apply Review Resolution with technical-designer, then retain the review of the updated artifact as the current review.
 - After the applicable revision bullets complete, continue to Unit Completion.
 
 #### Unit Completion
 
-- [ ] `verdict.decision` is `approved`
 - [ ] Human review passed (if enabled in Step 0)
 
 **Next**: Proceed to next unit. After all units -> Final Report.

--- a/.agents/skills/recipe-review/SKILL.md
+++ b/.agents/skills/recipe-review/SKILL.md
@@ -37,16 +37,16 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 ## Execution Flow
 
 ### Step 1: Prerequisite Check
-Identify Design Doc in docs/design/ and check implementation files via git diff.
+Identify the Design Doc in `docs/design/`. Resolve the review base from an explicitly supplied revision or the repository's default branch, and use its merge-base with `HEAD`. Derive `$STEP_1_FILES` as the paths changed from that base through the current repository state, including committed, staged, unstaged, and untracked changes, whose change implements or verifies the Design Doc. Exclude the governing documents and task or plan artifacts used by this recipe. If the review base cannot be resolved, request the exact base instead of silently narrowing the review to the working tree.
 If a single active work plan is explicitly provided or unambiguously resolved for that Design Doc, read its `Review Scope` line. Otherwise set `Work Plan: none` and `Review Scope: none`; do not infer.
 
 ### Step 2: Execute code-reviewer
-Spawn code-reviewer agent: "Validate Design Doc compliance for the implementation. Design Doc path: [path]. Work Plan: [resolved work plan path or none]. Review Scope: [literal Review Scope value or none]. Implementation files: [git diff file list]. Review mode: full. Return structured JSON report per your Output Format specification."
+Spawn code-reviewer agent: "Validate Design Doc compliance for the implementation. Design Doc path: [path]. Work Plan: [resolved work plan path or none]. Review Scope: [literal Review Scope value or none]. Implementation files: [$STEP_1_FILES]. Review mode: full. Return structured JSON report per your Output Format specification."
 
 **Store output as**: `$STEP_2_OUTPUT`
 
 ### Step 3: Execute security-reviewer
-Spawn security-reviewer with `governingDocuments: [{type: "design-doc", path: [path]}]` and `implementationFiles: [file list from git diff in Step 1]`.
+Spawn security-reviewer with `governingDocuments: [{type: "design-doc", path: [path]}]` and `implementationFiles: $STEP_1_FILES`.
 
 **Store output as**: `$STEP_3_OUTPUT` and `$STEP_1_FILES` (the initial file list)
 

--- a/.agents/skills/recipe-review/SKILL.md
+++ b/.agents/skills/recipe-review/SKILL.md
@@ -37,7 +37,7 @@ Design Doc (uses most recent if omitted): $ARGUMENTS
 ## Execution Flow
 
 ### Step 1: Prerequisite Check
-Identify the Design Doc in `docs/design/`. Resolve the review base from an explicitly supplied revision or the repository's default branch, and use its merge-base with `HEAD`. Derive `$STEP_1_FILES` as the paths changed from that base through the current repository state, including committed, staged, unstaged, and untracked changes, whose change implements or verifies the Design Doc. Exclude the governing documents and task or plan artifacts used by this recipe. If the review base cannot be resolved, request the exact base instead of silently narrowing the review to the working tree.
+Identify the Design Doc in `docs/design/`. Derive `$STEP_1_FILES` as the complete change set for the current work from repository history, tracking state, and the working tree. Include committed, staged, unstaged, and untracked paths, and pass the complete set unchanged to both reviewers.
 If a single active work plan is explicitly provided or unambiguously resolved for that Design Doc, read its `Review Scope` line. Otherwise set `Work Plan: none` and `Review Scope: none`; do not infer.
 
 ### Step 2: Execute code-reviewer
@@ -48,7 +48,7 @@ Spawn code-reviewer agent: "Validate Design Doc compliance for the implementatio
 ### Step 3: Execute security-reviewer
 Spawn security-reviewer with `governingDocuments: [{type: "design-doc", path: [path]}]` and `implementationFiles: $STEP_1_FILES`.
 
-**Store output as**: `$STEP_3_OUTPUT` and `$STEP_1_FILES` (the initial file list)
+**Store output as**: `$STEP_3_OUTPUT`
 
 ### Step 4: Verdict and Response
 

--- a/.agents/skills/recipe-update-doc/SKILL.md
+++ b/.agents/skills/recipe-update-doc/SKILL.md
@@ -129,7 +129,7 @@ For PRD updates, spawn document-reviewer with the target and `confirmed_requirem
 
 **On review result**:
 - `approved` -> proceed to Step 6
-- `approved_with_conditions` or `needs_revision` -> Apply Review Resolution with the update agent, then review the updated document
+- `needs_revision` -> Apply Review Resolution with the update agent, then review the updated document
 - `rejected` -> Apply Orchestrator Escalation Resolution. Continue after self-resolution; ask the user only when that procedure reaches a user-decision condition
 
 ### Step 6: Consistency Verification and Approval

--- a/.agents/skills/requirement-convergence/SKILL.md
+++ b/.agents/skills/requirement-convergence/SKILL.md
@@ -57,7 +57,7 @@ Persist `weak-but-explicit` outcome, requirements, and non-goals as open questio
 
 - [ ] Scope facts and inferences are distinguished
 - [ ] Every buildable requirement traces to the outcome
-- [ ] Every `nonGoals` item is user-decided or `userAgreedNone` is true
+- [ ] Every non-goal is user-decided, and an empty `nonGoals` list reflects the user's explicit choice of none
 - [ ] Cost is approximate and evidence-backed
 - [ ] Every field is `ready` or user-approved `weak-but-explicit`
 

--- a/.agents/skills/requirement-convergence/references/criteria.md
+++ b/.agents/skills/requirement-convergence/references/criteria.md
@@ -18,7 +18,7 @@ Ask when the layer is unclear. Treating all three as equally binding turns explo
 
 ## nonGoals[]
 
-Present cost and its unknowns before asking what to exclude. Record exclusions in the user's wording. Set `userAgreedNone` only when the user considered exclusions and chose none.
+Present cost and its unknowns before asking what to exclude. Record exclusions in the user's wording. Treat an empty `nonGoals` list as ready only when the user considered exclusions and chose none.
 
 An agent-proposed capability remains a question until the user accepts or excludes it. Only then does it enter the record as a user decision.
 

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -120,7 +120,6 @@ Use agent statuses as routing signals, not as a parser contract. Interpret the r
 | Status | Scope | Meaning | Next Action |
 |--------|-------|---------|-------------|
 | `approved` | Review/approval agents | All criteria met | Proceed to next phase |
-| `approved_with_conditions` | Document agents | Criteria met with minor open items | Resolve actionable conditions before the next approval point |
 | `needs_revision` | Review/approval agents | Significant issues repairable within approved repository scope | Resolve through the normal review or verifier-fix cycle |
 | `rejected` | Document agents | Fundamental problems | Apply Orchestrator Escalation Resolution |
 | `blocked` | Agents whose schema permits it | An agent-specific blocking condition prevents a usable result | Apply Orchestrator Escalation Resolution |
@@ -222,7 +221,7 @@ Flow rules:
 - Pass only codebase-analyzer material that changes reuse, option validity or selection, lifecycle cost, a preserved contract, design, or verification to the relevant ADR/Design Doc owner.
 - Pass a Design Doc path to `code-verifier`, apply Review Resolution to its discrepancies, and pass only resolved verification evidence to `document-reviewer`.
 - Fullstack layer sequencing is defined in `references/monorepo-flow.md`
-- Run WorkPlan review after every Medium/Large work plan creation or update and before batch approval. Resolve `needs_revision` or `approved_with_conditions` through Review Resolution with work-planner, then ask the user to approve the reviewed plan. Route governing-source contradictions through Orchestrator Escalation Resolution.
+- Run WorkPlan review after every Medium/Large work plan creation or update and before batch approval. Resolve `needs_revision` through Review Resolution with work-planner, then ask the user to approve the reviewed plan. Route governing-source contradictions through Orchestrator Escalation Resolution.
 
 ## Autonomous Execution Mode
 

--- a/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
+++ b/.agents/skills/subagents-orchestration-guide/references/monorepo-flow.md
@@ -119,7 +119,7 @@ After work-planner creates or updates the plan, spawn document-reviewer:
 
 > "Review the fullstack work plan. doc_type: WorkPlan. target: [work plan path]. Verify Design Doc and UI Spec implementation coverage, repository-only scope, cross-layer dependency order, executable verification, optional Verification Focus, and Review Scope."
 
-On `needs_revision` or `approved_with_conditions`, apply Review Resolution with work-planner and review the updated plan. Route governing-source contradictions through Orchestrator Escalation Resolution. Stop for batch approval after WorkPlan review succeeds; after explicit user approval, record the plan-level status as approved.
+On `needs_revision`, apply Review Resolution with work-planner and review the updated plan. Route governing-source contradictions through Orchestrator Escalation Resolution. Stop for batch approval after WorkPlan review succeeds; after explicit user approval, record the plan-level status as approved.
 
 ## Task Decomposition Phase
 

--- a/.agents/skills/subagents-orchestration-guide/references/review-resolution.md
+++ b/.agents/skills/subagents-orchestration-guide/references/review-resolution.md
@@ -16,7 +16,7 @@ For `apply`, pass the complete finding or discrepancy unchanged with its disposi
 
 ## 2. Revise and Reconsider
 
-Invoke the responsible author when at least one `apply` finding or discrepancy exists, and pass only the `apply` findings or discrepancies. Then rerun the same reviewer or verifier with the changed artifact and the declined reasons as prior feedback. An empty `apply` set proceeds directly to the next workflow step.
+Invoke the responsible author when at least one `apply` finding or discrepancy exists, and pass only the `apply` findings or discrepancies. Then rerun the same reviewer or verifier with its original inputs and the changed artifact or implementation. When that agent accepts `prior_feedback`, include the applied corrections and declined reasons; otherwise keep the dispositions in the active workflow context for orchestrator reassessment. An empty `apply` set proceeds directly to the next workflow step.
 
 The reviewer withdraws a declined finding when the reason is consistent with governing evidence. It may maintain the finding when existing or newly observed governing evidence still shows the result is incorrect, non-executable, or non-verifiable. A maintained non-blocking recommendation does not prevent progression.
 

--- a/.agents/skills/task-analyzer/references/skills-index.yaml
+++ b/.agents/skills/task-analyzer/references/skills-index.yaml
@@ -86,7 +86,7 @@ skills:
   documentation-criteria:
     skill: "documentation-criteria"
     tags: [documentation, decision-making, adr, prd, design-doc, ui-spec, work-plan, templates, planning, process, scale-assessment]
-    typical-use: "Scale assessment at implementation start, document creation criteria, ADR/PRD/Design Doc/Work Plan creation standards"
+    typical-use: "Scale assessment, document routing, and template selection for PRD, ADR, UI Spec, Design Doc, and Work Plan"
     size: medium
     key-references:
       - "ADR Method - Michael Nygard"
@@ -97,13 +97,9 @@ skills:
       - "Creation Decision Matrix [MANDATORY]"
       - "Structural Scale"
       - "ADR Creation Conditions"
-      - "Detailed Document Definitions"
-      - "Creation Process [MANDATORY]"
+      - "What Each Document Fixes"
       - "Storage Locations"
       - "ADR Status"
-      - "AI Automation Rules [MANDATORY]"
-      - "Diagram Requirements"
-      - "Common ADR Relationships"
     references:
       - "references/prd-template.md"
       - "references/adr-template.md"

--- a/.codex/agents/document-reviewer.toml
+++ b/.codex/agents/document-reviewer.toml
@@ -103,7 +103,6 @@ When `prior_feedback` contains an orchestrator decline, withdraw the finding whe
 ## Decision
 
 - `approved`: no blocking issue remains; recommendations may still be reported.
-- `approved_with_conditions`: a small actionable correction is needed before user approval but does not change approved scope or a major decision.
 - `needs_revision`: one or more blocking issues can be repaired within approved scope.
 - `rejected`: governing sources conflict or repair requires changing an approved product or major design decision.
 
@@ -114,7 +113,7 @@ The reviewer recommends; the user owns PRD, ADR, UI Spec, and Design Doc approva
 Return one JSON object:
 
 ```json
-{"metadata":{"docType":"DesignDoc|ADRBatch","targets":["docs/design/example.md"]},"verdict":{"decision":"approved|approved_with_conditions|needs_revision|rejected"},"issues":[{"id":"I001","severity":"critical|important|suggestion","target":"artifact path","location":"section or line","description":"specific issue","basis":"governing source or observed fact","expectedEffect":"observable effect of correction","blocking":true,"suggestion":"smallest sufficient correction"}],"recommendations":["non-blocking item"]}
+{"metadata":{"docType":"DesignDoc|ADRBatch","targets":["docs/design/example.md"]},"verdict":{"decision":"approved|needs_revision|rejected"},"issues":[{"id":"I001","severity":"critical|important|suggestion","target":"artifact path","location":"section or line","description":"specific issue","basis":"governing source or observed fact","expectedEffect":"observable effect of correction","blocking":true,"suggestion":"smallest sufficient correction"}],"recommendations":["non-blocking item"]}
 ```
 
 Use an empty `issues` array when none remain. Accept equivalent wording when the artifact and evidence make the result observable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Codex CLI workflows that keep larger software changes within the approved scope, from planning through review",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

- simplify documentation guidance around the decisions each artifact owns
- remove the redundant approved_with_conditions review state and rely on Review Resolution for actionable findings
- collect the complete current-work change set for compliance and security review without prescribing a Git route
- bump the package version to 1.1.1

## Validation

- npm run check:skills-index
- npm test
- npm pack --dry-run
- git diff --check origin/main