### PR TITLE
docs: add multilingual README translations

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,423 @@
+# codex-workflows
+
+[![Codex CLI](https://img.shields.io/badge/Codex%20CLI-Compatible-10a37f)](https://developers.openai.com/codex/cli)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-Compatible-blue)](https://developers.openai.com/codex/skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | **Español** | [한국어](README.ko.md) | [Português (Brasil)](README.pt-BR.md)
+
+En trabajos de producto grandes, Codex puede perseguir una coherencia técnica que va más allá de lo que el usuario necesita. Cubrir hasta el último caso límite y forzar un resultado determinista en cada camino puede acabar cambiando lo que ve el usuario, aunque el resultado acordado no lo requiera.
+
+codex-workflows mantiene el trabajo dentro del resultado mínimo aprobado. Primero deja claro qué comportamiento visible puede cambiar y qué debe permanecer intacto; después exige pruebas antes de dar el trabajo por terminado. Dentro de esos límites, Codex elige detalles de implementación reversibles a partir de lo que ya existe en el repositorio.
+
+Los flujos se instalan como Agent Skills y agentes personalizados para [OpenAI Codex CLI](https://developers.openai.com/codex/cli). La sesión principal de Codex confirma el alcance y el coste aproximado antes de diseñar, se hace cargo del avance y de las decisiones de revisión, y lleva el trabajo aprobado desde la implementación hasta una verificación independiente.
+
+---
+
+## ¿Por qué no usar Codex directamente?
+
+Codex por sí solo es la mejor opción para una corrección bien acotada, un experimento desechable o un script puntual. Cuando el resultado esperado y el límite seguro de implementación ya están claros, es más rápido y económico.
+
+Usa codex-workflows cuando una decisión técnica pueda ampliar el producto, alterar el comportamiento visible o deba conservarse al cambiar de contexto.
+
+Por ejemplo, una petición para ampliar un flujo de autenticación existente puede desembocar en un segundo mecanismo —técnicamente más limpio—, más validaciones y un contrato de respuesta nuevo. El frontend puede adaptarse y todas las pruebas pueden pasar, pero el usuario termina recibiendo un comportamiento que nunca se aprobó.
+
+codex-workflows evita que el alcance crezca sin control durante toda la ejecución:
+
+| Control | Qué cambia |
+|---|---|
+| Alcance | El flujo contrasta la petición con el resultado deseado, las exclusiones expresas, el código existente y el coste aproximado. Lo que no justifica su coste se descarta antes de convertirse en arquitectura. |
+| Controles entre fases | Los requisitos, el diseño y el plan se revisan antes de autorizar la siguiente fase. Los agentes nuevos leen las decisiones aprobadas y la evidencia que necesitan, en vez de reconstruir la intención a partir de una conversación larga. |
+| Ejecución | Una vez aprobado el alcance de implementación, Codex ejecuta el conjunto de tareas de forma autónoma. Cada tarea supera su verificación específica y las comprobaciones aplicables del repositorio antes del commit de implementación. |
+| Finalización | Revisiones independientes de código y seguridad inspeccionan el cambio completo. Las correcciones obligatorias vuelven al mismo ciclo de implementación y calidad; las mejoras opcionales pueden descartarse si hay argumentos para hacerlo. |
+
+Este flujo requiere más llamadas a agentes y más tokens que una ejecución directa. Úsalo cuando proteger el resultado acordado compense ese coste.
+
+Un caso límite no exige trabajo solo porque Codex sepa resolverlo. Añadir validaciones, hacer determinista un comportamiento o crear otra abstracción debe servir para proteger un requisito aprobado o un contrato observable, o para corregir un fallo demostrado.
+
+### Un caso real
+
+La [integración del proveedor BytePlus Seedream en mcp-image](https://github.com/shinpr/mcp-image/pull/114) añadió un tercer proveedor externo de imágenes en 18 archivos. Ocho tareas planificadas permitieron evolucionar la implementación específica del proveedor sin modificar los contratos públicos de solicitud MCP, cliente, guardado de archivos ni URI de archivo.
+
+Antes del merge, una evaluación contra el servicio real fijó el enrutamiento final de modelos, los límites del prompt, el timeout y el tratamiento de respuestas. Las revisiones independientes también detectaron una lectura de archivos sin límite, una vía para saltarse la validación, una ruta FIFO bloqueante y una normalización incoherente de claves API. Se corrigieron los cuatro problemas y el PR superó 303 pruebas repartidas en 19 archivos, además de una llamada real al proveedor sin reintentos. Los contratos públicos aprobados se mantuvieron intactos durante las ocho tareas y las cuatro correcciones.
+
+---
+
+## Inicio rápido
+
+Necesitas Node.js 22 o posterior y la última versión de [Codex CLI](https://developers.openai.com/codex/cli).
+
+### Instalar y ejecutar
+
+```bash
+cd your-project
+npx codex-workflows install
+```
+
+Después, invoca un flujo desde Codex CLI:
+
+```
+$recipe-implement Añade autenticación de usuarios con JWT
+```
+
+El prefijo `$` invoca una skill de forma explícita. Escribe `$recipe-` para ver los flujos disponibles.
+
+### Elige el punto de entrada
+
+| ¿Qué necesitas? | Empieza por |
+|---|---|
+| Entregar de principio a fin un cambio de backend, API, CLI o de propósito general | `$recipe-implement` |
+| Diseñar ahora e implementar más adelante | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
+| Diseñar y construir un frontend web con React / TypeScript | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
+| Entregar juntos un cambio de backend y otro de frontend React | `$recipe-fullstack-implement` |
+| Revisar una implementación frente a su diseño | `$recipe-review` o `$recipe-front-review` |
+| Investigar un problema sin tocar el código | `$recipe-diagnose` |
+| Hacer un experimento desechable o un script puntual | Usa Codex directamente |
+
+---
+
+## Cómo funciona
+
+```mermaid
+flowchart LR
+    A[Petición] --> B[Acordar el resultado mínimo útil]
+    B --> C{¿Hay una vía de implementación clara?}
+    C -->|Sí| S[Ciclo directo de tareas y revisión de seguridad]
+    S --> L[Finalizado]
+    C -->|No| D[Inspección, diseño y revisión]
+    D --> E[Planificar el trabajo dependiente]
+    E --> F[Aprobar el alcance de implementación]
+    F --> H[Por tarea: implementar, verificar, comprobar calidad y hacer commit]
+    H --> K[Verificación independiente de código y seguridad]
+    K -->|Corrección| H
+    K -->|Cambian los requisitos o el diseño principal| B
+    K -->|Aprobado| L[Finalizado]
+```
+
+La ruta depende del número de decisiones independientes de producto y diseño, no de cuántos archivos cambien ni de cuántos casos límite sea capaz de encontrar Codex.
+
+| Tamaño | Qué necesita el cambio | Qué ocurre |
+|--------|------------------------|-----------|
+| Pequeño | Un resultado que sigue un patrón existente en una parte del sistema | Tarea confirmada → implementación → controles de calidad y seguridad |
+| Mediano | Un resultado que exige coordinar varias partes del sistema o tomar una decisión de diseño duradera | Design Doc revisado, más UI Spec / ADR si corresponde → verificación de integración/E2E seleccionada → Work Plan revisado → ciclos autónomos de tareas → verificación final |
+| Grande | Varios resultados que requieren decisiones de diseño independientes | PRD y Design Docs revisados, más UI Spec / ADR si corresponde → verificación de integración/E2E seleccionada → Work Plan revisado → ciclos autónomos de tareas → verificación final |
+
+Solo se crea un ADR para una decisión duradera dentro del alcance actual cuando existen al menos dos opciones materialmente distintas. Si hay varias decisiones que cumplen estas condiciones, sus ADR se revisan en conjunto. Una prueba de integración o E2E solo se elige cuando otra prueba más barata no puede demostrar la interacción necesaria. Hay cambios que no necesitan ninguna de las dos cosas.
+
+Únicamente las decisiones que afectan al producto o a la implementación del repositorio pasan a documentos permanentes del proyecto. La aprobación de terceros, el acceso a producción, la ejecución de una release y otras tareas operativas ajenas no se convierten en bloqueos de implementación.
+
+Tras aprobar el alcance, el orquestador ejecuta las tareas, sus verificaciones específicas, los controles aplicables del repositorio y un commit de implementación por tarea. Primero resuelve los problemas a partir de los documentos aprobados y de las pruebas del repositorio. El comportamiento visible sigue siendo una frontera de producto: la implementación no puede ajustarlo por su cuenta para lograr coherencia interna. El orquestador solo consulta al usuario cuando avanzar exige un requisito de producto nuevo, cambiar una decisión principal ya aprobada, usar una autorización que solo posee el usuario o realizar una acción irreversible que no se autorizó.
+
+Los agentes especialistas reciben exactamente los documentos y las rutas que necesitan. Aportan evidencia concreta, pero no tienen autoridad para ampliar el resultado aprobado.
+
+### Cómo se conservan las decisiones al cambiar de contexto
+
+Separar los contextos evita que exploración, diseño, implementación y revisión compartan supuestos de forma implícita. La [plantilla de Work Plan](.agents/skills/documentation-criteria/references/plan-template.md) incluida enlaza cada tarea de implementación con su sección del Design Doc y sus criterios de aceptación:
+
+```markdown
+### P1-T1: Conservar el contrato de respuestas de error
+
+- **Fuente**: `docs/design/example-design.md`, contrato de API, AC-2
+- **Alcance**: Actualizar la implementación del repositorio y sus pruebas específicas
+- **Dependencias**: ninguna
+- **Verificación**: Ejecutar la prueba de contrato y comprobar la estructura de respuesta documentada
+```
+
+El [Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md) lleva a la implementación la fuente, el resultado esperado, los archivos afectados y una verificación ejecutable. Solo añade un `Verification Focus` cuando una prueba podría pasar sin demostrar un comportamiento importante. Tras ejecutar la tarea, se aplican al cambio completo todos los controles pertinentes del repositorio antes del commit. Los revisores finales comparan el código terminado con los documentos aprobados y repiten la revisión después de las correcciones aceptadas.
+
+---
+
+## Instalación
+
+### Requisitos
+
+- [Codex CLI](https://developers.openai.com/codex/cli) (última versión)
+- Node.js >= 22
+
+### Instalar
+
+Instala los flujos en el proyecto actual:
+
+```bash
+cd your-project
+npx codex-workflows install
+```
+
+Se copiarán estos elementos al proyecto:
+
+- `.agents/skills/`: skills de Codex (fundamentos y flujos)
+- `.codex/agents/`: definiciones TOML de subagentes
+- Un manifiesto para controlar los archivos gestionados
+
+Para que los flujos estén disponibles en todos tus proyectos, instálalos en el `CODEX_HOME` del usuario:
+
+```bash
+npx codex-workflows install --user
+```
+
+Las skills se instalan en `$CODEX_HOME/skills/` y los agentes en `$CODEX_HOME/agents/`. Si `CODEX_HOME` no está definido, se usa `~/.codex`.
+
+### Actualizar
+
+```bash
+# Previsualizar los cambios
+npx codex-workflows update --dry-run
+
+# Aplicar la actualización
+npx codex-workflows update
+
+# Actualizar una instalación de usuario
+npx codex-workflows update --user
+```
+
+El actualizador conserva los archivos que hayas modificado localmente. Compara cada archivo con su hash en el momento de la instalación y omite los que hayan cambiado. El historial de actualizaciones versionado aplica en orden los movimientos y eliminaciones, de modo que los cambios locales siguen a un archivo trasladado hasta su ruta actual. Los archivos modificados que se retiran sin sustituto se mueven a `.codex-workflows-preserved/<version>/`. Los archivos nuevos se añaden automáticamente.
+
+```bash
+# Consultar la versión instalada
+npx codex-workflows status
+
+# Consultar una instalación de usuario
+npx codex-workflows status --user
+```
+
+---
+
+## Referencia de flujos
+
+Invoca un flujo con `$recipe-name` en Codex. Escribe `$recipe-` y usa el autocompletado con Tab para ver todas las opciones.
+
+<details>
+<summary>Ver todos los puntos de entrada</summary>
+
+### Backend y uso general
+
+| Flujo | Qué hace | Cuándo usarlo |
+|-------|----------|---------------|
+| `$recipe-implement` | Ciclo completo con selección de capa (backend/frontend/fullstack) | Funcionalidades nuevas (entrada universal) |
+| `$recipe-task` | Una sola tarea con selección de reglas | Correcciones y cambios pequeños |
+| `$recipe-design` | Requisitos → documentos de producto y diseño según el tamaño | Diseño de producto y arquitectura |
+| `$recipe-plan` | Design Doc → esqueletos selectivos de integración/E2E → Work Plan | Planificación desde un Design Doc aprobado |
+| `$recipe-prepare-implementation` | Prepara las herramientas locales ya existentes que necesita un Work Plan aprobado | Petición expresa de preparación o capacidad necesaria no disponible |
+| `$recipe-build` | Ejecuta tareas de backend con validación entre pasos | Retomar una implementación de backend |
+| `$recipe-review` | Verifica el Design Doc y la seguridad, con correcciones aprobadas opcionales | Revisión tras implementar |
+| `$recipe-diagnose` | Investigación → verificación del punto de fallo → solución | Investigación de errores |
+| `$recipe-reverse-engineer` | Genera PRD y Design Docs a partir del código existente | Documentar sistemas heredados |
+| `$recipe-add-integration-tests` | Añade pruebas de integración/E2E a partir del Design Doc | Mejorar la cobertura del código existente |
+| `$recipe-update-doc` | Actualiza y revisa un Design Doc / PRD / ADR existente | Cambios de especificación y mantenimiento documental |
+
+### Frontend (React/TypeScript)
+
+| Flujo | Qué hace | Cuándo usarlo |
+|-------|----------|---------------|
+| `$recipe-front-design` | Requisitos → documentos de UI y diseño según el tamaño | Diseño de producto y arquitectura frontend |
+| `$recipe-front-adjust` | Ajuste acotado de UI con pruebas del repositorio, material aportado o fuentes externas necesarias | Cambios puntuales de UI después de implementar |
+| `$recipe-front-plan` | Design Doc frontend → esqueletos selectivos de integración/E2E → Work Plan | Planificación frontend |
+| `$recipe-front-build` | Ejecuta tareas frontend con verificación específica y controles de calidad | Retomar una implementación frontend |
+| `$recipe-front-review` | Verifica cumplimiento y seguridad frontend, con correcciones React aprobadas opcionales | Revisión frontend posterior a la implementación |
+
+### Fullstack (entre capas)
+
+| Flujo | Qué hace | Cuándo usarlo |
+|-------|----------|---------------|
+| `$recipe-fullstack-implement` | Ciclo completo con un Design Doc separado por capa | Funcionalidades que cruzan capas |
+| `$recipe-fullstack-build` | Ejecuta tareas asignando agentes según la capa | Retomar una implementación fullstack |
+
+</details>
+
+## Estado de trabajo
+
+Los flujos usan `docs/plans/` como estado temporal para Work Plans, Task Files de implementación y Task Files provisionales de corrección o ampliación de pruebas. El avance de tareas y fases se actualiza allí después de cada commit de implementación aprobado por calidad, pero esos archivos de estado no entran en el commit. Añade el directorio al `.gitignore` del proyecto, salvo que el equipo quiera revisar expresamente esos archivos transitorios:
+
+```gitignore
+docs/plans/
+```
+
+Los PRD, ADR, UI Spec y Design Docs son documentación permanente del proyecto y sí deben incluirse en los commits.
+
+---
+
+## Orientaciones incluidas
+
+Cada flujo carga las reglas adaptadas al repositorio que necesita la tarea actual. Rara vez tendrás que elegir estas skills a mano.
+
+<details>
+<summary>Ver skills fundamentales</summary>
+
+| Skill | Qué aporta |
+|-------|------------|
+| `coding-rules` | Calidad de código, diseño de funciones, gestión de errores y refactorización |
+| `testing` | TDD ajustado al alcance, selección de verificaciones observables, integridad de tests y verificaciones exigidas por el repositorio |
+| `ai-development-guide` | Causa raíz respaldada por evidencia, análisis del impacto ajustado al alcance y control de calidad aplicable |
+| `reviewee-judgment` | Evaluación basada en pruebas antes de convertir observaciones de revisión en trabajo |
+| `documentation-criteria` | Reglas y plantillas para PRD, ADR, Design Doc y Work Plan |
+| `requirement-convergence` | Resultado, capas de requisitos, exclusiones decididas por el usuario y coste aproximado antes del diseño |
+| `implementation-approach` | MVP directo, ampliación justificada, recorte, división y frontera de verificación |
+| `integration-e2e-testing` | Selección y diseño exclusivo de pruebas de integración/E2E que demuestran una interacción real necesaria |
+| `external-resource-context` | Consulta acotada de una fuente externa necesaria para una decisión concreta |
+| `llm-friendly-context` | Contexto claro para los agentes que lo usarán después: prompts, traspasos, artefactos generados, Task Files y observaciones de revisión |
+| `task-analyzer` | Análisis de intención, clasificación de tareas y selección de skills |
+| `subagents-orchestration-guide` | Coordinación multiagente, gestión de flujos y ejecución autónoma guiada |
+
+También se incluyen referencias para TypeScript de frontend web, incluidas aplicaciones React (`coding-rules/references/typescript.md` y `testing/references/typescript.md`). No se aplican a TypeScript de backend.
+
+</details>
+
+---
+
+## Agentes especializados
+
+Codex crea estos agentes cuando un flujo los necesita. No hace falta aprender sus funciones de antemano: los flujos derivan cada trabajo al especialista adecuado y el orquestador mantiene el control general. Cada agente trabaja en su propio contexto, con instrucciones especializadas y las skills obligatorias nombradas de forma explícita.
+
+<details>
+<summary>Ver todos los agentes especializados</summary>
+
+### Agentes de documentación
+
+| Agente | Función |
+|--------|---------|
+| `requirement-analyzer` | Resume las señales de la petición y las pruebas del repositorio necesarias para decidir alcance y coste |
+| `prd-creator` | Crea y estructura PRD |
+| `technical-designer` | Crea un lote completo de ADR o un Design Doc (backend/general) |
+| `technical-designer-frontend` | Crea un lote completo de ADR o un Design Doc frontend (React) |
+| `ui-spec-designer` | Genera una UI Specification a partir del PRD y, opcionalmente, código de prototipo |
+| `codebase-analyzer` | Recopila evidencia concisa del repositorio para elegir opciones, diseñar lo mínimo y verificar |
+| `ui-analyzer` | Recoge hechos sobre la UI desde recursos externos (herramientas de diseño, documentación del sistema de diseño e interfaces desplegadas) y código frontend |
+| `work-planner` | Crea el Work Plan a partir de Design Docs |
+| `document-reviewer` | Revisa documentos frente a los requisitos y decisiones de diseño que los gobiernan |
+| `design-sync` | Comprueba la coherencia entre documentos |
+
+### Agentes de implementación
+
+| Agente | Función |
+|--------|---------|
+| `task-decomposer` | Convierte el Work Plan en el menor número de Task Files ejecutables |
+| `task-executor` | Implementa Task Files con verificación específica (backend) |
+| `task-executor-frontend` | Implementa React con la verificación RTL de comportamiento aplicable |
+| `quality-fixer` | Ejecuta los controles aplicables del repositorio y corrige problemas de calidad dentro del alcance (backend) |
+| `quality-fixer-frontend` | Ejecuta y corrige controles aplicables de React, TypeScript, RTL y bundle |
+| `acceptance-test-generator` | Genera esqueletos de las pruebas de integración/E2E seleccionadas |
+| `integration-test-reviewer` | Revisa la calidad de las pruebas |
+
+### Agentes de análisis
+
+| Agente | Función |
+|--------|---------|
+| `code-reviewer` | Valida el cumplimiento del Design Doc |
+| `code-verifier` | Comprueba la coherencia entre documentos y código |
+| `security-reviewer` | Revisa la seguridad después de implementar |
+| `rule-advisor` | Elige skills para tareas independientes no cubiertas por un flujo |
+| `scope-discoverer` | Descubre el alcance del código para documentación inversa y agrupa unidades de PRD |
+
+### Agentes de diagnóstico
+
+| Agente | Función |
+|--------|---------|
+| `investigator` | Recopila evidencia, traza rutas y localiza puntos de fallo |
+| `verifier` | Valida la cobertura de rutas y evalúa los fallos de forma independiente |
+| `solver` | Deriva soluciones y analiza sus trade-offs |
+
+</details>
+
+---
+
+## Estructura del proyecto
+
+Después de la instalación, el proyecto contiene:
+
+<details>
+<summary>Ver la estructura instalada</summary>
+
+```
+your-project/
+├── .agents/skills/           # Skills de Codex
+│   ├── coding-rules/         # Criterios fundamentales
+│   ├── testing/
+│   ├── ai-development-guide/
+│   ├── reviewee-judgment/
+│   ├── documentation-criteria/
+│   ├── requirement-convergence/
+│   ├── implementation-approach/
+│   ├── integration-e2e-testing/
+│   ├── external-resource-context/
+│   ├── llm-friendly-context/
+│   ├── task-analyzer/
+│   ├── subagents-orchestration-guide/
+│   └── recipe-*/             # Puntos de entrada ($recipe-*)
+├── .codex/agents/            # Definiciones TOML de subagentes
+│   ├── requirement-analyzer.toml
+│   ├── technical-designer.toml
+│   ├── ui-analyzer.toml
+│   ├── task-executor.toml
+│   └── ... (25 agentes en total)
+└── docs/                     # Se crea al usar los flujos
+    ├── prd/
+    ├── design/
+    ├── adr/
+    ├── ui-spec/
+    └── plans/
+        └── tasks/
+```
+
+</details>
+
+---
+
+## Herramientas relacionadas
+
+Si los requisitos ya están en Linear o en un PRD, [linear-prism](https://github.com/shinpr/linear-prism) puede leer el código, dividirlos en tareas listas para implementar, hacer explícitas sus dependencias y conservar las fronteras del Design Doc.
+
+Esas tareas pueden pasarse a `$recipe-design` para entrar en la fase de diseño con el alcance más claro y una mejor visión del trabajo.
+
+---
+
+## Preguntas frecuentes
+
+**P: ¿Con qué modelos funciona?**
+
+R: Está pensado para los modelos GPT actuales. El modelo se puede configurar por agente en sus archivos TOML.
+
+**P: ¿Puedo personalizar los agentes?**
+
+R: Sí. Edita los archivos TOML de `.codex/agents/` para cambiar `model`, `sandbox_mode` o `developer_instructions`. Las skills obligatorias de cada agente aparecen en `developer_instructions`. Los archivos que modifiques localmente se conservan al ejecutar `npx codex-workflows update`.
+
+En una instalación de usuario, edita los archivos de `$CODEX_HOME/agents/` y usa `npx codex-workflows update --user`. Los archivos de usuario modificados después de la instalación se conservan de la misma manera.
+
+**P: ¿Qué diferencia hay entre `$recipe-implement` y `$recipe-fullstack-implement`?**
+
+R: `$recipe-implement` es el punto de entrada universal. Ejecuta primero requirement-analyzer, determina qué capas están afectadas a partir de la petición y del repositorio, y deriva automáticamente al flujo backend, frontend o fullstack. `$recipe-fullstack-implement` omite esa detección y entra directamente en el flujo fullstack: Design Docs separados por capa, design-sync y ejecución de tareas según la capa. Usa `$recipe-implement` si no estás seguro y `$recipe-fullstack-implement` si ya sabes que la funcionalidad abarca ambas capas.
+
+**P: ¿Funciona con servidores MCP?**
+
+R: Sí. Las skills y los subagentes de Codex funcionan junto con [MCP](https://developers.openai.com/codex/mcp). Las skills operan en la capa de instrucciones y MCP en la de transporte de herramientas. Si el TOML de un agente no define `mcp_servers`, el agente personalizado hereda los `mcp_servers` del padre. Añade configuración MCP local al agente solo para servidores propios o filtrado de herramientas.
+
+**P: ¿Qué relación tiene con claude-code-workflows?**
+
+R: [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) es el proyecto equivalente para Claude Code. Ambos repositorios comparten la misma filosofía, adaptada a los puntos de extensión nativos de cada herramienta. Pueden convivir en un proyecto porque codex-workflows instala sus agentes en `.codex/agents/`, mientras que Claude Code utiliza su propio directorio `.claude/`.
+
+**P: ¿Qué hago si un subagente parece bloqueado?**
+
+R: La sesión principal de Codex es responsable del avance. Revisa la evidencia recibida, repite o corrige los resultados que no sirven y continúa el trabajo que no esté afectado. El resultado de un subagente no detiene por sí solo el flujo.
+
+---
+
+## Motivos de diseño
+
+<details>
+<summary>Lecturas en las que se apoya el diseño</summary>
+
+- [Why LLMs Are Bad at 'First Try' and Great at Verification](https://www.norsica.jp/blog/llm-verification-over-generation): por qué los ciclos de revisión y la separación de sesiones son más fiables que generar de una vez en trabajos complejos
+- [When Better Models Make Old Agent Workflows Worse](https://www.norsica.jp/blog/when-better-models-make-old-agent-workflows-worse): por qué un flujo debe proteger límites y evidencia sin dictar el camino interno del modelo
+- [Reasoning Effort Is Not a Quality Setting](https://www.norsica.jp/blog/reasoning-effort-is-not-a-quality-setting): por qué explorar más solo aporta valor cuando la fase puede seleccionar y descartar el trabajo adicional
+- [Stop Putting Everything in AGENTS.md](https://www.norsica.jp/blog/stop-putting-everything-in-agents-md): por qué `AGENTS.md` debe ser breve y las reglas, documentos e instrucciones deben vivir cerca del lugar donde se usan
+
+</details>
+
+---
+
+## Licencia
+
+Licencia MIT. Puedes usar, modificar y distribuir el proyecto libremente.
+
+---
+
+Creado y mantenido por [@shinpr](https://github.com/shinpr).

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,423 @@
+# codex-workflows
+
+[![Codex CLI](https://img.shields.io/badge/Codex%20CLI-Compatible-10a37f)](https://developers.openai.com/codex/cli)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-Compatible-blue)](https://developers.openai.com/codex/skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+[English](README.md) | [简体中文](README.zh-CN.md) | **日本語** | [Español](README.es.md) | [한국어](README.ko.md) | [Português (Brasil)](README.pt-BR.md)
+
+規模の大きなプロダクト開発では、Codexがユーザーの求める範囲を越えて、技術的な一貫性を追い求めてしまうことがあります。あらゆるエッジケースを処理し、すべての経路を決定論的にしようとすると、合意した成果には不要なはずの変更が、ユーザーから見える挙動にまで及びかねません。
+
+codex-workflowsは、作業を「合意した最小限の成果」の内側に収めます。変更してよいユーザー向けの挙動と、変えてはいけないものを明確にし、完了前には根拠を求めます。その境界内の実装詳細は、リポジトリを踏まえてCodexが可逆的な選択を行います。
+
+ワークフローは、[OpenAI Codex CLI](https://developers.openai.com/codex/cli)向けのAgent Skillsとカスタムエージェントとしてインストールされます。メインのCodexセッションが、設計前にスコープと概算コストを確認し、進行管理とレビュー判断を担い、承認済みの作業を実装から独立検証まで進めます。
+
+---
+
+## Codexをそのまま使うのではだめ？
+
+範囲が明確な修正、使い捨ての検証、単発スクリプトなら、Codexを直接使うほうが適しています。求める結果と安全な実装範囲がすでにはっきりしている場合は、そのほうが速く、コストも抑えられます。
+
+技術的な選択がプロダクトの範囲やユーザー向けの挙動を変えうる場合、あるいは判断を別のコンテキストへ引き継ぐ必要がある場合には、codex-workflowsを使ってください。
+
+たとえば、既存の認証経路を拡張する依頼から、技術的にはきれいでも別の認証方式、より広いバリデーション、新しいレスポンス契約が生まれることがあります。フロントエンドが対応し、テストも通っていても、ユーザーには承認されていない挙動が提供されてしまいます。
+
+codex-workflowsは、実行中を通してこうした拡大を抑えます。
+
+| 制御 | 変わること |
+|---|---|
+| スコープ | 依頼内容を、目指す成果、明示的な除外事項、既存コード、実装の概算コストと照合します。コストに見合わない作業は、アーキテクチャになる前に取り除きます。 |
+| フェーズゲート | 要件・設計・計画の成果物を確認し、合格したものだけが次のフェーズを開始できます。新しいエージェントは、長い会話から意図を組み立て直すのではなく、承認済みの判断と必要な根拠を読みます。 |
+| 実行 | 実装が承認されると、Codexがタスク一式を自律的に実行します。各タスクは実装コミットの前に、対象を絞った検証と該当するリポジトリチェックを通過します。 |
+| 完了 | 独立したコード検証とセキュリティ検証が、変更全体を確認します。必須の修正は同じ実装・品質サイクルに戻り、任意の堅牢化は根拠を示したうえで見送れます。 |
+
+このワークフローは、Codexを直接使う場合よりエージェント呼び出しとトークンを多く消費します。合意した成果を守る価値が、そのコストを上回るときに使ってください。
+
+Codexが対応できるというだけで、エッジケースへの対応が必要になるわけではありません。追加のバリデーション、決定論的な挙動、新しい抽象化は、承認済みの要件や観測可能な契約を守るため、または実際に確認された不具合に対処するためのものでなければなりません。
+
+### 実際のワークフロー例
+
+[mcp-imageへのBytePlus Seedreamプロバイダー統合](https://github.com/shinpr/mcp-image/pull/114)では、18ファイルにまたがって3つ目の外部画像プロバイダーを追加しました。8つの計画済みタスクを通じ、プロバイダー固有の実装を発展させながら、公開MCPリクエスト、クライアント、ファイル保存、ファイルURIの各契約は変えませんでした。
+
+マージ前に実サービスを使って評価し、最終的なモデルルーティング、プロンプト上限、タイムアウト、レスポンス処理を確定しました。独立レビューでは、上限のないファイル読み込み、バリデーションの迂回、ブロッキングするFIFOパス、APIキー正規化の不整合も発見されました。4件すべてを修正し、19ファイル・303件のテストに加え、リトライなしの実プロバイダー呼び出しにも合格しました。8つのタスクと4つの修正を通じ、承認済みの公開契約は維持されました。
+
+---
+
+## クイックスタート
+
+Node.js 22以降と、最新の[Codex CLI](https://developers.openai.com/codex/cli)が必要です。
+
+### インストールと実行
+
+```bash
+cd your-project
+npx codex-workflows install
+```
+
+Codex CLIでレシピを呼び出します。
+
+```
+$recipe-implement JWTによるユーザー認証を追加する
+```
+
+`$`を付けるとスキルを明示的に呼び出せます。利用できるワークフローは、`$recipe-`まで入力すると確認できます。
+
+### 目的に合う入口を選ぶ
+
+| やりたいこと | 最初に使うもの |
+|---|---|
+| バックエンド、API、CLI、または一般的な変更を一貫して仕上げる | `$recipe-implement` |
+| 先に設計し、実装はあとで行う | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
+| React / TypeScriptのWebフロントエンドを設計・実装する | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
+| バックエンドとReactフロントエンドをまとめて変更する | `$recipe-fullstack-implement` |
+| 設計どおりに実装されているかレビューする | `$recipe-review` または `$recipe-front-review` |
+| コードを変えずに問題を調査する | `$recipe-diagnose` |
+| 使い捨ての検証や単発スクリプトを実行する | Codexを直接使う |
+
+---
+
+## 仕組み
+
+```mermaid
+flowchart LR
+    A[依頼] --> B[役に立つ最小限の成果を合意]
+    B --> C{実装方針が1つに定まるか？}
+    C -->|はい| S[直接タスクサイクルとセキュリティレビュー]
+    S --> L[完了]
+    C -->|いいえ| D[調査・設計・レビュー]
+    D --> E[依存関係を踏まえて作業を計画]
+    E --> F[実装範囲を承認]
+    F --> H[タスクごとに実装・検証・品質確認・コミット]
+    H --> K[独立したコード検証とセキュリティ検証]
+    K -->|修正あり| H
+    K -->|要件または主要設計が変更| B
+    K -->|合格| L[完了]
+```
+
+どの経路を通るかは、ファイル数やCodexが見つけたエッジケースの数ではなく、独立したプロダクト判断・設計判断の数で決まります。
+
+| 規模 | 変更に必要なもの | 実行内容 |
+|-------|------------------|----------|
+| 小 | システム内の一領域で、既存パターンに沿って実現できる1つの成果 | 確定済みタスク → 実装 → 品質・セキュリティチェック |
+| 中 | 複数領域の連携、または今後も残る設計判断を要する1つの成果 | レビュー済みDesign Doc（必要に応じてUI Spec / ADR）→ 選定した統合/E2E検証 → レビュー済みWork Plan → 自律タスクサイクル → 最終検証 |
+| 大 | 個別の設計判断が必要な複数の成果 | レビュー済みPRDとDesign Doc（必要に応じてUI Spec / ADR）→ 選定した統合/E2E検証 → レビュー済みWork Plan → 自律タスクサイクル → 最終検証 |
+
+ADRを作るのは、現在のスコープに属し、長く残る選択で、かつ実質的に異なる案が2つ以上ある場合だけです。該当する選択が複数あれば、ADRをまとめてレビューします。統合テストやE2Eテストを選ぶのも、より安価なテストでは必要な連携を証明できない場合だけです。どちらも不要な変更もあります。
+
+長期的に残すプロジェクト文書へ引き継ぐのは、プロダクトまたはリポジトリ実装に影響する判断だけです。第三者の承認、本番環境へのアクセス、リリース作業、無関係な運用作業が実装のゲートになることはありません。
+
+実装範囲が承認されると、オーケストレーターがタスク、対象を絞った検証、該当するリポジトリチェック、タスクごとの実装コミットを実行します。問題はまず、承認済み文書とリポジトリの根拠に基づいて解決します。ユーザーから見える挙動はプロダクト上の境界であり、内部的な整合性のために実装側が勝手に変えてよいものではありません。オーケストレーターが確認を求めるのは、新しいプロダクト要件、承認済みの主要設計判断の変更、ユーザーだけが持つ権限、または未承認の不可逆操作が必要になったときだけです。
+
+専門エージェントには、担当作業に必要な文書とパスだけを渡します。エージェントは焦点を絞った根拠を提供しますが、承認済みの成果を広げる権限までは持ちません。
+
+### 新しいコンテキストへ判断を引き継ぐ仕組み
+
+コンテキストを分けることで、調査・設計・実装・レビューの間で暗黙の前提が共有されるのを防ぎます。同梱の[Work Planテンプレート](.agents/skills/documentation-criteria/references/plan-template.md)では、各実装タスクをDesign Docの該当箇所と受け入れ基準に結び付けます。
+
+```markdown
+### P1-T1: エラーレスポンス契約を維持する
+
+- **根拠**: `docs/design/example-design.md`、API契約、AC-2
+- **対象範囲**: リポジトリ実装と、対象を絞ったテストを更新
+- **依存先**: なし
+- **検証**: 契約テストを実行し、文書どおりのレスポンス形式を確認
+```
+
+[Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md)は、根拠、期待する結果、対象ファイル、実行可能な検証方法を実装フェーズへ渡します。テストが通っても重要な挙動を証明できないおそれがある場合だけ、`Verification Focus`を追加します。実行後は、コミット前にタスクの変更全体へ該当するリポジトリチェックをかけます。最終レビュアーは、承認済み文書と完成したコードを照合し、採用された修正後にもう一度確認します。
+
+---
+
+## インストール
+
+### 必要なもの
+
+- [Codex CLI](https://developers.openai.com/codex/cli)（最新版）
+- Node.js 22以上
+
+### インストール方法
+
+現在のプロジェクトへインストールします。
+
+```bash
+cd your-project
+npx codex-workflows install
+```
+
+次のファイルがプロジェクトへコピーされます。
+
+- `.agents/skills/`: Codexスキル（基礎スキルとレシピ）
+- `.codex/agents/`: サブエージェントのTOML定義
+- 管理対象ファイルを追跡するマニフェスト
+
+すべてのプロジェクトでワークフローを使うには、ユーザー単位の`CODEX_HOME`へインストールします。
+
+```bash
+npx codex-workflows install --user
+```
+
+スキルは`$CODEX_HOME/skills/`、エージェントは`$CODEX_HOME/agents/`へインストールされます。`CODEX_HOME`が未設定の場合は`~/.codex`が使われます。
+
+### 更新
+
+```bash
+# 変更内容を確認
+npx codex-workflows update --dry-run
+
+# 更新を適用
+npx codex-workflows update
+
+# ユーザー単位のインストールを更新
+npx codex-workflows update --user
+```
+
+ローカルで編集したファイルは、アップデート時にも保持されます。各ファイルをインストール時のハッシュと比較し、変更済みのものは更新をスキップします。バージョンごとの更新履歴に沿って移動と削除を順番に適用するため、ローカル変更は移動後のファイルにも引き継がれます。代替なしで廃止された変更済みファイルは、`.codex-workflows-preserved/<version>/`へ移動します。新しいファイルは自動的に追加されます。
+
+```bash
+# インストール済みバージョンを確認
+npx codex-workflows status
+
+# ユーザー単位のインストールを確認
+npx codex-workflows status --user
+```
+
+---
+
+## ワークフローレシピ一覧
+
+Codexでは`$recipe-name`でレシピを呼び出します。`$recipe-`まで入力し、タブ補完を使うと利用可能なレシピを確認できます。
+
+<details>
+<summary>レシピの入口をすべて表示</summary>
+
+### バックエンド・一般
+
+| レシピ | 内容 | 用途 |
+|--------|------|------|
+| `$recipe-implement` | レイヤー判定を含む開発ライフサイクル全体（バックエンド/フロントエンド/フルスタック） | 新機能（汎用エントリーポイント） |
+| `$recipe-task` | ルール選択を含む単一タスク | バグ修正、小規模な変更 |
+| `$recipe-design` | 要件 → 規模に応じたプロダクト・設計文書 | プロダクト設計、アーキテクチャ設計 |
+| `$recipe-plan` | Design Doc → 必要な統合/E2Eテストのひな型 → Work Plan | 承認済みDesign Docからの計画 |
+| `$recipe-prepare-implementation` | 承認済みWork Planに必要な既存のリポジトリ内ツールを準備 | 明示的なセットアップ依頼、または必要なタスク機能が利用できない場合 |
+| `$recipe-build` | ステップ間の検証を含むバックエンドタスクの実行 | バックエンド実装の再開 |
+| `$recipe-review` | Design Doc準拠とセキュリティの検証、必要に応じて承認済み修正 | 実装後の確認 |
+| `$recipe-diagnose` | 問題調査 → 障害点の検証 → 解決策 | 不具合調査 |
+| `$recipe-reverse-engineer` | 既存コードからPRDとDesign Docを生成 | レガシーシステムの文書化 |
+| `$recipe-add-integration-tests` | Design Docをもとに統合/E2Eテストを追加 | 既存コードのテスト拡充 |
+| `$recipe-update-doc` | 既存のDesign Doc / PRD / ADRをレビュー付きで更新 | 仕様変更、文書メンテナンス |
+
+### フロントエンド（React/TypeScript）
+
+| レシピ | 内容 | 用途 |
+|--------|------|------|
+| `$recipe-front-design` | 要件 → 規模に応じたUI・設計文書 | フロントエンドのプロダクト設計・アーキテクチャ設計 |
+| `$recipe-front-adjust` | リポジトリ、提供資料、必要な外部根拠に基づく、範囲を絞ったUI調整 | 実装後の部分的なUI変更 |
+| `$recipe-front-plan` | フロントエンドDesign Doc → 必要な統合/E2Eテストのひな型 → Work Plan | フロントエンドの計画フェーズ |
+| `$recipe-front-build` | 対象を絞った検証と品質チェックを含むフロントエンドタスクの実行 | フロントエンド実装の再開 |
+| `$recipe-front-review` | フロントエンド準拠・セキュリティ検証と、必要に応じた承認済みReact修正 | フロントエンド実装後の確認 |
+
+### フルスタック（レイヤー横断）
+
+| レシピ | 内容 | 用途 |
+|--------|------|------|
+| `$recipe-fullstack-implement` | レイヤーごとにDesign Docを分ける開発ライフサイクル全体 | レイヤーをまたぐ機能 |
+| `$recipe-fullstack-build` | レイヤーに応じたエージェント振り分けを含むタスク実行 | フルスタック実装の再開 |
+
+</details>
+
+## 作業状態
+
+レシピは、Work Plan、実装Task File、一時的なレビュー修正・テスト追加用Task Fileの作業領域として`docs/plans/`を使います。品質確認を通過した実装コミットごとにタスクとフェーズの進捗が更新されますが、進捗ファイル自体はそのコミットに含まれません。一時ファイルもレビュー対象にしたい場合を除き、プロジェクトの`.gitignore`に次を追加してください。
+
+```gitignore
+docs/plans/
+```
+
+PRD、ADR、UI Spec、Design Docは長期的に残すプロジェクト文書であり、コミット対象です。
+
+---
+
+## 同梱のガイダンス
+
+レシピは、現在のタスクに必要な、リポジトリの状況を踏まえたガイダンスを読み込みます。通常、これらのスキルを直接選ぶ必要はありません。
+
+<details>
+<summary>基礎スキルを表示</summary>
+
+| スキル | 提供するもの |
+|-------|--------------|
+| `coding-rules` | コード品質、関数設計、エラー処理、リファクタリング |
+| `testing` | 適切な規模のTDD、観測可能な検証方法の選択、テストの完全性、リポジトリ所定の検証 |
+| `ai-development-guide` | 根拠に基づく原因分析、影響範囲の適切な評価、該当する品質保証 |
+| `reviewee-judgment` | レビュー指摘を修正作業に変える前の、根拠に基づく評価 |
+| `documentation-criteria` | 文書作成ルールとテンプレート（PRD、ADR、Design Doc、Work Plan） |
+| `requirement-convergence` | 設計前に行う成果・要件レイヤー・ユーザー指定の除外事項・概算コストの整理 |
+| `implementation-approach` | 直接的なMVP、根拠のある拡張、削減、分割、検証境界 |
+| `integration-e2e-testing` | 必要な実連携を証明する統合/E2Eテストだけを選び、設計する方法 |
+| `external-resource-context` | 現在の判断に必要な外部情報源を1つに絞って確認する方法 |
+| `llm-friendly-context` | 後続エージェントが迷わず使える、明確なプロンプト、引き継ぎ、生成物、Task File、レビュー指摘 |
+| `task-analyzer` | タスクの意図分析、種類の分類、スキル選択 |
+| `subagents-orchestration-guide` | マルチエージェントの連携、ワークフローの進行、指針に沿った自律実行 |
+
+Webフロントエンドで使うTypeScript向けには、Reactアプリケーションを含む追加資料（`coding-rules/references/typescript.md`、`testing/references/typescript.md`）も同梱されています。バックエンドTypeScriptには適用されません。
+
+</details>
+
+---
+
+## 専門エージェント
+
+レシピの実行中、Codexが必要に応じて次のエージェントを起動します。事前に役割を覚える必要はありません。オーケストレーターがワークフロー全体を管理し、レシピが分野に応じて担当エージェントを選びます。各エージェントは個別のコンテキストで、専門的な指示と明示された必須スキルに従って動作します。
+
+<details>
+<summary>専門エージェントの役割をすべて表示</summary>
+
+### 文書作成エージェント
+
+| エージェント | 役割 |
+|--------------|------|
+| `requirement-analyzer` | 依頼から得られる要点と、スコープ・コスト判断に必要なリポジトリ上の根拠を簡潔に整理 |
+| `prd-creator` | PRDの作成と構成整理 |
+| `technical-designer` | ADR一式またはDesign Docの作成（バックエンド/一般） |
+| `technical-designer-frontend` | フロントエンド向けADR一式またはDesign Docの作成（React） |
+| `ui-spec-designer` | PRDと任意のプロトタイプコードからUI Specificationを作成 |
+| `codebase-analyzer` | 選択肢の比較、最小設計、検証に必要なリポジトリ上の根拠を簡潔に収集 |
+| `ui-analyzer` | 外部資料（デザインツール、デザインシステム文書、公開中のUI）とフロントエンドコードからUIの事実を収集 |
+| `work-planner` | Design DocからWork Planを作成 |
+| `document-reviewer` | 上位要件と設計判断に照らして文書をレビュー |
+| `design-sync` | 文書間の整合性を検証 |
+
+### 実装エージェント
+
+| エージェント | 役割 |
+|--------------|------|
+| `task-decomposer` | Work Planから最小数の実行可能なTask Fileへ分解 |
+| `task-executor` | Task Fileに沿った実装と対象を絞った検証（バックエンド） |
+| `task-executor-frontend` | 必要に応じて振る舞い中心のRTL検証を行うReact実装 |
+| `quality-fixer` | 該当するリポジトリチェックと範囲内の品質修正（バックエンド） |
+| `quality-fixer-frontend` | React、TypeScript、RTL、バンドルについて該当するチェックと修正 |
+| `acceptance-test-generator` | 選定済みの統合/E2Eテストのひな型を生成 |
+| `integration-test-reviewer` | テスト品質をレビュー |
+
+### 分析エージェント
+
+| エージェント | 役割 |
+|--------------|------|
+| `code-reviewer` | Design Docへの準拠を検証 |
+| `code-verifier` | 文書とコードの整合性を検証 |
+| `security-reviewer` | 実装後のセキュリティ準拠をレビュー |
+| `rule-advisor` | レシピの管理外にある単独タスクのスキルを選定 |
+| `scope-discoverer` | 既存システムの文書化に向けてコードベースの範囲を調査し、PRDの単位を整理 |
+
+### 調査エージェント
+
+| エージェント | 役割 |
+|--------------|------|
+| `investigator` | 根拠収集、経路の整理、障害点の発見 |
+| `verifier` | 経路の網羅性と障害点を独立して検証 |
+| `solver` | トレードオフを踏まえて解決策を導出 |
+
+</details>
+
+---
+
+## プロジェクト構成
+
+インストール後、プロジェクトには次のファイルが追加されます。
+
+<details>
+<summary>インストール後の構成を表示</summary>
+
+```
+your-project/
+├── .agents/skills/           # Codexスキル
+│   ├── coding-rules/         # 基礎ガイダンス
+│   ├── testing/
+│   ├── ai-development-guide/
+│   ├── reviewee-judgment/
+│   ├── documentation-criteria/
+│   ├── requirement-convergence/
+│   ├── implementation-approach/
+│   ├── integration-e2e-testing/
+│   ├── external-resource-context/
+│   ├── llm-friendly-context/
+│   ├── task-analyzer/
+│   ├── subagents-orchestration-guide/
+│   └── recipe-*/             # ワークフローの入口（$recipe-*）
+├── .codex/agents/            # サブエージェントのTOML定義
+│   ├── requirement-analyzer.toml
+│   ├── technical-designer.toml
+│   ├── ui-analyzer.toml
+│   ├── task-executor.toml
+│   └── ...（全25エージェント）
+└── docs/                     # レシピの利用に応じて作成
+    ├── prd/
+    ├── design/
+    ├── adr/
+    ├── ui-spec/
+    └── plans/
+        └── tasks/
+```
+
+</details>
+
+---
+
+## 連携できるツール
+
+要件がすでにLinearや既存のPRDにまとまっている場合は、[linear-prism](https://github.com/shinpr/linear-prism)を使うと、コードベースを読みながら要件を実装可能なタスクへ分解し、依存関係を明示しつつDesign Docの境界を維持できます。
+
+作成したタスクを`$recipe-design`へ渡せば、スコープが明確で見通しのよい状態から設計フェーズを始められます。
+
+---
+
+## FAQ
+
+**Q: どのモデルで使えますか？**
+
+A: 現行のGPTモデル向けに設計されています。エージェントごとにTOMLファイルでモデルを設定できます。
+
+**Q: エージェントをカスタマイズできますか？**
+
+A: はい。`.codex/agents/`のTOMLファイルを編集すると、`model`、`sandbox_mode`、`developer_instructions`を変更できます。各エージェントが必要とするスキルは`developer_instructions`に記載されています。ローカルで変更したファイルは、`npx codex-workflows update`を実行しても保持されます。
+
+ユーザー単位でインストールした場合は、`$CODEX_HOME/agents/`のファイルを編集し、`npx codex-workflows update --user`を使ってください。インストール後に変更したユーザー単位のファイルも同様に保持されます。
+
+**Q: `$recipe-implement`と`$recipe-fullstack-implement`の違いは？**
+
+A: `$recipe-implement`は汎用の入口です。最初にrequirement-analyzerを実行し、依頼内容とリポジトリの範囲から影響するレイヤーを判定して、バックエンド、フロントエンド、フルスタックのいずれかへ自動的に振り分けます。`$recipe-fullstack-implement`はこの判定を省き、フルスタックフロー（レイヤーごとのDesign Doc、design-sync、レイヤーに応じたタスク実行）へ直接進みます。判断がつかない場合は`$recipe-implement`、機能が両レイヤーにまたがると最初からわかっている場合は`$recipe-fullstack-implement`を使ってください。
+
+**Q: MCPサーバーと一緒に使えますか？**
+
+A: はい。Codexのスキルとサブエージェントは、[MCP](https://developers.openai.com/codex/mcp)と併用できます。スキルは指示レイヤー、MCPはツール転送レイヤーで動作します。エージェントのTOMLで`mcp_servers`を省略すると、カスタムエージェントは親の`mcp_servers`を引き継ぎます。エージェント固有のサーバーやツール制限が必要な場合だけ、個別のMCP設定を追加してください。
+
+**Q: claude-code-workflowsとの関係は？**
+
+A: [claude-code-workflows](https://github.com/shinpr/claude-code-workflows)はClaude Code版にあたります。共通のワークフロー思想を、それぞれのツールが持つ拡張機構に合わせて実装しています。codex-workflowsはエージェント定義を`.codex/agents/`へ、Claude Codeは独自の`.claude/`配下へ配置するため、同じプロジェクト内で併用できます。
+
+**Q: サブエージェントが止まっているように見えたら？**
+
+A: 進行を管理するのはメインのCodexセッションです。返された根拠を確認し、使えない結果なら再実行または修正し、影響を受けない作業はそのまま進めます。1つのサブエージェントの結果だけでワークフロー全体が止まることはありません。
+
+---
+
+## 設計の背景
+
+<details>
+<summary>ワークフロー設計の参考資料</summary>
+
+- [Why LLMs Are Bad at 'First Try' and Great at Verification](https://www.norsica.jp/blog/llm-verification-over-generation)：複雑な作業では、一度で生成するよりレビューサイクルとセッション分離のほうが信頼できる理由
+- [When Better Models Make Old Agent Workflows Worse](https://www.norsica.jp/blog/when-better-models-make-old-agent-workflows-worse)：モデル内部の進め方を縛らず、境界と根拠を守るワークフロー制約が必要な理由
+- [Reasoning Effort Is Not a Quality Setting](https://www.norsica.jp/blog/reasoning-effort-is-not-a-quality-setting)：広い技術探索に価値があるのは、フェーズ内で余分な作業を選別できる場合だけである理由
+- [Stop Putting Everything in AGENTS.md](https://www.norsica.jp/blog/stop-putting-everything-in-agents-md)：`AGENTS.md`を簡潔に保ち、ルール・文書・タスク指示を利用箇所の近くへ置くべき理由
+
+</details>
+
+---
+
+## ライセンス
+
+MIT License。利用、変更、再配布は自由です。
+
+---
+
+[@shinpr](https://github.com/shinpr)が開発・メンテナンスしています。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,423 @@
+# codex-workflows
+
+[![Codex CLI](https://img.shields.io/badge/Codex%20CLI-Compatible-10a37f)](https://developers.openai.com/codex/cli)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-Compatible-blue)](https://developers.openai.com/codex/skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md) | **한국어** | [Português (Brasil)](README.pt-BR.md)
+
+규모가 큰 제품 작업에서 Codex는 사용자가 원하는 수준을 넘어 기술적 일관성을 좇을 때가 있습니다. 모든 엣지 케이스를 처리하고 모든 경로의 결과를 결정적으로 만들다 보면, 합의한 목표에 필요하지 않은데도 사용자가 보는 동작까지 바뀔 수 있습니다.
+
+codex-workflows는 작업을 승인된 최소한의 결과 안에 머물게 합니다. 사용자에게 보이는 동작 중 무엇을 바꿔도 되는지, 무엇은 그대로 두어야 하는지 확인하고, 완료 전에 근거를 요구합니다. 그 경계 안에서 Codex는 저장소를 바탕으로 되돌리기 쉬운 구현 세부 사항을 선택합니다.
+
+워크플로는 [OpenAI Codex CLI](https://developers.openai.com/codex/cli)의 Agent Skills와 사용자 정의 에이전트로 설치됩니다. 메인 Codex 세션이 설계 전에 범위와 대략적인 비용을 확인하고, 진행 상황과 리뷰 판단을 책임지며, 승인된 작업을 구현부터 독립 검증까지 이어갑니다.
+
+---
+
+## Codex를 바로 쓰면 안 되나요?
+
+범위가 명확한 수정, 일회성 실험, 한 번 쓰고 버릴 스크립트라면 Codex를 직접 사용하는 편이 낫습니다. 원하는 결과와 안전한 구현 경계가 이미 분명하다면 더 빠르고 비용도 적게 듭니다.
+
+기술적 선택이 제품 범위나 사용자에게 보이는 동작을 바꿀 수 있거나, 어떤 결정을 여러 컨텍스트에 걸쳐 유지해야 한다면 codex-workflows를 사용하세요.
+
+예를 들어 기존 인증 경로를 확장해 달라는 요청이 기술적으로 더 깔끔한 두 번째 인증 방식, 더 넓은 검증, 새로운 응답 계약으로 번질 수 있습니다. 프런트엔드가 이에 맞춰 바뀌고 테스트가 모두 통과하더라도, 사용자는 승인받은 적 없는 동작을 받게 됩니다.
+
+codex-workflows는 실행 내내 이런 범위 확장을 제어합니다.
+
+| 제어 항목 | 달라지는 점 |
+|---|---|
+| 범위 | 요청을 원하는 결과, 명시적 제외 사항, 기존 코드, 대략적인 구현 비용과 비교합니다. 비용만큼 가치가 없는 작업은 아키텍처가 되기 전에 제거합니다. |
+| 단계 게이트 | 요구사항, 설계, 계획 결과물을 확인한 뒤에만 다음 단계를 허용합니다. 새 에이전트는 긴 대화에서 의도를 다시 추측하는 대신 승인된 결정과 필요한 근거를 읽습니다. |
+| 실행 | 구현이 승인되면 Codex가 작업 묶음을 자율적으로 수행합니다. 각 작업은 구현 커밋 전에 해당 작업에 맞춘 검증과 저장소에서 요구하는 검사를 통과합니다. |
+| 완료 | 독립적인 코드 및 보안 검증이 변경 전체를 살핍니다. 반드시 고쳐야 할 문제는 같은 구현·품질 주기로 돌아가며, 선택적인 보강은 근거를 제시하고 하지 않을 수 있습니다. |
+
+이 워크플로는 Codex를 직접 실행할 때보다 더 많은 에이전트 호출과 토큰을 사용합니다. 승인된 결과를 지키는 일이 그 비용보다 중요할 때 사용하세요.
+
+Codex가 처리할 수 있다는 이유만으로 모든 엣지 케이스가 작업 대상이 되는 것은 아닙니다. 추가 검증, 결정적인 동작, 새로운 추상화는 승인된 요구사항이나 관찰 가능한 계약을 지키거나, 실제로 확인된 장애에 대응하기 위한 것이어야 합니다.
+
+### 실제 실행 사례
+
+[mcp-image의 BytePlus Seedream 공급자 연동](https://github.com/shinpr/mcp-image/pull/114)은 18개 파일에 걸쳐 세 번째 외부 이미지 공급자를 추가했습니다. 공급자별 구현을 발전시키는 동안에도, 계획된 8개 작업은 공개 MCP 요청, 클라이언트, 파일 저장, 파일 URI 계약을 그대로 유지했습니다.
+
+병합 전 실제 서비스 평가를 통해 최종 모델 라우팅, 프롬프트 제한, 타임아웃, 응답 처리를 확정했습니다. 독립 리뷰에서는 제한 없는 파일 읽기, 검증 우회, 블로킹 FIFO 경로, 일관되지 않은 API 키 정규화도 발견했습니다. 네 가지를 모두 수정했고, PR은 19개 파일의 303개 테스트와 재시도 없는 실제 공급자 호출을 통과했습니다. 8개 작업과 4개 수정 내내 승인된 공개 계약은 바뀌지 않았습니다.
+
+---
+
+## 빠른 시작
+
+Node.js 22 이상과 최신 [Codex CLI](https://developers.openai.com/codex/cli)가 필요합니다.
+
+### 설치 및 실행
+
+```bash
+cd your-project
+npx codex-workflows install
+```
+
+그다음 Codex CLI에서 레시피를 호출합니다.
+
+```
+$recipe-implement JWT 사용자 인증 추가
+```
+
+`$`는 스킬을 명시적으로 호출한다는 뜻입니다. `$recipe-`를 입력하면 사용 가능한 워크플로를 볼 수 있습니다.
+
+### 목적에 맞는 경로 선택
+
+| 필요한 작업 | 시작할 레시피 |
+|---|---|
+| 백엔드, API, CLI 또는 일반 변경을 처음부터 끝까지 구현 | `$recipe-implement` |
+| 먼저 설계하고 나중에 구현 | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
+| React / TypeScript 웹 프런트엔드를 설계하고 구현 | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
+| 백엔드와 React 프런트엔드 변경을 함께 구현 | `$recipe-fullstack-implement` |
+| 설계에 맞게 구현되었는지 리뷰 | `$recipe-review` 또는 `$recipe-front-review` |
+| 코드를 바꾸지 않고 문제 조사 | `$recipe-diagnose` |
+| 일회성 실험이나 단발성 스크립트 실행 | Codex 직접 사용 |
+
+---
+
+## 작동 방식
+
+```mermaid
+flowchart LR
+    A[요청] --> B[가장 작고 유용한 결과에 합의]
+    B --> C{명확한 구현 경로가 하나인가?}
+    C -->|예| S[직접 작업 주기 및 보안 리뷰]
+    S --> L[완료]
+    C -->|아니요| D[조사, 설계 및 리뷰]
+    D --> E[의존 작업 계획]
+    E --> F[구현 범위 승인]
+    F --> H[작업별 구현, 검증, 품질 검사 및 커밋]
+    H --> K[독립 코드 및 보안 검증]
+    K -->|수정 필요| H
+    K -->|요구사항 또는 주요 설계 변경| B
+    K -->|통과| L[완료]
+```
+
+어떤 경로를 택할지는 파일 수나 Codex가 찾아낸 엣지 케이스의 수가 아니라, 서로 독립적인 제품 및 설계 결정의 수로 정합니다.
+
+| 규모 | 변경에 필요한 것 | 진행 방식 |
+|------|------------------|-----------|
+| 소 | 시스템의 한 부분에서 기존 패턴을 따르는 하나의 결과 | 확정된 작업 → 구현 → 품질 및 보안 검사 |
+| 중 | 시스템 여러 부분의 조율이나 오래 유지할 설계 결정이 필요한 하나의 결과 | 리뷰된 Design Doc과 필요시 UI Spec / ADR → 선정된 통합/E2E 검증 → 리뷰된 Work Plan → 자율 작업 주기 → 최종 검증 |
+| 대 | 별도의 설계 결정이 필요한 여러 결과 | 리뷰된 PRD와 Design Doc, 필요시 UI Spec / ADR → 선정된 통합/E2E 검증 → 리뷰된 Work Plan → 자율 작업 주기 → 최종 검증 |
+
+ADR은 현재 범위에 속하고 오래 유지되는 선택에 실질적으로 다른 대안이 둘 이상 있을 때만 만듭니다. 해당 선택이 여러 개면 ADR을 함께 리뷰합니다. 통합 또는 E2E 테스트도 더 저렴한 테스트로 필요한 상호작용을 증명할 수 없을 때만 선택합니다. 둘 다 필요하지 않은 변경도 있습니다.
+
+제품이나 저장소 구현에 영향을 주는 결정만 장기 프로젝트 문서로 남깁니다. 제3자 승인, 운영 환경 접근, 릴리스 실행, 무관한 운영 작업은 구현 게이트가 되지 않습니다.
+
+구현 범위가 승인되면 오케스트레이터가 작업, 작업에 맞춘 검증, 적용 가능한 저장소 검사, 작업별 구현 커밋을 실행합니다. 문제는 먼저 승인 문서와 저장소 근거를 사용해 해결합니다. 사용자에게 보이는 동작은 제품 경계이므로 내부 일관성을 위해 구현이 임의로 조정할 수 없습니다. 새로운 제품 요구사항, 승인된 주요 설계 결정 변경, 사용자만 가진 권한, 승인하지 않은 되돌릴 수 없는 작업이 필요할 때만 사용자에게 묻습니다.
+
+전문 에이전트는 작업에 꼭 필요한 문서와 경로만 받습니다. 필요한 범위의 구체적인 근거를 제공하지만 승인된 결과를 넓힐 권한은 없습니다.
+
+### 새 컨텍스트에서도 결정이 유지되는 방식
+
+컨텍스트를 분리하면 조사, 설계, 구현, 리뷰가 암묵적인 가정을 공유하는 일을 막을 수 있습니다. 포함된 [Work Plan 템플릿](.agents/skills/documentation-criteria/references/plan-template.md)은 각 구현 작업을 Design Doc의 해당 섹션과 인수 기준에 연결합니다.
+
+```markdown
+### P1-T1: 오류 응답 계약 유지
+
+- **출처**: `docs/design/example-design.md`, API 계약, AC-2
+- **범위**: 저장소 구현과 관련 집중 테스트 업데이트
+- **의존성**: 없음
+- **검증**: 계약 테스트를 실행하고 문서에 정의된 응답 형태 확인
+```
+
+[Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md)는 출처, 의도한 결과, 대상 파일, 실행 가능한 검증을 구현 단계로 전달합니다. 테스트가 통과해도 중요한 동작을 증명하지 못할 수 있을 때만 `Verification Focus`를 추가합니다. 실행 후에는 커밋 전에 작업 변경 전체에 해당 저장소 검사를 적용합니다. 최종 리뷰어는 승인 문서와 완성된 코드를 비교하고, 채택된 수정이 끝나면 다시 검토합니다.
+
+---
+
+## 설치
+
+### 요구 사항
+
+- 최신 [Codex CLI](https://developers.openai.com/codex/cli)
+- Node.js 22 이상
+
+### 설치 방법
+
+현재 프로젝트에 설치합니다.
+
+```bash
+cd your-project
+npx codex-workflows install
+```
+
+다음 항목이 프로젝트에 복사됩니다.
+
+- `.agents/skills/`: Codex 스킬(기초 스킬 + 레시피)
+- `.codex/agents/`: 하위 에이전트 TOML 정의
+- 관리 파일 추적용 매니페스트
+
+모든 프로젝트에서 워크플로를 사용하려면 사용자 수준 `CODEX_HOME`에 설치하세요.
+
+```bash
+npx codex-workflows install --user
+```
+
+스킬은 `$CODEX_HOME/skills/`에, 에이전트는 `$CODEX_HOME/agents/`에 설치됩니다. `CODEX_HOME`이 없으면 기본값은 `~/.codex`입니다.
+
+### 업데이트
+
+```bash
+# 변경 내용 미리 보기
+npx codex-workflows update --dry-run
+
+# 업데이트 적용
+npx codex-workflows update
+
+# 사용자 수준 설치 업데이트
+npx codex-workflows update --user
+```
+
+업데이터는 로컬에서 수정한 파일을 보존합니다. 각 파일을 설치 시점의 해시와 비교하고, 바뀐 파일은 건너뜁니다. 버전별 업데이트 기록에 따라 이동과 삭제를 순서대로 적용하므로 로컬 변경도 이동된 파일의 현재 경로를 따라갑니다. 대체 파일 없이 제거된 수정 파일은 `.codex-workflows-preserved/<version>/`로 옮깁니다. 새 파일은 자동으로 추가됩니다.
+
+```bash
+# 설치된 버전 확인
+npx codex-workflows status
+
+# 사용자 수준 설치 확인
+npx codex-workflows status --user
+```
+
+---
+
+## 워크플로 레시피 목록
+
+Codex에서 `$recipe-name`으로 레시피를 호출합니다. `$recipe-`를 입력하고 탭 자동 완성을 사용하면 모든 레시피를 볼 수 있습니다.
+
+<details>
+<summary>모든 레시피 진입점 보기</summary>
+
+### 백엔드 및 일반
+
+| 레시피 | 기능 | 사용 시점 |
+|--------|------|-----------|
+| `$recipe-implement` | 계층 판별을 포함한 전체 수명 주기(백엔드/프런트엔드/풀스택) | 새 기능(범용 진입점) |
+| `$recipe-task` | 규칙 선택을 포함한 단일 작업 | 버그 수정, 작은 변경 |
+| `$recipe-design` | 요구사항 → 규모에 맞춘 제품 및 설계 문서 | 제품 및 아키텍처 설계 |
+| `$recipe-plan` | Design Doc → 필요한 통합/E2E 골격 → Work Plan | 승인된 Design Doc에서 계획 수립 |
+| `$recipe-prepare-implementation` | 승인된 Work Plan에 필요한 기존 저장소 내부 도구 준비 | 명시적인 설정 요청 또는 필요한 작업 기능이 없을 때 |
+| `$recipe-build` | 단계 사이 검증과 함께 백엔드 작업 실행 | 백엔드 구현 재개 |
+| `$recipe-review` | Design Doc 준수 및 보안 검증, 필요시 승인된 수정 | 구현 후 확인 |
+| `$recipe-diagnose` | 문제 조사 → 장애 지점 검증 → 해결책 | 버그 조사 |
+| `$recipe-reverse-engineer` | 기존 코드에서 PRD와 Design Doc 생성 | 레거시 시스템 문서화 |
+| `$recipe-add-integration-tests` | Design Doc에서 통합/E2E 테스트 추가 | 기존 코드의 테스트 범위 확대 |
+| `$recipe-update-doc` | 기존 Design Doc / PRD / ADR을 리뷰와 함께 업데이트 | 명세 변경, 문서 유지보수 |
+
+### 프런트엔드(React/TypeScript)
+
+| 레시피 | 기능 | 사용 시점 |
+|--------|------|-----------|
+| `$recipe-front-design` | 요구사항 → 규모에 맞춘 UI 및 설계 문서 | 프런트엔드 제품 및 아키텍처 설계 |
+| `$recipe-front-adjust` | 저장소, 제공 자료 또는 필요한 외부 근거를 사용한 집중 UI 조정 | 구현 후의 좁은 UI 변경 |
+| `$recipe-front-plan` | 프런트엔드 Design Doc → 필요한 통합/E2E 골격 → Work Plan | 프런트엔드 계획 단계 |
+| `$recipe-front-build` | 작업에 맞춘 검증과 품질 검사를 포함한 프런트엔드 작업 실행 | 프런트엔드 구현 재개 |
+| `$recipe-front-review` | 프런트엔드 준수 및 보안 검증, 필요시 승인된 React 수정 | 프런트엔드 구현 후 확인 |
+
+### 풀스택(계층 간)
+
+| 레시피 | 기능 | 사용 시점 |
+|--------|------|-----------|
+| `$recipe-fullstack-implement` | 계층별 별도 Design Doc을 사용하는 전체 수명 주기 | 계층을 넘나드는 기능 |
+| `$recipe-fullstack-build` | 계층에 따라 에이전트를 배정해 작업 실행 | 풀스택 구현 재개 |
+
+</details>
+
+## 작업 상태
+
+레시피는 Work Plan, 구현 Task File, 임시 리뷰 수정 또는 테스트 추가 Task File의 작업 상태로 `docs/plans/`를 사용합니다. 품질 승인을 받은 구현 커밋마다 작업 및 단계 진행 상황이 이곳에서 갱신되지만, 진행 파일 자체는 해당 커밋에 포함되지 않습니다. 팀이 이 임시 파일을 리뷰하려는 경우가 아니라면 프로젝트 `.gitignore`에 다음을 추가하세요.
+
+```gitignore
+docs/plans/
+```
+
+PRD, ADR, UI Spec, Design Doc은 장기 프로젝트 문서이므로 커밋해야 합니다.
+
+---
+
+## 포함된 가이드
+
+레시피는 현재 작업에 필요한 저장소 맞춤형 지침을 불러옵니다. 보통은 이 스킬들을 직접 선택할 필요가 없습니다.
+
+<details>
+<summary>기초 스킬 보기</summary>
+
+| 스킬 | 제공하는 내용 |
+|------|---------------|
+| `coding-rules` | 코드 품질, 함수 설계, 오류 처리, 리팩터링 |
+| `testing` | 작업에 맞는 TDD, 관찰 가능한 검증 방법 선택, 테스트 무결성, 저장소 필수 검증 |
+| `ai-development-guide` | 근거 기반 근본 원인, 적정한 영향 분석, 적용 가능한 품질 보증 |
+| `reviewee-judgment` | 리뷰 의견을 수정 작업으로 만들기 전의 근거 기반 판단 |
+| `documentation-criteria` | 문서 작성 규칙과 템플릿(PRD, ADR, Design Doc, Work Plan) |
+| `requirement-convergence` | 설계 전 결과, 요구사항 계층, 사용자 결정 제외 사항, 대략적 비용 정리 |
+| `implementation-approach` | 직접 MVP, 근거 있는 확장, 축소, 분할, 검증 경계 |
+| `integration-e2e-testing` | 필요한 실제 상호작용을 증명하는 통합/E2E 테스트만 선택하고 설계 |
+| `external-resource-context` | 현재 결정에 필요한 외부 근거 하나만 선별해 확인 |
+| `llm-friendly-context` | 후속 에이전트를 위한 명확한 프롬프트, 인수인계, 산출물, Task File, 리뷰 의견 |
+| `task-analyzer` | 작업 의도 분석, 유형 분류, 스킬 선택 |
+| `subagents-orchestration-guide` | 다중 에이전트 조율, 워크플로 진행, 가이드에 따른 자율 실행 |
+
+React 애플리케이션을 포함한 웹 프런트엔드 TypeScript용 참고 자료(`coding-rules/references/typescript.md`, `testing/references/typescript.md`)도 포함됩니다. 백엔드 TypeScript에는 적용되지 않습니다.
+
+</details>
+
+---
+
+## 전문 에이전트
+
+레시피 실행 중 Codex가 필요에 따라 다음 에이전트를 생성합니다. 역할을 미리 익힐 필요는 없습니다. 레시피가 분야에 맞는 에이전트로 작업을 보내고 오케스트레이터는 전체 흐름을 계속 관리합니다. 각 에이전트는 별도 컨텍스트에서 전문 지침과 명시된 필수 스킬을 사용합니다.
+
+<details>
+<summary>모든 전문 에이전트 역할 보기</summary>
+
+### 문서 작성 에이전트
+
+| 에이전트 | 역할 |
+|----------|------|
+| `requirement-analyzer` | 요청의 핵심 신호와 범위·비용 판단에 필요한 저장소 근거 정리 |
+| `prd-creator` | PRD 작성 및 구조화 |
+| `technical-designer` | 전체 ADR 묶음 또는 Design Doc 작성(백엔드/일반) |
+| `technical-designer-frontend` | 프런트엔드 ADR 묶음 또는 Design Doc 작성(React) |
+| `ui-spec-designer` | PRD와 선택적 프로토타입 코드에서 UI Specification 작성 |
+| `codebase-analyzer` | 선택지 결정, 최소 설계, 검증을 위한 간결한 저장소 근거 수집 |
+| `ui-analyzer` | 외부 자료(디자인 도구, 디자인 시스템 문서, 배포된 UI)와 프런트엔드 코드에서 UI 정보 수집 |
+| `work-planner` | Design Doc에서 Work Plan 작성 |
+| `document-reviewer` | 상위 요구사항과 설계 결정에 따라 문서 리뷰 |
+| `design-sync` | 문서 간 일관성 검증 |
+
+### 구현 에이전트
+
+| 에이전트 | 역할 |
+|----------|------|
+| `task-decomposer` | Work Plan을 실행 가능한 최소 개수의 Task File로 변환 |
+| `task-executor` | Task File 구현 및 작업에 맞춘 검증(백엔드) |
+| `task-executor-frontend` | 적용 가능한 동작 중심 RTL 검증과 함께 React 구현 |
+| `quality-fixer` | 적용 가능한 저장소 검사와 범위 내 품질 수정(백엔드) |
+| `quality-fixer-frontend` | 적용 가능한 React, TypeScript, RTL, 번들 검사 및 수정 |
+| `acceptance-test-generator` | 선택한 통합/E2E 테스트 골격 생성 |
+| `integration-test-reviewer` | 테스트 품질 리뷰 |
+
+### 분석 에이전트
+
+| 에이전트 | 역할 |
+|----------|------|
+| `code-reviewer` | Design Doc 준수 검증 |
+| `code-verifier` | 문서와 코드 일치 검증 |
+| `security-reviewer` | 구현 후 보안 준수 리뷰 |
+| `rule-advisor` | 레시피 밖의 단독 작업을 위한 스킬 선택 |
+| `scope-discoverer` | 역문서화를 위한 코드베이스 범위 조사와 PRD 단위 구성 |
+
+### 진단 에이전트
+
+| 에이전트 | 역할 |
+|----------|------|
+| `investigator` | 근거 수집, 경로 매핑, 장애 지점 발견 |
+| `verifier` | 경로 범위 검증 및 장애 지점 독립 평가 |
+| `solver` | 장단점을 고려한 해결책 도출 |
+
+</details>
+
+---
+
+## 프로젝트 구조
+
+설치 후 프로젝트에는 다음 항목이 생깁니다.
+
+<details>
+<summary>설치된 구조 보기</summary>
+
+```
+your-project/
+├── .agents/skills/           # Codex 스킬
+│   ├── coding-rules/         # 기초 가이드
+│   ├── testing/
+│   ├── ai-development-guide/
+│   ├── reviewee-judgment/
+│   ├── documentation-criteria/
+│   ├── requirement-convergence/
+│   ├── implementation-approach/
+│   ├── integration-e2e-testing/
+│   ├── external-resource-context/
+│   ├── llm-friendly-context/
+│   ├── task-analyzer/
+│   ├── subagents-orchestration-guide/
+│   └── recipe-*/             # 워크플로 진입점($recipe-*)
+├── .codex/agents/            # 하위 에이전트 TOML 정의
+│   ├── requirement-analyzer.toml
+│   ├── technical-designer.toml
+│   ├── ui-analyzer.toml
+│   ├── task-executor.toml
+│   └── ... (총 25개 에이전트)
+└── docs/                     # 레시피를 사용하면서 생성
+    ├── prd/
+    ├── design/
+    ├── adr/
+    ├── ui-spec/
+    └── plans/
+        └── tasks/
+```
+
+</details>
+
+---
+
+## 함께 사용할 수 있는 도구
+
+요구사항이 이미 Linear나 기존 PRD에 있다면 [linear-prism](https://github.com/shinpr/linear-prism)이 코드베이스를 읽어 구현 가능한 작업으로 나누고, 의존성을 명확히 하며, Design Doc 경계를 유지할 수 있습니다.
+
+이 작업을 `$recipe-design`에 전달하면 범위와 작업을 더 명확히 파악한 상태에서 설계 단계를 시작할 수 있습니다.
+
+---
+
+## 자주 묻는 질문
+
+**Q: 어떤 모델에서 사용할 수 있나요?**
+
+A: 현재 GPT 모델을 기준으로 설계되었습니다. 에이전트별 TOML 파일에서 모델을 설정할 수 있습니다.
+
+**Q: 에이전트를 사용자 정의할 수 있나요?**
+
+A: 네. `.codex/agents/`의 TOML 파일을 편집해 `model`, `sandbox_mode`, `developer_instructions`를 바꿀 수 있습니다. 각 에이전트의 필수 스킬은 `developer_instructions`에 적혀 있습니다. 로컬에서 수정한 파일은 `npx codex-workflows update`를 실행해도 보존됩니다.
+
+사용자 수준 설치에서는 `$CODEX_HOME/agents/`의 파일을 편집하고 `npx codex-workflows update --user`를 사용하세요. 설치 후 수정한 사용자 수준 파일도 같은 방식으로 보존됩니다.
+
+**Q: `$recipe-implement`와 `$recipe-fullstack-implement`는 무엇이 다른가요?**
+
+A: `$recipe-implement`는 범용 진입점입니다. 먼저 requirement-analyzer를 실행하고 요청과 저장소 범위에서 영향을 받는 계층을 확인한 다음 백엔드, 프런트엔드, 풀스택 흐름으로 자동 분기합니다. `$recipe-fullstack-implement`는 판별을 생략하고 풀스택 흐름(계층별 Design Doc, design-sync, 계층 맞춤 작업 실행)으로 바로 들어갑니다. 잘 모르겠다면 `$recipe-implement`를, 기능이 두 계층에 걸친다는 사실을 알고 있다면 `$recipe-fullstack-implement`를 사용하세요.
+
+**Q: MCP 서버와 함께 사용할 수 있나요?**
+
+A: 네. Codex 스킬과 하위 에이전트는 [MCP](https://developers.openai.com/codex/mcp)와 함께 작동합니다. 스킬은 지침 계층에서, MCP는 도구 전송 계층에서 작동합니다. 에이전트 TOML에 `mcp_servers`가 없으면 사용자 정의 에이전트가 부모의 `mcp_servers`를 상속합니다. 에이전트 전용 서버나 도구 필터링이 필요할 때만 에이전트별 MCP 설정을 추가하세요.
+
+**Q: claude-code-workflows와는 어떤 관계인가요?**
+
+A: [claude-code-workflows](https://github.com/shinpr/claude-code-workflows)는 Claude Code용 대응 프로젝트입니다. 두 저장소는 같은 워크플로 철학을 공유하되 각 도구의 기본 확장 지점에 맞게 구현되어 있습니다. codex-workflows는 에이전트 정의를 `.codex/agents/`에, Claude Code는 자체 `.claude/` 디렉터리에 설치하므로 한 프로젝트에서 함께 사용할 수 있습니다.
+
+**Q: 하위 에이전트가 멈춘 것처럼 보이면 어떻게 하나요?**
+
+A: 메인 Codex 세션이 진행을 책임집니다. 반환된 근거를 확인하고, 사용할 수 없는 결과는 다시 시도하거나 수정하며, 영향받지 않은 작업은 계속 진행합니다. 하위 에이전트 하나의 결과만으로 워크플로가 중단되지는 않습니다.
+
+---
+
+## 설계 배경
+
+<details>
+<summary>워크플로 설계의 참고 자료</summary>
+
+- [Why LLMs Are Bad at 'First Try' and Great at Verification](https://www.norsica.jp/blog/llm-verification-over-generation): 복잡한 작업에서 한 번에 생성하는 것보다 리뷰 주기와 세션 분리가 더 신뢰할 수 있는 이유
+- [When Better Models Make Old Agent Workflows Worse](https://www.norsica.jp/blog/when-better-models-make-old-agent-workflows-worse): 모델 내부 경로를 규정하지 않으면서 워크플로 제약이 경계와 근거를 지켜야 하는 이유
+- [Reasoning Effort Is Not a Quality Setting](https://www.norsica.jp/blog/reasoning-effort-is-not-a-quality-setting): 단계가 추가 작업을 선택하고 버릴 수 있을 때만 폭넓은 기술 탐색이 유용한 이유
+- [Stop Putting Everything in AGENTS.md](https://www.norsica.jp/blog/stop-putting-everything-in-agents-md): `AGENTS.md`는 간결하게 유지하고 규칙, 문서, 작업 지침은 사용 지점 가까이에 두어야 하는 이유
+
+</details>
+
+---
+
+## 라이선스
+
+MIT License. 자유롭게 사용, 수정, 배포할 수 있습니다.
+
+---
+
+[@shinpr](https://github.com/shinpr)가 개발하고 유지보수합니다.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Agent Skills](https://img.shields.io/badge/Agent%20Skills-Compatible-blue)](https://developers.openai.com/codex/skills/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+**English** | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md) | [한국어](README.ko.md) | [Português (Brasil)](README.pt-BR.md)
+
 On larger product work, Codex can pursue technical consistency beyond what the user needs. Handling every edge case and making each path deterministic can alter what users see even when the approved outcome does not require it.
 
 codex-workflows keeps that work within the smallest approved outcome. It confirms which user-visible behavior may change, records what must not, and requires evidence before completion. Within those boundaries, Codex chooses reversible implementation details from the repository.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,423 @@
+# codex-workflows
+
+[![Codex CLI](https://img.shields.io/badge/Codex%20CLI-Compatible-10a37f)](https://developers.openai.com/codex/cli)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-Compatible-blue)](https://developers.openai.com/codex/skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+[English](README.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [Español](README.es.md) | [한국어](README.ko.md) | **Português (Brasil)**
+
+Em trabalhos maiores de produto, o Codex pode buscar uma consistência técnica que vai além do que o usuário realmente precisa. Cobrir todos os casos extremos e tornar cada caminho determinístico parece rigoroso, mas pode alterar o que o usuário vê mesmo quando o resultado aprovado não exige isso.
+
+O codex-workflows mantém o trabalho dentro do menor resultado aprovado. Primeiro, deixa claro quais comportamentos visíveis podem mudar e quais devem permanecer intactos; depois, exige evidências antes de considerar o trabalho concluído. Dentro desses limites, o Codex escolhe detalhes de implementação reversíveis com base no que já existe no repositório.
+
+Os fluxos são instalados como Agent Skills e agentes personalizados para o [OpenAI Codex CLI](https://developers.openai.com/codex/cli). A sessão principal do Codex confirma o escopo e o custo aproximado antes do design, acompanha o andamento e decide como tratar as revisões, levando o trabalho aprovado da implementação até uma verificação independente.
+
+---
+
+## Por que não usar o Codex diretamente?
+
+O Codex sozinho é mais indicado para uma correção bem delimitada, um experimento descartável ou um script pontual. Quando o resultado esperado e o limite seguro de implementação já estão claros, essa opção é mais rápida e econômica.
+
+Use o codex-workflows quando uma escolha técnica puder ampliar o escopo do produto, alterar o comportamento percebido pelo usuário ou quando uma decisão precisar sobreviver à troca de contexto.
+
+Por exemplo, um pedido para estender um fluxo de autenticação existente pode acabar criando um segundo mecanismo — tecnicamente mais elegante —, validações mais amplas e um novo contrato de resposta. O frontend pode se adaptar e todos os testes podem passar, mas o usuário recebe um comportamento que nunca foi aprovado.
+
+O codex-workflows controla esse crescimento de escopo ao longo de toda a execução:
+
+| Controle | O que muda |
+|---|---|
+| Escopo | O fluxo compara o pedido com o resultado desejado, as exclusões explícitas, o código existente e o custo aproximado de implementação. O trabalho que não justifica seu custo é removido antes de virar arquitetura. |
+| Controles entre fases | Os resultados de requisitos, design e planejamento são revisados antes de autorizar a próxima fase. Novos agentes leem as decisões aprovadas e as evidências necessárias, em vez de reconstruir a intenção a partir de uma conversa longa. |
+| Execução | Depois que o escopo de implementação é aprovado, o Codex executa o conjunto de tarefas de forma autônoma. Cada tarefa passa por sua verificação específica e pelas checagens aplicáveis do repositório antes do commit de implementação. |
+| Conclusão | Revisões independentes de código e segurança examinam toda a mudança. Correções obrigatórias voltam ao mesmo ciclo de implementação e qualidade; reforços opcionais podem ser recusados quando houver justificativa. |
+
+Esse fluxo usa mais chamadas de agentes e mais tokens do que uma execução direta. Use-o quando proteger o resultado aprovado valer esse custo.
+
+Um caso extremo não exige trabalho só porque o Codex sabe resolvê-lo. Validações adicionais, comportamento determinístico ou uma nova abstração precisam servir para proteger um requisito aprovado ou um contrato observável, ou para corrigir uma falha comprovada.
+
+### Um caso real
+
+A [integração do provedor BytePlus Seedream no mcp-image](https://github.com/shinpr/mcp-image/pull/114) adicionou um terceiro provedor externo de imagens em 18 arquivos. Oito tarefas planejadas permitiram evoluir a implementação específica do provedor sem alterar os contratos públicos de solicitação MCP, cliente, salvamento de arquivos ou URI de arquivo.
+
+Antes do merge, uma avaliação com o serviço real definiu o roteamento final dos modelos, os limites do prompt, o timeout e o tratamento das respostas. Revisões independentes também encontraram uma leitura de arquivo sem limite, uma forma de contornar a validação, um caminho FIFO bloqueante e uma normalização inconsistente das chaves de API. Os quatro problemas foram corrigidos, e o PR passou por 303 testes em 19 arquivos, além de uma chamada real ao provedor sem novas tentativas. Os contratos públicos aprovados permaneceram intactos durante as oito tarefas e as quatro correções.
+
+---
+
+## Início rápido
+
+Requer Node.js 22 ou mais recente e a versão mais atual do [Codex CLI](https://developers.openai.com/codex/cli).
+
+### Instalar e executar
+
+```bash
+cd your-project
+npx codex-workflows install
+```
+
+Depois, invoque um fluxo no Codex CLI:
+
+```
+$recipe-implement Adicione autenticação de usuários com JWT
+```
+
+O prefixo `$` invoca uma skill explicitamente. Digite `$recipe-` para ver os fluxos disponíveis.
+
+### Escolha o ponto de partida
+
+| O que você precisa? | Comece por |
+|---|---|
+| Entregar de ponta a ponta uma mudança de backend, API, CLI ou de propósito geral | `$recipe-implement` |
+| Projetar agora e implementar depois | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
+| Projetar e construir um frontend web com React / TypeScript | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
+| Entregar juntos uma mudança de backend e outra de frontend React | `$recipe-fullstack-implement` |
+| Revisar uma implementação com base no design | `$recipe-review` ou `$recipe-front-review` |
+| Investigar um problema sem alterar o código | `$recipe-diagnose` |
+| Fazer um experimento descartável ou um script pontual | Use o Codex diretamente |
+
+---
+
+## Como funciona
+
+```mermaid
+flowchart LR
+    A[Pedido] --> B[Concordar com o menor resultado útil]
+    B --> C{Há um caminho de implementação evidente?}
+    C -->|Sim| S[Ciclo direto de tarefas e revisão de segurança]
+    S --> L[Concluído]
+    C -->|Não| D[Inspeção, design e revisão]
+    D --> E[Planejar trabalhos dependentes]
+    E --> F[Aprovar o escopo da implementação]
+    F --> H[Por tarefa: implementar, verificar, checar qualidade e fazer commit]
+    H --> K[Verificação independente de código e segurança]
+    K -->|Correção| H
+    K -->|Requisito ou design principal mudou| B
+    K -->|Aprovado| L[Concluído]
+```
+
+O caminho depende da quantidade de decisões independentes de produto e design, não do número de arquivos nem da quantidade de casos extremos que o Codex consegue identificar.
+
+| Tamanho | O que a mudança exige | O que acontece |
+|---------|-----------------------|----------------|
+| Pequeno | Um resultado que segue um padrão existente em uma parte do sistema | Tarefa confirmada → implementação → checagens de qualidade e segurança |
+| Médio | Um resultado que exige coordenação entre partes do sistema ou uma decisão de design duradoura | Design Doc revisado, mais UI Spec / ADR quando necessário → verificação de integração/E2E selecionada → Work Plan revisado → ciclos autônomos de tarefas → verificação final |
+| Grande | Vários resultados que exigem decisões de design separadas | PRD e Design Docs revisados, mais UI Spec / ADR quando necessário → verificação de integração/E2E selecionada → Work Plan revisado → ciclos autônomos de tarefas → verificação final |
+
+Um ADR só é criado para uma escolha duradoura dentro do escopo atual quando existem pelo menos duas opções materialmente diferentes. Se várias escolhas atenderem a esses critérios, seus ADRs são revisados em conjunto. Um teste de integração ou E2E só é escolhido quando um teste mais barato não consegue comprovar a interação necessária. Algumas mudanças não exigem nenhum dos dois.
+
+Somente decisões que afetam o produto ou a implementação do repositório seguem para documentos permanentes do projeto. Aprovação de terceiros, acesso à produção, execução de releases e tarefas operacionais sem relação com a mudança não se tornam bloqueios de implementação.
+
+Depois da aprovação do escopo, o orquestrador executa as tarefas, as verificações específicas, as checagens aplicáveis do repositório e um commit de implementação por tarefa. Primeiro, resolve problemas com base nos documentos aprovados e nas evidências do repositório. O comportamento percebido pelo usuário continua sendo um limite de produto: a implementação não pode ajustá-lo por conta própria em nome da consistência interna. O orquestrador só consulta o usuário quando avançar exige um novo requisito de produto, uma mudança em uma decisão principal já aprovada, uma autorização que apenas o usuário possui ou uma ação irreversível que não foi autorizada.
+
+Os agentes especialistas recebem exatamente os documentos e caminhos necessários para o trabalho. Eles apresentam evidências específicas, mas não têm autoridade para ampliar o resultado aprovado.
+
+### Como as decisões sobrevivem à troca de contexto
+
+Separar os contextos evita que exploração, design, implementação e revisão compartilhem premissas de forma silenciosa. O [modelo de Work Plan](.agents/skills/documentation-criteria/references/plan-template.md) incluído associa cada tarefa de implementação à seção correspondente do Design Doc e aos critérios de aceite:
+
+```markdown
+### P1-T1: Preservar o contrato de respostas de erro
+
+- **Fonte**: `docs/design/example-design.md`, contrato da API, AC-2
+- **Escopo**: Atualizar a implementação do repositório e seus testes específicos
+- **Dependências**: nenhuma
+- **Verificação**: Executar o teste de contrato e observar o formato de resposta documentado
+```
+
+O [Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md) leva para a implementação a fonte, o resultado esperado, os arquivos-alvo e uma verificação executável. Ele só acrescenta um `Verification Focus` quando um teste pode passar sem comprovar um comportamento importante. Após a execução, todas as checagens aplicáveis do repositório rodam sobre a mudança completa antes do commit. Os revisores finais comparam o código concluído com os documentos aprovados e repetem a análise depois das correções aceitas.
+
+---
+
+## Instalação
+
+### Requisitos
+
+- [Codex CLI](https://developers.openai.com/codex/cli) (versão mais recente)
+- Node.js >= 22
+
+### Instalar
+
+Instale no projeto atual:
+
+```bash
+cd your-project
+npx codex-workflows install
+```
+
+Os seguintes itens serão copiados para o projeto:
+
+- `.agents/skills/`: skills do Codex (fundamentos e fluxos)
+- `.codex/agents/`: definições TOML dos subagentes
+- Um manifesto para acompanhar os arquivos gerenciados
+
+Para disponibilizar os fluxos em todos os projetos, instale-os no `CODEX_HOME` do usuário:
+
+```bash
+npx codex-workflows install --user
+```
+
+As skills são instaladas em `$CODEX_HOME/skills/` e os agentes em `$CODEX_HOME/agents/`. Quando `CODEX_HOME` não está definido, o padrão é `~/.codex`.
+
+### Atualizar
+
+```bash
+# Visualizar as mudanças
+npx codex-workflows update --dry-run
+
+# Aplicar a atualização
+npx codex-workflows update
+
+# Atualizar uma instalação de usuário
+npx codex-workflows update --user
+```
+
+O atualizador preserva os arquivos modificados localmente. Ele compara cada arquivo com o hash registrado na instalação e ignora os que mudaram. O histórico versionado de atualizações aplica movimentações e exclusões na ordem correta, de modo que as alterações locais acompanham um arquivo movido até o caminho atual. Arquivos modificados que forem removidos sem substituto são transferidos para `.codex-workflows-preserved/<version>/`. Arquivos novos são adicionados automaticamente.
+
+```bash
+# Consultar a versão instalada
+npx codex-workflows status
+
+# Consultar uma instalação de usuário
+npx codex-workflows status --user
+```
+
+---
+
+## Referência dos fluxos
+
+No Codex, use `$recipe-name` para invocar um fluxo. Digite `$recipe-` e use o preenchimento com Tab para ver todas as opções.
+
+<details>
+<summary>Ver todos os pontos de entrada</summary>
+
+### Backend e uso geral
+
+| Fluxo | O que faz | Quando usar |
+|-------|-----------|-------------|
+| `$recipe-implement` | Ciclo completo com escolha de camada (backend/frontend/fullstack) | Novas funcionalidades (entrada universal) |
+| `$recipe-task` | Uma tarefa com seleção de regras | Correções e mudanças pequenas |
+| `$recipe-design` | Requisitos → documentos de produto e design conforme o porte | Design de produto e arquitetura |
+| `$recipe-plan` | Design Doc → estruturas seletivas de testes de integração/E2E → Work Plan | Planejamento a partir de um Design Doc aprovado |
+| `$recipe-prepare-implementation` | Prepara as ferramentas locais já existentes exigidas por um Work Plan aprovado | Pedido explícito de preparação ou recurso necessário indisponível |
+| `$recipe-build` | Executa tarefas de backend com validação entre etapas | Retomar uma implementação de backend |
+| `$recipe-review` | Valida conformidade com o Design Doc e segurança, com correções aprovadas opcionais | Revisão após a implementação |
+| `$recipe-diagnose` | Investigação → verificação do ponto de falha → solução | Investigação de bugs |
+| `$recipe-reverse-engineer` | Gera PRD e Design Docs com base no código existente | Documentação de sistemas legados |
+| `$recipe-add-integration-tests` | Adiciona testes de integração/E2E a partir do Design Doc | Ampliar a cobertura do código existente |
+| `$recipe-update-doc` | Atualiza e revisa um Design Doc / PRD / ADR existente | Mudanças de especificação e manutenção de documentação |
+
+### Frontend (React/TypeScript)
+
+| Fluxo | O que faz | Quando usar |
+|-------|-----------|-------------|
+| `$recipe-front-design` | Requisitos → documentos de UI e design conforme o porte | Design de produto e arquitetura frontend |
+| `$recipe-front-adjust` | Ajuste delimitado de UI com evidências do repositório, material fornecido ou fontes externas necessárias | Mudanças pontuais de UI após a implementação |
+| `$recipe-front-plan` | Design Doc frontend → estruturas seletivas de integração/E2E → Work Plan | Fase de planejamento frontend |
+| `$recipe-front-build` | Executa tarefas frontend com verificação específica e checagens de qualidade | Retomar uma implementação frontend |
+| `$recipe-front-review` | Valida conformidade e segurança frontend, com correções React aprovadas opcionais | Revisão frontend após a implementação |
+
+### Fullstack (entre camadas)
+
+| Fluxo | O que faz | Quando usar |
+|-------|-----------|-------------|
+| `$recipe-fullstack-implement` | Ciclo completo com um Design Doc separado por camada | Funcionalidades que atravessam camadas |
+| `$recipe-fullstack-build` | Executa tarefas encaminhando agentes conforme a camada | Retomar uma implementação fullstack |
+
+</details>
+
+## Estado de trabalho
+
+Os fluxos usam `docs/plans/` como estado temporário para Work Plans, Task Files de implementação e Task Files provisórios de correção ou adição de testes. O progresso de tarefas e fases é atualizado ali depois de cada commit aprovado pelas checagens de qualidade, mas esses arquivos de estado não entram no commit. Adicione o diretório ao `.gitignore` do projeto, a menos que a equipe queira revisar deliberadamente esses arquivos transitórios:
+
+```gitignore
+docs/plans/
+```
+
+PRDs, ADRs, UI Specs e Design Docs são documentos permanentes do projeto e devem ser incluídos nos commits.
+
+---
+
+## Orientações incluídas
+
+Cada fluxo carrega as orientações adaptadas ao repositório de que a tarefa atual precisa. Raramente é necessário selecionar essas skills manualmente.
+
+<details>
+<summary>Ver skills fundamentais</summary>
+
+| Skill | O que oferece |
+|-------|---------------|
+| `coding-rules` | Qualidade de código, design de funções, tratamento de erros e refatoração |
+| `testing` | TDD proporcional ao escopo, escolha de verificações observáveis, integridade dos testes e verificações exigidas pelo repositório |
+| `ai-development-guide` | Causa raiz apoiada por evidências, análise de impacto proporcional ao escopo e garantia de qualidade aplicável |
+| `reviewee-judgment` | Avaliação baseada em evidências antes que observações de revisão virem trabalho |
+| `documentation-criteria` | Regras e modelos para PRD, ADR, Design Doc e Work Plan |
+| `requirement-convergence` | Resultado, camadas de requisitos, exclusões decididas pelo usuário e custo aproximado antes do design |
+| `implementation-approach` | MVP direto, expansão justificada, redução, divisão e limite de verificação |
+| `integration-e2e-testing` | Seleção e design apenas dos testes de integração/E2E que comprovam uma interação real necessária |
+| `external-resource-context` | Consulta direcionada a uma fonte externa necessária para a decisão atual |
+| `llm-friendly-context` | Contexto claro para os agentes que o usarão depois: prompts, repasses, artefatos gerados, Task Files e observações de revisão |
+| `task-analyzer` | Análise de intenção, classificação de tarefas e seleção de skills |
+| `subagents-orchestration-guide` | Coordenação de múltiplos agentes, condução dos fluxos e execução autônoma guiada |
+
+Também há referências para TypeScript de frontend web, incluindo aplicações React (`coding-rules/references/typescript.md` e `testing/references/typescript.md`). Elas não se aplicam a TypeScript de backend.
+
+</details>
+
+---
+
+## Agentes especializados
+
+O Codex cria esses agentes conforme a necessidade durante a execução dos fluxos. Não é preciso conhecer seus papéis antes: os fluxos encaminham o trabalho para o especialista adequado, enquanto o orquestrador mantém o controle geral. Cada agente trabalha em um contexto próprio, com instruções especializadas e skills obrigatórias nomeadas explicitamente.
+
+<details>
+<summary>Ver todos os agentes especializados</summary>
+
+### Agentes de documentação
+
+| Agente | Função |
+|--------|--------|
+| `requirement-analyzer` | Resume os sinais do pedido e as evidências do repositório necessárias para decisões de escopo e custo |
+| `prd-creator` | Cria e estrutura PRDs |
+| `technical-designer` | Cria um lote completo de ADRs ou um Design Doc (backend/geral) |
+| `technical-designer-frontend` | Cria um lote completo de ADRs ou um Design Doc frontend (React) |
+| `ui-spec-designer` | Cria uma UI Specification a partir do PRD e, opcionalmente, de código de protótipo |
+| `codebase-analyzer` | Reúne evidências concisas do repositório para escolher opções, projetar o mínimo e verificar |
+| `ui-analyzer` | Levanta fatos sobre a UI a partir de recursos externos (ferramentas de design, documentação do design system e interfaces em produção) e do código frontend |
+| `work-planner` | Cria o Work Plan a partir de Design Docs |
+| `document-reviewer` | Revisa documentos com base nos requisitos e decisões de design que os regem |
+| `design-sync` | Verifica a consistência entre documentos |
+
+### Agentes de implementação
+
+| Agente | Função |
+|--------|--------|
+| `task-decomposer` | Converte o Work Plan no menor número possível de Task Files executáveis |
+| `task-executor` | Implementa Task Files com verificação específica (backend) |
+| `task-executor-frontend` | Implementa React com a verificação comportamental RTL aplicável |
+| `quality-fixer` | Executa as checagens aplicáveis do repositório e corrige problemas de qualidade dentro do escopo (backend) |
+| `quality-fixer-frontend` | Executa e corrige checagens aplicáveis de React, TypeScript, RTL e bundle |
+| `acceptance-test-generator` | Gera estruturas para os testes de integração/E2E selecionados |
+| `integration-test-reviewer` | Revisa a qualidade dos testes |
+
+### Agentes de análise
+
+| Agente | Função |
+|--------|--------|
+| `code-reviewer` | Valida a conformidade com o Design Doc |
+| `code-verifier` | Verifica a consistência entre documentos e código |
+| `security-reviewer` | Revisa a segurança depois da implementação |
+| `rule-advisor` | Seleciona skills para tarefas avulsas fora dos fluxos existentes |
+| `scope-discoverer` | Descobre o escopo do código para documentação reversa e agrupa unidades de PRD |
+
+### Agentes de diagnóstico
+
+| Agente | Função |
+|--------|--------|
+| `investigator` | Coleta evidências, mapeia caminhos e encontra pontos de falha |
+| `verifier` | Valida a cobertura dos caminhos e avalia falhas de forma independente |
+| `solver` | Deriva soluções e analisa seus trade-offs |
+
+</details>
+
+---
+
+## Estrutura do projeto
+
+Após a instalação, o projeto recebe:
+
+<details>
+<summary>Ver a estrutura instalada</summary>
+
+```
+your-project/
+├── .agents/skills/           # Skills do Codex
+│   ├── coding-rules/         # Orientações fundamentais
+│   ├── testing/
+│   ├── ai-development-guide/
+│   ├── reviewee-judgment/
+│   ├── documentation-criteria/
+│   ├── requirement-convergence/
+│   ├── implementation-approach/
+│   ├── integration-e2e-testing/
+│   ├── external-resource-context/
+│   ├── llm-friendly-context/
+│   ├── task-analyzer/
+│   ├── subagents-orchestration-guide/
+│   └── recipe-*/             # Pontos de entrada ($recipe-*)
+├── .codex/agents/            # Definições TOML dos subagentes
+│   ├── requirement-analyzer.toml
+│   ├── technical-designer.toml
+│   ├── ui-analyzer.toml
+│   ├── task-executor.toml
+│   └── ... (25 agentes no total)
+└── docs/                     # Criado conforme os fluxos são usados
+    ├── prd/
+    ├── design/
+    ├── adr/
+    ├── ui-spec/
+    └── plans/
+        └── tasks/
+```
+
+</details>
+
+---
+
+## Ferramentas relacionadas
+
+Se os requisitos já estiverem no Linear ou em um PRD existente, o [linear-prism](https://github.com/shinpr/linear-prism) pode ler o código, dividi-los em tarefas prontas para implementação, explicitar as dependências e preservar os limites do Design Doc.
+
+Essas tarefas podem ser passadas para `$recipe-design`, iniciando a fase de design com um escopo mais claro e melhor visibilidade do trabalho.
+
+---
+
+## Perguntas frequentes
+
+**P: Com quais modelos funciona?**
+
+R: O projeto foi criado para os modelos GPT atuais. O modelo pode ser configurado por agente nos arquivos TOML.
+
+**P: Posso personalizar os agentes?**
+
+R: Sim. Edite os arquivos TOML em `.codex/agents/` para alterar `model`, `sandbox_mode` ou `developer_instructions`. As skills obrigatórias de cada agente aparecem em `developer_instructions`. Os arquivos modificados localmente são preservados ao executar `npx codex-workflows update`.
+
+Em uma instalação de usuário, edite os arquivos em `$CODEX_HOME/agents/` e use `npx codex-workflows update --user`. Arquivos de usuário alterados após a instalação são preservados da mesma forma.
+
+**P: Qual é a diferença entre `$recipe-implement` e `$recipe-fullstack-implement`?**
+
+R: `$recipe-implement` é o ponto de entrada universal. Primeiro ele executa requirement-analyzer, identifica as camadas afetadas com base no pedido e no escopo do repositório e encaminha automaticamente para o fluxo backend, frontend ou fullstack. `$recipe-fullstack-implement` pula essa detecção e entra direto no fluxo fullstack: Design Docs separados por camada, design-sync e execução de tarefas de acordo com a camada. Use `$recipe-implement` quando não tiver certeza e `$recipe-fullstack-implement` quando já souber que a funcionalidade envolve as duas camadas.
+
+**P: Funciona com servidores MCP?**
+
+R: Sim. As skills e os subagentes do Codex funcionam junto com o [MCP](https://developers.openai.com/codex/mcp). As skills operam na camada de instruções, enquanto o MCP opera na camada de transporte de ferramentas. Se o TOML do agente não definir `mcp_servers`, o agente personalizado herda os `mcp_servers` do pai. Adicione configuração MCP específica ao agente apenas quando precisar de servidores próprios ou filtragem de ferramentas.
+
+**P: Como este projeto se relaciona com o claude-code-workflows?**
+
+R: [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) é o projeto equivalente para Claude Code. Os dois repositórios compartilham a mesma filosofia de fluxo, adaptada aos pontos de extensão nativos de cada ferramenta. Eles podem coexistir no mesmo projeto porque o codex-workflows instala as definições em `.codex/agents/`, enquanto o Claude Code usa seu próprio diretório `.claude/`.
+
+**P: O que fazer se um subagente parecer travado?**
+
+R: A sessão principal do Codex é responsável pelo andamento. Ela inspeciona as evidências recebidas, repete ou corrige resultados inutilizáveis e continua o trabalho não afetado. O resultado de um subagente, por si só, não interrompe o fluxo.
+
+---
+
+## Fundamentos do design
+
+<details>
+<summary>Leituras que fundamentam o design do fluxo</summary>
+
+- [Why LLMs Are Bad at 'First Try' and Great at Verification](https://www.norsica.jp/blog/llm-verification-over-generation): por que ciclos de revisão e separação de sessões são mais confiáveis do que uma única geração em trabalhos complexos
+- [When Better Models Make Old Agent Workflows Worse](https://www.norsica.jp/blog/when-better-models-make-old-agent-workflows-worse): por que as restrições do fluxo devem proteger limites e evidências sem prescrever o caminho interno do modelo
+- [Reasoning Effort Is Not a Quality Setting](https://www.norsica.jp/blog/reasoning-effort-is-not-a-quality-setting): por que uma exploração técnica mais ampla só ajuda quando a fase consegue selecionar e descartar o trabalho adicional
+- [Stop Putting Everything in AGENTS.md](https://www.norsica.jp/blog/stop-putting-everything-in-agents-md): por que o `AGENTS.md` deve permanecer enxuto, com regras, documentos e instruções perto do ponto de uso
+
+</details>
+
+---
+
+## Licença
+
+Licença MIT. Uso, modificação e distribuição são livres.
+
+---
+
+Criado e mantido por [@shinpr](https://github.com/shinpr).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,423 @@
+# codex-workflows
+
+[![Codex CLI](https://img.shields.io/badge/Codex%20CLI-Compatible-10a37f)](https://developers.openai.com/codex/cli)
+[![Agent Skills](https://img.shields.io/badge/Agent%20Skills-Compatible-blue)](https://developers.openai.com/codex/skills/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+[English](README.md) | **简体中文** | [日本語](README.ja.md) | [Español](README.es.md) | [한국어](README.ko.md) | [Português (Brasil)](README.pt-BR.md)
+
+面对规模较大的产品开发，Codex有时会为了技术上的一致性，把事情做得比用户真正需要的更多。穷尽所有边界情况、让每条路径都得到确定结果，看似严谨，却可能在既定目标并不要求的地方改变用户实际看到的行为。
+
+codex-workflows把工作限制在“已确认的最小目标”之内。它先明确哪些用户可见行为允许改变、哪些绝不能动，并要求在结束前拿出验证依据。在这些边界内，Codex再结合仓库现状，选择容易回退的实现细节。
+
+这些工作流以Agent Skills和自定义代理的形式安装到[OpenAI Codex CLI](https://developers.openai.com/codex/cli)中。主Codex会话在设计前确认范围和大致成本，负责推进工作并处理评审意见，再将获批的工作一路推进到实现和独立验证。
+
+---
+
+## 为什么不直接使用Codex？
+
+如果只是范围明确的修复、一次性实验或临时脚本，直接使用Codex更合适。当预期结果和安全的实现边界已经很清楚时，这样更快，成本也更低。
+
+如果技术选择可能改变产品范围、用户可见行为，或者某项决策需要跨上下文长期保留，就适合使用codex-workflows。
+
+比如，“扩展现有认证流程”这项需求，可能逐渐演变成第二套认证机制、更宽泛的校验和新的响应约定。前端可以跟着适配，测试也都能通过，但用户最终得到的行为却从未经过确认。
+
+codex-workflows会在整个执行过程中约束这种范围膨胀：
+
+| 控制点 | 带来的变化 |
+|---|---|
+| 范围 | 工作流会对照预期结果、明确排除项、现有代码和大致实现成本来检查需求。投入与收益不相称的工作，会在演变成架构设计之前被删掉。 |
+| 阶段门槛 | 需求、设计和计划的产出必须先通过检查，才能授权下一阶段。新代理直接读取已经批准的决策和所需依据，无须从一段很长的对话中重新猜测意图。 |
+| 执行 | 实现范围获批后，Codex会自主完成整组任务。每项任务都要通过针对性验证和仓库要求的检查，之后才会提交实现。 |
+| 完成 | 独立的代码和安全评审会检查全部改动。必须修复的问题会回到相同的实现与质量流程；可选的加固项则可以在有依据的情况下不做。 |
+
+与直接执行相比，这套工作流会调用更多代理、消耗更多token。只有当保护既定目标值得这笔成本时，才需要使用它。
+
+Codex能处理某个边界情况，并不代表这项工作就有必要做。额外校验、确定性行为或新的抽象层，必须是为了保护已批准的需求或可观测契约，或者处理已经证实的故障。
+
+### 一次真实的工作流运行
+
+[mcp-image中的BytePlus Seedream提供商集成](https://github.com/shinpr/mcp-image/pull/114)跨18个文件加入了第三家外部图像服务。8项计划任务在逐步完善提供商特有实现的同时，始终没有改变公开的MCP请求、客户端、文件保存和文件URI契约。
+
+合并前针对真实服务的评估确定了最终的模型路由、提示词上限、超时和响应处理方式。独立评审还发现了无上限文件读取、绕过校验、会阻塞的FIFO路径，以及API密钥规范化不一致等问题。这四项问题全部得到修复，PR最终通过了19个文件中的303项测试，以及一次不重试的真实服务调用。8项任务和4次修复从头到尾都没有改变已经批准的公开契约。
+
+---
+
+## 快速开始
+
+需要Node.js 22或更高版本，以及最新的[Codex CLI](https://developers.openai.com/codex/cli)。
+
+### 安装并运行
+
+```bash
+cd your-project
+npx codex-workflows install
+```
+
+然后在Codex CLI中调用一个工作流：
+
+```
+$recipe-implement 使用JWT添加用户认证
+```
+
+`$`表示显式调用一项技能。输入`$recipe-`即可查看可用工作流。
+
+### 选择合适的入口
+
+| 你的目标 | 从这里开始 |
+|---|---|
+| 完整交付后端、API、CLI或一般改动 | `$recipe-implement` |
+| 先完成设计，稍后再实现 | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
+| 设计并实现React / TypeScript Web前端 | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
+| 同时交付后端和React前端改动 | `$recipe-fullstack-implement` |
+| 按照设计评审实现 | `$recipe-review` 或 `$recipe-front-review` |
+| 调查问题但不修改代码 | `$recipe-diagnose` |
+| 做一次性实验或临时脚本 | 直接使用Codex |
+
+---
+
+## 工作原理
+
+```mermaid
+flowchart LR
+    A[需求] --> B[确认最小且有用的目标]
+    B --> C{实现路径是否已经明确？}
+    C -->|是| S[直接任务循环与安全评审]
+    S --> L[完成]
+    C -->|否| D[调研、设计与评审]
+    D --> E[规划存在依赖关系的工作]
+    E --> F[批准实现范围]
+    F --> H[逐项实现、验证、质量检查并提交]
+    H --> K[独立代码和安全验证]
+    K -->|需要修正| H
+    K -->|需求或主要设计发生变化| B
+    K -->|通过| L[完成]
+```
+
+决定采用哪条路径的，是互相独立的产品和设计决策数量，而不是文件数量，也不是Codex能找出多少边界情况。
+
+| 规模 | 改动所需条件 | 执行方式 |
+|------|--------------|----------|
+| 小 | 一个目标，并且能在系统的某一部分沿用现有模式 | 确认任务 → 实现 → 质量和安全检查 |
+| 中 | 一个目标，但需要系统多个部分相互配合，或需要作出长期保留的设计决策 | 已评审的Design Doc，必要时补充UI Spec / ADR → 选定集成/E2E验证 → 已评审的Work Plan → 自主任务循环 → 最终验证 |
+| 大 | 多个目标，并且各自需要设计决策 | 已评审的PRD和Design Doc，必要时补充UI Spec / ADR → 选定集成/E2E验证 → 已评审的Work Plan → 自主任务循环 → 最终验证 |
+
+只有当前范围中存在一项需要长期保留的选择，并且至少有两个实质不同的方案时，才会创建ADR。若有多项选择符合条件，会集中评审这些ADR。只有成本更低的测试无法证明所需交互时，才会选择集成或E2E测试。有些改动两者都不需要。
+
+只有会影响产品或仓库实现的决策，才会写进需要长期保留的项目文档。第三方审批、生产环境权限、发布操作和无关的运维工作，不会变成实现阶段的门槛。
+
+实现范围获批后，编排器会执行任务、针对性验证、适用的仓库检查，并为每项任务生成一次实现提交。遇到问题时，它会优先根据已批准的文档和仓库证据自行解决。用户可见行为始终是产品边界，不能为了内部一致性而由实现擅自调整。只有当继续推进需要新增产品需求、改变已批准的主要设计决策、使用只有你拥有的权限，或执行未经授权且无法撤销的操作时，编排器才会询问你。
+
+专业代理只会收到为各自工作明确指定的文档和路径。它们负责提供与任务直接相关的依据，但无权扩大已经批准的目标。
+
+### 如何让决策在新上下文中继续生效
+
+将上下文分开，可以避免调研、设计、实现和评审在不知不觉间共享未经说明的前提。内置的[Work Plan模板](.agents/skills/documentation-criteria/references/plan-template.md)会把每项实现任务关联到Design Doc中的对应章节和验收标准：
+
+```markdown
+### P1-T1: 保持错误响应契约不变
+
+- **来源**: `docs/design/example-design.md`，API契约，AC-2
+- **范围**: 更新仓库实现及对应的针对性测试
+- **依赖**: 无
+- **验证**: 运行契约测试，确认响应结构符合文档
+```
+
+[Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md)会把来源、预期结果、目标文件和可执行的验证方法传递到实现阶段。只有在测试可能通过、却没有证明某项关键行为时，才会增加`Verification Focus`。任务执行完毕后，完整改动必须在提交前通过适用的仓库检查。最终评审者会将完成的代码与已批准文档逐项对照，并在接受的修正完成后重新检查。
+
+---
+
+## 安装
+
+### 环境要求
+
+- 最新版[Codex CLI](https://developers.openai.com/codex/cli)
+- Node.js 22或更高版本
+
+### 安装方式
+
+安装到当前项目：
+
+```bash
+cd your-project
+npx codex-workflows install
+```
+
+以下内容会被复制到项目中：
+
+- `.agents/skills/`：Codex技能（基础技能和工作流）
+- `.codex/agents/`：子代理TOML定义
+- 用于跟踪托管文件的清单
+
+如果希望所有项目都能使用这些工作流，请改为安装到用户级`CODEX_HOME`：
+
+```bash
+npx codex-workflows install --user
+```
+
+技能会安装到`$CODEX_HOME/skills/`，代理会安装到`$CODEX_HOME/agents/`。未设置`CODEX_HOME`时，默认使用`~/.codex`。
+
+### 更新
+
+```bash
+# 预览变更
+npx codex-workflows update --dry-run
+
+# 应用更新
+npx codex-workflows update
+
+# 更新用户级安装
+npx codex-workflows update --user
+```
+
+更新程序会保留你在本地修改过的文件。它会把每个文件与安装时的哈希值进行比较，并跳过已经改动的文件。带版本的更新历史会按顺序处理文件移动和删除，因此本地修改也会跟随文件移动到新路径。已修改但被移除且没有替代文件的内容，会转移到`.codex-workflows-preserved/<version>/`。新增文件则会自动加入。
+
+```bash
+# 查看已安装版本
+npx codex-workflows status
+
+# 查看用户级安装状态
+npx codex-workflows status --user
+```
+
+---
+
+## 工作流参考
+
+在Codex中使用`$recipe-name`调用工作流。输入`$recipe-`并使用Tab补全，可以查看所有可用选项。
+
+<details>
+<summary>查看全部工作流入口</summary>
+
+### 后端与通用开发
+
+| 工作流 | 功能 | 适用场景 |
+|--------|------|----------|
+| `$recipe-implement` | 完整生命周期，并根据层次分流（后端/前端/全栈） | 新功能（通用入口） |
+| `$recipe-task` | 单项任务，并自动选择规则 | 修复缺陷、小改动 |
+| `$recipe-design` | 需求 → 根据规模选择产品和设计文档 | 产品与架构设计 |
+| `$recipe-plan` | Design Doc → 按需生成集成/E2E测试骨架 → Work Plan | 根据已批准的Design Doc制定计划 |
+| `$recipe-prepare-implementation` | 准备已批准Work Plan所需的现有仓库内工具 | 明确要求准备环境，或任务所需能力不可用 |
+| `$recipe-build` | 执行后端任务，并在各步骤之间验证 | 继续后端实现 |
+| `$recipe-review` | 检查Design Doc符合性和安全性，并按需完成已批准修正 | 实现后检查 |
+| `$recipe-diagnose` | 调查问题 → 验证故障点 → 提出解决方案 | 缺陷调查 |
+| `$recipe-reverse-engineer` | 从现有代码生成PRD和Design Doc | 遗留系统文档化 |
+| `$recipe-add-integration-tests` | 根据Design Doc添加集成/E2E测试 | 为现有代码补充测试 |
+| `$recipe-update-doc` | 评审并更新已有Design Doc / PRD / ADR | 规格变更、文档维护 |
+
+### 前端（React/TypeScript）
+
+| 工作流 | 功能 | 适用场景 |
+|--------|------|----------|
+| `$recipe-front-design` | 需求 → 根据规模选择UI和设计文档 | 前端产品与架构设计 |
+| `$recipe-front-adjust` | 根据仓库、已有资料或必要外部依据进行针对性UI调整 | 实现后的局部UI修改 |
+| `$recipe-front-plan` | 前端Design Doc → 按需生成集成/E2E测试骨架 → Work Plan | 前端规划阶段 |
+| `$recipe-front-build` | 执行前端任务，并进行针对性验证和质量检查 | 继续前端实现 |
+| `$recipe-front-review` | 检查前端符合性和安全性，并按需完成已批准的React修正 | 前端实现后检查 |
+
+### 全栈（跨层）
+
+| 工作流 | 功能 | 适用场景 |
+|--------|------|----------|
+| `$recipe-fullstack-implement` | 完整生命周期，每一层使用独立Design Doc | 跨层功能 |
+| `$recipe-fullstack-build` | 根据层次把任务交给对应代理执行 | 继续全栈实现 |
+
+</details>
+
+## 工作状态
+
+工作流使用`docs/plans/`存放临时状态，包括Work Plan、实现Task File，以及临时的评审修复或测试补充Task File。每次实现提交通过质量检查后，这里会更新任务和阶段进度，但这些进度文件不会进入实现提交。除非团队希望评审这些临时文件，否则请把该目录加入项目的`.gitignore`：
+
+```gitignore
+docs/plans/
+```
+
+PRD、ADR、UI Spec和Design Doc属于需要长期保存的项目文档，应当提交。
+
+---
+
+## 内置指导原则
+
+工作流会自动加载当前任务所需、并且了解仓库约定的指导原则。通常不需要手动选择这些技能。
+
+<details>
+<summary>查看基础技能</summary>
+
+| 技能 | 提供的能力 |
+|------|------------|
+| `coding-rules` | 代码质量、函数设计、错误处理、重构 |
+| `testing` | 与任务规模相称的TDD、可观测验证方式选择、测试完整性和仓库规定的检查 |
+| `ai-development-guide` | 基于证据的根因分析、合理的影响评估和适用的质量保证 |
+| `reviewee-judgment` | 在评审意见转化为修改工作前，先根据证据进行判断 |
+| `documentation-criteria` | 文档创建规则和模板（PRD、ADR、Design Doc、Work Plan） |
+| `requirement-convergence` | 在设计前明确目标、需求层次、用户决定的排除项和大致成本 |
+| `implementation-approach` | 直接MVP、有依据的扩展、删减、切分和验证边界 |
+| `integration-e2e-testing` | 只选择和设计能够证明必要真实交互的集成/E2E测试 |
+| `external-resource-context` | 针对当前决策，只查找并确认所需的一项外部依据 |
+| `llm-friendly-context` | 供后续代理使用的清晰提示、交接内容、生成文档、Task File和评审意见 |
+| `task-analyzer` | 分析任务意图、任务分类和技能选择 |
+| `subagents-orchestration-guide` | 多代理协调、工作流推进和按既定指引自主执行 |
+
+另有面向Web前端TypeScript（包括React应用）的参考资料：`coding-rules/references/typescript.md`和`testing/references/typescript.md`。这些内容不适用于后端TypeScript。
+
+</details>
+
+---
+
+## 专业代理
+
+执行工作流时，Codex会按需启动以下代理。你无须事先掌握这些角色：工作流会把不同领域的任务交给对应代理，编排器继续掌控整体流程。每个代理都有独立上下文、专业指令和明确列出的必需技能。
+
+<details>
+<summary>查看全部专业代理角色</summary>
+
+### 文档创建代理
+
+| 代理 | 职责 |
+|------|------|
+| `requirement-analyzer` | 整理需求中的关键信号，以及支持编排器判断范围和成本的仓库证据 |
+| `prd-creator` | 创建并组织PRD |
+| `technical-designer` | 创建完整ADR批次或Design Doc（后端/通用） |
+| `technical-designer-frontend` | 创建完整的前端ADR批次或Design Doc（React） |
+| `ui-spec-designer` | 根据PRD和可选原型代码创建UI Specification |
+| `codebase-analyzer` | 为方案选择、最小设计和验证收集精简的仓库证据 |
+| `ui-analyzer` | 从外部资源（设计工具、设计系统文档、线上UI）和前端代码中整理UI事实 |
+| `work-planner` | 根据Design Doc创建Work Plan |
+| `document-reviewer` | 按照上层需求和设计决策评审文档 |
+| `design-sync` | 验证不同文档之间的一致性 |
+
+### 实现代理
+
+| 代理 | 职责 |
+|------|------|
+| `task-decomposer` | 将Work Plan拆成数量最少、可以执行的Task File |
+| `task-executor` | 根据Task File实现并完成针对性验证（后端） |
+| `task-executor-frontend` | 实现React改动，并完成适用的行为型RTL验证 |
+| `quality-fixer` | 执行适用的仓库检查，修复范围内的质量问题（后端） |
+| `quality-fixer-frontend` | 执行并修复适用的React、TypeScript、RTL和打包检查 |
+| `acceptance-test-generator` | 生成已选定的集成/E2E测试骨架 |
+| `integration-test-reviewer` | 评审测试质量 |
+
+### 分析代理
+
+| 代理 | 职责 |
+|------|------|
+| `code-reviewer` | 验证实现是否符合Design Doc |
+| `code-verifier` | 验证文档与代码的一致性 |
+| `security-reviewer` | 实现后进行安全符合性评审 |
+| `rule-advisor` | 为不受现有工作流管理的独立任务选择技能 |
+| `scope-discoverer` | 为逆向文档发现代码库范围，并整理PRD单元 |
+
+### 诊断代理
+
+| 代理 | 职责 |
+|------|------|
+| `investigator` | 收集证据、梳理路径并发现故障点 |
+| `verifier` | 验证路径覆盖，并独立评估故障点 |
+| `solver` | 权衡取舍，推导解决方案 |
+
+</details>
+
+---
+
+## 项目结构
+
+安装后，项目中会增加以下内容：
+
+<details>
+<summary>查看安装后的目录结构</summary>
+
+```
+your-project/
+├── .agents/skills/           # Codex技能
+│   ├── coding-rules/         # 基础指导原则
+│   ├── testing/
+│   ├── ai-development-guide/
+│   ├── reviewee-judgment/
+│   ├── documentation-criteria/
+│   ├── requirement-convergence/
+│   ├── implementation-approach/
+│   ├── integration-e2e-testing/
+│   ├── external-resource-context/
+│   ├── llm-friendly-context/
+│   ├── task-analyzer/
+│   ├── subagents-orchestration-guide/
+│   └── recipe-*/             # 工作流入口（$recipe-*）
+├── .codex/agents/            # 子代理TOML定义
+│   ├── requirement-analyzer.toml
+│   ├── technical-designer.toml
+│   ├── ui-analyzer.toml
+│   ├── task-executor.toml
+│   └── ...（共25个代理）
+└── docs/                     # 使用工作流时创建
+    ├── prd/
+    ├── design/
+    ├── adr/
+    ├── ui-spec/
+    └── plans/
+        └── tasks/
+```
+
+</details>
+
+---
+
+## 配套工具
+
+如果需求已经记录在Linear或现有PRD中，[linear-prism](https://github.com/shinpr/linear-prism)可以读取代码库，将需求拆成能够直接实现的任务，同时明确依赖关系，并保持Design Doc的边界。
+
+之后可以把这些任务交给`$recipe-design`，在范围更清楚、任务更直观的基础上进入设计阶段。
+
+---
+
+## 常见问题
+
+**问：支持哪些模型？**
+
+答：本项目面向当前的GPT模型设计。每个代理使用的模型都可以在TOML文件中配置。
+
+**问：可以自定义代理吗？**
+
+答：可以。编辑`.codex/agents/`中的TOML文件，即可修改`model`、`sandbox_mode`或`developer_instructions`。每个代理所需的技能都列在`developer_instructions`中。本地修改过的文件会在运行`npx codex-workflows update`时保留。
+
+如果采用用户级安装，请编辑`$CODEX_HOME/agents/`中的文件，并使用`npx codex-workflows update --user`。安装后修改的用户级文件也会以同样方式保留。
+
+**问：`$recipe-implement`和`$recipe-fullstack-implement`有什么区别？**
+
+答：`$recipe-implement`是通用入口。它会先运行requirement-analyzer，根据需求和仓库范围判断受影响的层，再自动进入后端、前端或全栈流程。`$recipe-fullstack-implement`跳过判断，直接进入全栈流程（每层单独的Design Doc、design-sync，以及按层分配任务）。如果不确定该走哪条路径，请使用`$recipe-implement`；如果一开始就知道功能横跨前后端，请使用`$recipe-fullstack-implement`。
+
+**问：能与MCP服务器一起使用吗？**
+
+答：可以。Codex技能和子代理可以与[MCP](https://developers.openai.com/codex/mcp)同时使用。技能位于指令层，MCP位于工具传输层。代理TOML没有设置`mcp_servers`时，自定义代理会继承父级的`mcp_servers`；只有代理需要专属服务器或工具过滤时，才需要添加代理级MCP配置。
+
+**问：它与claude-code-workflows有什么关系？**
+
+答：[claude-code-workflows](https://github.com/shinpr/claude-code-workflows)是面向Claude Code的对应项目。两个仓库采用相同的工作流理念，再针对各自工具原生的扩展方式进行适配。它们可以安装在同一项目中，因为codex-workflows把代理定义放在`.codex/agents/`，Claude Code则使用自己的`.claude/`目录。
+
+**问：子代理似乎卡住了怎么办？**
+
+答：主Codex会话负责推进工作。它会检查返回的证据，对无法使用的结果重新尝试或修正，同时继续不受影响的其他工作。单个子代理的结果本身不会让整个工作流停止。
+
+---
+
+## 设计思路
+
+<details>
+<summary>了解工作流设计背后的资料</summary>
+
+- [Why LLMs Are Bad at 'First Try' and Great at Verification](https://www.norsica.jp/blog/llm-verification-over-generation)：为什么面对复杂工作，评审循环和会话隔离比一次生成更可靠
+- [When Better Models Make Old Agent Workflows Worse](https://www.norsica.jp/blog/when-better-models-make-old-agent-workflows-worse)：为什么工作流约束应保护边界和证据，而不是规定模型内部必须走哪条路径
+- [Reasoning Effort Is Not a Quality Setting](https://www.norsica.jp/blog/reasoning-effort-is-not-a-quality-setting)：为什么只有当前阶段有能力筛选并放弃额外工作时，更广泛的技术探索才有价值
+- [Stop Putting Everything in AGENTS.md](https://www.norsica.jp/blog/stop-putting-everything-in-agents-md)：为什么`AGENTS.md`应保持精简，而规则、文档和任务说明应靠近实际使用位置
+
+</details>
+
+---
+
+## 许可证
+
+MIT License。可自由使用、修改和分发。
+
+---
+
+由[@shinpr](https://github.com/shinpr)开发并维护。


### PR DESCRIPTION
## Summary

- add complete README translations for Simplified Chinese, Japanese, Spanish, Korean, and Brazilian Portuguese
- add language navigation across the English and localized README files
- preserve recipe names, commands, paths, links, and numerical facts while adapting the prose for natural use by developers in each language

## Translation review

- incorporate native-language review feedback for proof, evidence, focused verification, phase gates, and other abstract workflow terms
- restore omitted source details such as existing repository-local tools, downstream agents, guided autonomous execution, behavior-focused RTL verification, and applicable checks
- keep intentional product terms such as Design Doc, Work Plan, Task File, Agent Skills, and recipe command names unchanged where they are clearer to developers

## Validation

- confirmed matching structure across all six README files: 13 primary sections, 15 subsections, 18 recipe rows, 20 code fences, and 10 details tags
- verified URL and numerical fact parity, including the workflow example and agent count
- checked Markdown whitespace with git diff --check
- passed the repository check-skills-index commit hook

Documentation-only change; no runtime tests were required.