### PR TITLE
Converge final verification reruns

### DIFF
--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -273,7 +273,7 @@ Code-verifier runs correspond to durable governing documents. The Small path pas
 
 #### Post-Verification Rerun Rule
 
-Apply Review Resolution to verifier findings. Consolidate the `apply` set into the fewest executor-routed ephemeral tasks, execute them through the normal task cycle, then re-run the verifiers affected by the actual repository changes. Delete the ephemeral task files after verification passes. A remaining unusable result enters Orchestrator Escalation Resolution.
+Apply Review Resolution to verifier findings. Consolidate the `apply` set into the fewest executor-routed ephemeral tasks, execute them through the normal task cycle, then re-run only verifiers classified as Fail by the table above. A Pass result completes that verifier's work for this build. Delete the ephemeral task files after final verification. A remaining unusable result enters Orchestrator Escalation Resolution.
 
 ## Main Orchestrator Roles
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Codex CLI workflows that keep larger software changes within the approved scope, from planning through review",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

- rerun only final verifiers that failed
- keep a verifier complete after its first passing result
- align cleanup with the final verification phase
- bump the package version to 1.2.2

## Verification

- npm run check:skills-index
- npm test
- git diff --check