### PR TITLE
docs: document Nautilus workflow handoff

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -364,9 +364,9 @@ your-project/
 
 ## Herramientas relacionadas
 
-Si los requisitos ya están en Linear o en un PRD, [linear-prism](https://github.com/shinpr/linear-prism) puede leer el código, dividirlos en tareas listas para implementar, hacer explícitas sus dependencias y conservar las fronteras del Design Doc.
+Cuando una idea de producto todavía necesita exploración o validación, [Nautilus](https://github.com/shinpr/nautilus) puede poner a prueba sus supuestos y convertir los resultados en un PRD. Una vez aprobado, pasa el PRD a `$recipe-implement` o `$recipe-design`.
 
-Esas tareas pueden pasarse a `$recipe-design` para entrar en la fase de diseño con el alcance más claro y una mejor visión del trabajo.
+Si los requisitos ya están en Linear o en un PRD, [linear-prism](https://github.com/shinpr/linear-prism) puede leer el código, dividir el trabajo en incidencias de Linear listas para implementar y registrar qué incidencias bloquean a otras. Usa una incidencia aprobada como entrada para `$recipe-design`.
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -364,9 +364,9 @@ your-project/
 
 ## 連携できるツール
 
-要件がすでにLinearや既存のPRDにまとまっている場合は、[linear-prism](https://github.com/shinpr/linear-prism)を使うと、コードベースを読みながら要件を実装可能なタスクへ分解し、依存関係を明示しつつDesign Docの境界を維持できます。
+プロダクトのアイデアをさらに探索・検証したい場合は、[Nautilus](https://github.com/shinpr/nautilus)を使って前提を確かめ、その結果をPRDにまとめられます。承認後は、そのPRDを`$recipe-implement`または`$recipe-design`へ渡せます。
 
-作成したタスクを`$recipe-design`へ渡せば、スコープが明確で見通しのよい状態から設計フェーズを始められます。
+要件がすでにLinearや既存のPRDにまとまっている場合は、[linear-prism](https://github.com/shinpr/linear-prism)を使うと、コードベースを読みながら実装可能なLinearのissueへ分解し、依存関係を明示できます。承認したissueは`$recipe-design`の入力にできます。
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -364,9 +364,9 @@ your-project/
 
 ## 함께 사용할 수 있는 도구
 
-요구사항이 이미 Linear나 기존 PRD에 있다면 [linear-prism](https://github.com/shinpr/linear-prism)이 코드베이스를 읽어 구현 가능한 작업으로 나누고, 의존성을 명확히 하며, Design Doc 경계를 유지할 수 있습니다.
+제품 아이디어를 더 탐색하거나 검증해야 한다면 [Nautilus](https://github.com/shinpr/nautilus)로 관련 가설을 확인하고 그 결과를 PRD로 정리할 수 있습니다. 승인된 PRD를 `$recipe-implement`나 `$recipe-design`에 전달하세요.
 
-이 작업을 `$recipe-design`에 전달하면 범위와 작업을 더 명확히 파악한 상태에서 설계 단계를 시작할 수 있습니다.
+요구사항이 이미 Linear나 기존 PRD에 있다면 [linear-prism](https://github.com/shinpr/linear-prism)이 코드베이스를 읽어 구현 가능한 Linear 이슈로 나누고 이슈 간 의존 관계를 기록할 수 있습니다. 승인된 이슈를 `$recipe-design`의 입력으로 사용하세요.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -365,9 +365,9 @@ your-project/
 
 ## Works With
 
-If your requirements already live in Linear or an existing PRD, [linear-prism](https://github.com/shinpr/linear-prism) can decompose them into implementation-ready tasks by reading the codebase, making dependencies explicit, and preserving Design Doc boundaries.
+When a product idea still needs discovery or validation, [Nautilus](https://github.com/shinpr/nautilus) can test the assumptions behind it and turn the results into a PRD. Pass the approved PRD to `$recipe-implement` or `$recipe-design`.
 
-Those tasks can then be passed into `$recipe-design` to enter the design phase with clearer scope and better task visibility.
+If requirements already live in Linear or an existing PRD, [linear-prism](https://github.com/shinpr/linear-prism) can read the codebase, split the work into implementation-ready Linear issues, and record blocking relationships. Use an approved issue as input to `$recipe-design`.
 
 ---
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -364,9 +364,9 @@ your-project/
 
 ## Ferramentas relacionadas
 
-Se os requisitos já estiverem no Linear ou em um PRD existente, o [linear-prism](https://github.com/shinpr/linear-prism) pode ler o código, dividi-los em tarefas prontas para implementação, explicitar as dependências e preservar os limites do Design Doc.
+Quando uma ideia de produto ainda precisa de descoberta ou validação, o [Nautilus](https://github.com/shinpr/nautilus) pode testar as premissas por trás dela e transformar os resultados em um PRD. Depois da aprovação, passe o PRD para `$recipe-implement` ou `$recipe-design`.
 
-Essas tarefas podem ser passadas para `$recipe-design`, iniciando a fase de design com um escopo mais claro e melhor visibilidade do trabalho.
+Se os requisitos já estiverem no Linear ou em um PRD existente, o [linear-prism](https://github.com/shinpr/linear-prism) pode ler o código, dividir o trabalho em issues do Linear prontas para implementação e registrar as dependências entre elas. Use uma issue aprovada como entrada para `$recipe-design`.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -364,9 +364,9 @@ your-project/
 
 ## 配套工具
 
-如果需求已经记录在Linear或现有PRD中，[linear-prism](https://github.com/shinpr/linear-prism)可以读取代码库，将需求拆成能够直接实现的任务，同时明确依赖关系，并保持Design Doc的边界。
+产品想法还需要进一步探索或验证时，可以用[Nautilus](https://github.com/shinpr/nautilus)检验相关假设，并将结果整理成PRD。PRD获批后，可将其交给`$recipe-implement`或`$recipe-design`。
 
-之后可以把这些任务交给`$recipe-design`，在范围更清楚、任务更直观的基础上进入设计阶段。
+如果需求已经记录在Linear或现有PRD中，[linear-prism](https://github.com/shinpr/linear-prism)可以结合代码库，将工作拆成可直接实施的Linear任务，并明确任务之间的依赖关系。获批的任务可作为`$recipe-design`的输入。
 
 ---
 


### PR DESCRIPTION
## Summary

- document Nautilus as the discovery and validation path that hands an approved PRD to `$recipe-implement` or `$recipe-design`
- clarify how linear-prism hands approved Linear issues to the design workflow
- keep the localized README variants aligned with the English documentation

## Verification

- `npm test`
- `npm run check:skills-index`
- `git diff --check`