### PR TITLE
Use repository quality profiles during implementation

### DIFF
--- a/.codex/agents/task-executor-frontend.toml
+++ b/.codex/agents/task-executor-frontend.toml
@@ -81,7 +81,7 @@ When the task file, Dependencies, or Investigation Targets reference `docs/proje
 **Unavailable**: Return `escalation_needed` with the missing repository-local capability, affected verification, and command evidence so the caller can run the preparation side path.
 
 #### Pre-implementation Verification (Pattern 5 Compliant)
-1. **Read Governing Sources** and extract required contracts, UI behavior, scope boundaries, and verification expectations. Resolve cited document sections when present; otherwise use the embedded confirmed requirement scope.
+1. **Read Governing Sources** and extract required contracts, UI behavior, scope boundaries, and verification expectations. When `docs/project-context/quality.yaml` exists, use it as implementation guidance. Resolve cited document sections when present; otherwise use the embedded confirmed requirement scope.
 2. **Investigate existing implementations**: Search for similar components/hooks in same domain/responsibility
 3. **Cross-check against Investigation Notes**: Ensure planned implementation is consistent with the observations recorded in the task file
 4. **Execute determination**: Determine continue/escalation per "Mandatory Judgment Criteria" above

--- a/.codex/agents/task-executor.toml
+++ b/.codex/agents/task-executor.toml
@@ -78,7 +78,7 @@ When the task file, Dependencies, or Investigation Targets reference `docs/proje
 **Unavailable**: Return `escalation_needed` with the missing repository-local capability, affected verification, and command evidence so the caller can run the preparation side path.
 
 #### Pre-implementation Verification (Pattern 5 Compliant)
-1. **Read Governing Sources** and extract required contracts, constraints, scope boundaries, and verification expectations. Resolve cited document sections when present; otherwise use the embedded confirmed requirement scope.
+1. **Read Governing Sources** and extract required contracts, constraints, scope boundaries, and verification expectations. When `docs/project-context/quality.yaml` exists, use it as implementation guidance. Resolve cited document sections when present; otherwise use the embedded confirmed requirement scope.
 2. **Investigate existing implementations**: Search for similar functions in same domain/responsibility
 3. **Cross-check against Investigation Notes**: Ensure planned implementation is consistent with the observations recorded in the task file
 4. **Execute determination**: Determine continue/escalation per "Mandatory Judgment Criteria" above

--- a/README.es.md
+++ b/README.es.md
@@ -71,7 +71,7 @@ El prefijo `$` invoca una skill de forma explícita. Escribe `$recipe-` para ver
 | Diseñar y construir un frontend web con React / TypeScript | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
 | Entregar juntos un cambio de backend y otro de frontend React | `$recipe-fullstack-implement` |
 | Revisar una implementación frente a su diseño | `$recipe-review` o `$recipe-front-review` |
-| Definir o actualizar reglas de revisión propias del repositorio | `$recipe-quality-profile` |
+| Definir o actualizar reglas de calidad propias del repositorio | `$recipe-quality-profile` |
 | Investigar un problema sin tocar el código | `$recipe-diagnose` |
 | Hacer un experimento desechable o un script puntual | Usa Codex directamente |
 
@@ -124,7 +124,7 @@ Separar los contextos evita que exploración, diseño, implementación y revisi�
 - **Verificación**: Ejecutar la prueba de contrato y comprobar la estructura de respuesta documentada
 ```
 
-El [Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md) lleva a la implementación la fuente, el resultado esperado, los archivos afectados y una verificación ejecutable. Solo añade un `Verification Focus` cuando una prueba podría pasar sin demostrar un comportamiento importante. Tras ejecutar la tarea, se aplican al cambio completo todos los controles pertinentes del repositorio antes del commit. Los revisores finales comparan el código terminado con los documentos aprobados. También buscan cambios fuera del alcance aprobado y problemas importantes de calidad del código. Cuando se acepta una corrección, la siguiente revisión se centra en los controles que esa corrección podría afectar. Ejecuta `$recipe-quality-profile` para definir reglas de revisión adicionales en `docs/project-context/quality.yaml` a partir de la evidencia del propio repositorio.
+El [Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md) lleva a la implementación la fuente, el resultado esperado, los archivos afectados y una verificación ejecutable. Solo añade un `Verification Focus` cuando una prueba podría pasar sin demostrar un comportamiento importante. Tras ejecutar la tarea, se aplican al cambio completo todos los controles pertinentes del repositorio antes del commit. Los revisores finales comparan el código terminado con los documentos aprobados. También buscan cambios fuera del alcance aprobado y problemas importantes de calidad del código. Cuando se acepta una corrección, la siguiente revisión se centra en los controles que esa corrección podría afectar. Ejecuta `$recipe-quality-profile` para definir en `docs/project-context/quality.yaml` las reglas de calidad del repositorio que se usarán durante la implementación y la revisión.
 
 ---
 
@@ -201,7 +201,7 @@ Invoca un flujo con `$recipe-name` en Codex. Escribe `$recipe-` y usa el autocom
 | `$recipe-prepare-implementation` | Prepara las herramientas locales ya existentes que necesita un Work Plan aprobado | Petición expresa de preparación o capacidad necesaria no disponible |
 | `$recipe-build` | Ejecuta tareas de backend con validación entre pasos | Retomar una implementación de backend |
 | `$recipe-review` | Revisa el alcance de implementación, el cumplimiento del Design Doc, la calidad del código y la seguridad; aplica las correcciones aprobadas por el usuario | Revisión tras implementar |
-| `$recipe-quality-profile` | Define o actualiza reglas de revisión propias del repositorio en `docs/project-context/quality.yaml` | Configuración y mantenimiento de las reglas de revisión |
+| `$recipe-quality-profile` | Define o actualiza reglas de calidad propias del repositorio en `docs/project-context/quality.yaml` | Configuración y mantenimiento de las reglas de calidad |
 | `$recipe-diagnose` | Investigación → verificación del punto de fallo → solución | Investigación de errores |
 | `$recipe-reverse-engineer` | Genera PRD y Design Docs a partir del código existente | Documentar sistemas heredados |
 | `$recipe-add-integration-tests` | Añade pruebas de integración/E2E a partir del Design Doc | Mejorar la cobertura del código existente |

--- a/README.ja.md
+++ b/README.ja.md
@@ -71,7 +71,7 @@ $recipe-implement JWTによるユーザー認証を追加する
 | React / TypeScriptのWebフロントエンドを設計・実装する | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
 | バックエンドとReactフロントエンドをまとめて変更する | `$recipe-fullstack-implement` |
 | 設計どおりに実装されているかレビューする | `$recipe-review` または `$recipe-front-review` |
-| リポジトリ固有のレビュールールを定義・更新する | `$recipe-quality-profile` |
+| リポジトリ固有の品質ルールを定義・更新する | `$recipe-quality-profile` |
 | コードを変えずに問題を調査する | `$recipe-diagnose` |
 | 使い捨ての検証や単発スクリプトを実行する | Codexを直接使う |
 
@@ -124,7 +124,7 @@ ADRを作るのは、現在のスコープに属し、長く残る選択で、�
 - **検証**: 契約テストを実行し、文書どおりのレスポンス形式を確認
 ```
 
-[Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md)は、根拠、期待する結果、対象ファイル、実行可能な検証方法を実装フェーズへ渡します。テストが通っても重要な挙動を証明できないおそれがある場合だけ、`Verification Focus`を追加します。実行後は、コミット前にタスクの変更全体へ該当するリポジトリチェックをかけます。最終レビュアーは、完成したコードを承認済み文書と照合します。さらに、承認範囲を超えた実装や重大なコード品質上の問題がないかも確認します。修正を採用したあとの再レビューでは、その修正の影響を受ける項目に対象を絞ります。`$recipe-quality-profile`を実行すると、リポジトリ内の根拠をもとに、固有のレビュールールを`docs/project-context/quality.yaml`へ追加できます。
+[Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md)は、根拠、期待する結果、対象ファイル、実行可能な検証方法を実装フェーズへ渡します。テストが通っても重要な挙動を証明できないおそれがある場合だけ、`Verification Focus`を追加します。実行後は、コミット前にタスクの変更全体へ該当するリポジトリチェックをかけます。最終レビュアーは、完成したコードを承認済み文書と照合します。さらに、承認範囲を超えた実装や重大なコード品質上の問題がないかも確認します。修正を採用したあとの再レビューでは、その修正の影響を受ける項目に対象を絞ります。`$recipe-quality-profile`を実行すると、実装とレビューで参照するリポジトリ固有の品質ルールを`docs/project-context/quality.yaml`に定義できます。
 
 ---
 
@@ -201,7 +201,7 @@ Codexでは`$recipe-name`でレシピを呼び出します。`$recipe-`まで入
 | `$recipe-prepare-implementation` | 承認済みWork Planに必要な既存のリポジトリ内ツールを準備 | 明示的なセットアップ依頼、または必要なタスク機能が利用できない場合 |
 | `$recipe-build` | ステップ間の検証を含むバックエンドタスクの実行 | バックエンド実装の再開 |
 | `$recipe-review` | 実装範囲、Design Doc準拠、コード品質、セキュリティをレビューし、ユーザーが承認した修正を適用 | 実装後の確認 |
-| `$recipe-quality-profile` | リポジトリ固有のレビュールールを`docs/project-context/quality.yaml`に定義・更新 | レビューポリシーの設定・保守 |
+| `$recipe-quality-profile` | リポジトリ固有の品質ルールを`docs/project-context/quality.yaml`に定義・更新 | 品質ルールの設定・保守 |
 | `$recipe-diagnose` | 問題調査 → 障害点の検証 → 解決策 | 不具合調査 |
 | `$recipe-reverse-engineer` | 既存コードからPRDとDesign Docを生成 | レガシーシステムの文書化 |
 | `$recipe-add-integration-tests` | Design Docをもとに統合/E2Eテストを追加 | 既存コードのテスト拡充 |

--- a/README.ko.md
+++ b/README.ko.md
@@ -71,7 +71,7 @@ $recipe-implement JWT 사용자 인증 추가
 | React / TypeScript 웹 프런트엔드를 설계하고 구현 | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
 | 백엔드와 React 프런트엔드 변경을 함께 구현 | `$recipe-fullstack-implement` |
 | 설계에 맞게 구현되었는지 리뷰 | `$recipe-review` 또는 `$recipe-front-review` |
-| 저장소별 리뷰 규칙 정의 또는 업데이트 | `$recipe-quality-profile` |
+| 저장소별 품질 규칙 정의 또는 업데이트 | `$recipe-quality-profile` |
 | 코드를 바꾸지 않고 문제 조사 | `$recipe-diagnose` |
 | 일회성 실험이나 단발성 스크립트 실행 | Codex 직접 사용 |
 
@@ -124,7 +124,7 @@ ADR은 현재 범위에 속하고 오래 유지되는 선택에 실질적으로 
 - **검증**: 계약 테스트를 실행하고 문서에 정의된 응답 형태 확인
 ```
 
-[Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md)는 출처, 의도한 결과, 대상 파일, 실행 가능한 검증을 구현 단계로 전달합니다. 테스트가 통과해도 중요한 동작을 증명하지 못할 수 있을 때만 `Verification Focus`를 추가합니다. 실행 후에는 커밋 전에 작업 변경 전체에 해당 저장소 검사를 적용합니다. 최종 리뷰어는 완성된 코드를 승인 문서와 대조합니다. 또한 승인 범위를 벗어난 구현이나 중대한 코드 품질 문제가 있는지 확인합니다. 수정이 채택되면 다음 리뷰에서는 해당 수정의 영향을 받을 수 있는 검사 항목에 집중합니다. `$recipe-quality-profile`을 실행하면 저장소의 근거를 바탕으로 `docs/project-context/quality.yaml`에 리뷰 규칙을 추가할 수 있습니다.
+[Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md)는 출처, 의도한 결과, 대상 파일, 실행 가능한 검증을 구현 단계로 전달합니다. 테스트가 통과해도 중요한 동작을 증명하지 못할 수 있을 때만 `Verification Focus`를 추가합니다. 실행 후에는 커밋 전에 작업 변경 전체에 해당 저장소 검사를 적용합니다. 최종 리뷰어는 완성된 코드를 승인 문서와 대조합니다. 또한 승인 범위를 벗어난 구현이나 중대한 코드 품질 문제가 있는지 확인합니다. 수정이 채택되면 다음 리뷰에서는 해당 수정의 영향을 받을 수 있는 검사 항목에 집중합니다. `$recipe-quality-profile`을 실행하면 구현과 리뷰에서 참고할 저장소별 품질 규칙을 `docs/project-context/quality.yaml`에 정의할 수 있습니다.
 
 ---
 
@@ -201,7 +201,7 @@ Codex에서 `$recipe-name`으로 레시피를 호출합니다. `$recipe-`를 입
 | `$recipe-prepare-implementation` | 승인된 Work Plan에 필요한 기존 저장소 내부 도구 준비 | 명시적인 설정 요청 또는 필요한 작업 기능이 없을 때 |
 | `$recipe-build` | 단계 사이 검증과 함께 백엔드 작업 실행 | 백엔드 구현 재개 |
 | `$recipe-review` | 구현 범위, Design Doc 준수 여부, 코드 품질 및 보안을 리뷰하고 사용자가 승인한 수정 적용 | 구현 후 확인 |
-| `$recipe-quality-profile` | `docs/project-context/quality.yaml`에 저장소별 리뷰 규칙 정의 또는 업데이트 | 리뷰 정책 설정 및 유지보수 |
+| `$recipe-quality-profile` | `docs/project-context/quality.yaml`에 저장소별 품질 규칙 정의 또는 업데이트 | 품질 규칙 설정 및 유지보수 |
 | `$recipe-diagnose` | 문제 조사 → 장애 지점 검증 → 해결책 | 버그 조사 |
 | `$recipe-reverse-engineer` | 기존 코드에서 PRD와 Design Doc 생성 | 레거시 시스템 문서화 |
 | `$recipe-add-integration-tests` | Design Doc에서 통합/E2E 테스트 추가 | 기존 코드의 테스트 범위 확대 |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $recipe-implement Add user authentication with JWT
 | Design and build a React / TypeScript web frontend | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
 | Deliver a backend and React frontend change together | `$recipe-fullstack-implement` |
 | Review an implementation against its design | `$recipe-review` or `$recipe-front-review` |
-| Define or update repository-specific review rules | `$recipe-quality-profile` |
+| Define or update repository-specific quality rules | `$recipe-quality-profile` |
 | Investigate a problem without changing code | `$recipe-diagnose` |
 | Run a throwaway experiment or one-shot script | Use Codex directly |
 
@@ -124,7 +124,7 @@ Fresh contexts keep exploration, design, implementation, and review from silentl
 - **Verification**: Run the contract test and observe the documented response shape
 ```
 
-The [Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md) carries the source, intended result, target files, and executable verification into implementation. It adds a `Verification Focus` only when a test could pass without proving one important behavior. After execution, the applicable repository checks run against the complete task change before commit. Final reviewers compare the completed code with the approved documents. They also look for work outside the approved scope and serious code-quality problems. When a correction is accepted, the next review focuses on the checks that correction could affect. Run `$recipe-quality-profile` to define additional review rules in `docs/project-context/quality.yaml` based on evidence from the repository.
+The [Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md) carries the source, intended result, target files, and executable verification into implementation. It adds a `Verification Focus` only when a test could pass without proving one important behavior. After execution, the applicable repository checks run against the complete task change before commit. Final reviewers compare the completed code with the approved documents. They also look for work outside the approved scope and serious code-quality problems. When a correction is accepted, the next review focuses on the checks that correction could affect. Run `$recipe-quality-profile` to define repository-specific quality rules in `docs/project-context/quality.yaml` for implementation and review.
 
 ---
 
@@ -202,7 +202,7 @@ Invoke recipes with `$recipe-name` in Codex. Type `$recipe-` and use tab complet
 | `$recipe-prepare-implementation` | Prepare existing repository-local tools needed by an approved Work Plan | Explicit setup request or a concrete task capability is unavailable |
 | `$recipe-build` | Execute backend tasks with validation between steps | Resume backend implementation |
 | `$recipe-review` | Review implementation scope, Design Doc compliance, code quality, and security; apply corrections approved by the user | Post-implementation check |
-| `$recipe-quality-profile` | Define or update repository-specific review rules in `docs/project-context/quality.yaml` | Set up or maintain review rules |
+| `$recipe-quality-profile` | Define or update repository-specific quality rules in `docs/project-context/quality.yaml` | Set up or maintain quality rules |
 | `$recipe-diagnose` | Problem investigation → failure-point verification → solution | Bug investigation |
 | `$recipe-reverse-engineer` | Generate PRD + Design Docs from existing code | Legacy system documentation |
 | `$recipe-add-integration-tests` | Add integration/E2E tests from Design Doc | Test coverage for existing code |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -71,7 +71,7 @@ O prefixo `$` invoca uma skill explicitamente. Digite `$recipe-` para ver os flu
 | Projetar e construir um frontend web com React / TypeScript | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
 | Entregar juntos uma mudança de backend e outra de frontend React | `$recipe-fullstack-implement` |
 | Revisar uma implementação com base no design | `$recipe-review` ou `$recipe-front-review` |
-| Definir ou atualizar regras de revisão específicas do repositório | `$recipe-quality-profile` |
+| Definir ou atualizar regras de qualidade específicas do repositório | `$recipe-quality-profile` |
 | Investigar um problema sem alterar o código | `$recipe-diagnose` |
 | Fazer um experimento descartável ou um script pontual | Use o Codex diretamente |
 
@@ -124,7 +124,7 @@ Separar os contextos evita que exploração, design, implementação e revisão 
 - **Verificação**: Executar o teste de contrato e observar o formato de resposta documentado
 ```
 
-O [Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md) leva para a implementação a fonte, o resultado esperado, os arquivos-alvo e uma verificação executável. Ele só acrescenta um `Verification Focus` quando um teste pode passar sem comprovar um comportamento importante. Após a execução, todas as checagens aplicáveis do repositório rodam sobre a mudança completa antes do commit. Os revisores finais comparam o código concluído com os documentos aprovados. Eles também procuram mudanças fora do escopo aprovado e problemas sérios de qualidade do código. Quando uma correção é aceita, a revisão seguinte se concentra nas verificações que ela pode afetar. Execute `$recipe-quality-profile` para definir outras regras de revisão em `docs/project-context/quality.yaml` com base nas evidências do próprio repositório.
+O [Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md) leva para a implementação a fonte, o resultado esperado, os arquivos-alvo e uma verificação executável. Ele só acrescenta um `Verification Focus` quando um teste pode passar sem comprovar um comportamento importante. Após a execução, todas as checagens aplicáveis do repositório rodam sobre a mudança completa antes do commit. Os revisores finais comparam o código concluído com os documentos aprovados. Eles também procuram mudanças fora do escopo aprovado e problemas sérios de qualidade do código. Quando uma correção é aceita, a revisão seguinte se concentra nas verificações que ela pode afetar. Execute `$recipe-quality-profile` para definir em `docs/project-context/quality.yaml` as regras de qualidade do repositório usadas durante a implementação e a revisão.
 
 ---
 
@@ -201,7 +201,7 @@ No Codex, use `$recipe-name` para invocar um fluxo. Digite `$recipe-` e use o pr
 | `$recipe-prepare-implementation` | Prepara as ferramentas locais já existentes exigidas por um Work Plan aprovado | Pedido explícito de preparação ou recurso necessário indisponível |
 | `$recipe-build` | Executa tarefas de backend com validação entre etapas | Retomar uma implementação de backend |
 | `$recipe-review` | Revisa o escopo de implementação, a conformidade com o Design Doc, a qualidade do código e a segurança; aplica as correções aprovadas pelo usuário | Revisão após a implementação |
-| `$recipe-quality-profile` | Define ou atualiza regras de revisão específicas do repositório em `docs/project-context/quality.yaml` | Configuração e manutenção das regras de revisão |
+| `$recipe-quality-profile` | Define ou atualiza regras de qualidade específicas do repositório em `docs/project-context/quality.yaml` | Configuração e manutenção das regras de qualidade |
 | `$recipe-diagnose` | Investigação → verificação do ponto de falha → solução | Investigação de bugs |
 | `$recipe-reverse-engineer` | Gera PRD e Design Docs com base no código existente | Documentação de sistemas legados |
 | `$recipe-add-integration-tests` | Adiciona testes de integração/E2E a partir do Design Doc | Ampliar a cobertura do código existente |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,7 +71,7 @@ $recipe-implement 使用JWT添加用户认证
 | 设计并实现React / TypeScript Web前端 | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
 | 同时交付后端和React前端改动 | `$recipe-fullstack-implement` |
 | 按照设计评审实现 | `$recipe-review` 或 `$recipe-front-review` |
-| 定义或更新仓库专属评审规则 | `$recipe-quality-profile` |
+| 定义或更新仓库专属质量规则 | `$recipe-quality-profile` |
 | 调查问题但不修改代码 | `$recipe-diagnose` |
 | 做一次性实验或临时脚本 | 直接使用Codex |
 
@@ -124,7 +124,7 @@ flowchart LR
 - **验证**: 运行契约测试，确认响应结构符合文档
 ```
 
-[Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md)会把来源、预期结果、目标文件和可执行的验证方法传递到实现阶段。只有在测试可能通过、却没有证明某项关键行为时，才会增加`Verification Focus`。任务执行完毕后，完整改动必须在提交前通过适用的仓库检查。最终评审者会将完成的代码与已批准文档逐项对照，同时检查是否存在超出批准范围的实现或重大的代码质量问题。接受修正后，下一轮评审只聚焦于可能受该修正影响的检查项。运行`$recipe-quality-profile`，可根据仓库中的依据，在`docs/project-context/quality.yaml`中定义额外的专属评审规则。
+[Task File Contract](.agents/skills/llm-friendly-context/references/task-template.md)会把来源、预期结果、目标文件和可执行的验证方法传递到实现阶段。只有在测试可能通过、却没有证明某项关键行为时，才会增加`Verification Focus`。任务执行完毕后，完整改动必须在提交前通过适用的仓库检查。最终评审者会将完成的代码与已批准文档逐项对照，同时检查是否存在超出批准范围的实现或重大的代码质量问题。接受修正后，下一轮评审只聚焦于可能受该修正影响的检查项。运行`$recipe-quality-profile`，可在`docs/project-context/quality.yaml`中定义实现和评审时使用的仓库专属质量规则。
 
 ---
 
@@ -201,7 +201,7 @@ npx codex-workflows status --user
 | `$recipe-prepare-implementation` | 准备已批准Work Plan所需的现有仓库内工具 | 明确要求准备环境，或任务所需能力不可用 |
 | `$recipe-build` | 执行后端任务，并在各步骤之间验证 | 继续后端实现 |
 | `$recipe-review` | 评审实现范围、Design Doc符合性、代码质量和安全性，并应用用户批准的修正 | 实现后检查 |
-| `$recipe-quality-profile` | 在`docs/project-context/quality.yaml`中定义或更新仓库专属评审规则 | 设置和维护评审策略 |
+| `$recipe-quality-profile` | 在`docs/project-context/quality.yaml`中定义或更新仓库专属质量规则 | 设置和维护质量规则 |
 | `$recipe-diagnose` | 调查问题 → 验证故障点 → 提出解决方案 | 缺陷调查 |
 | `$recipe-reverse-engineer` | 从现有代码生成PRD和Design Doc | 遗留系统文档化 |
 | `$recipe-add-integration-tests` | 根据Design Doc添加集成/E2E测试 | 为现有代码补充测试 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Codex CLI workflows that keep larger software changes within the approved scope, from planning through review",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

- use repository quality profiles as implementation guidance for backend and frontend executors
- update the English and localized READMEs to describe quality profiles as implementation and review guidance
- bump the package version to 1.3.1

## Testing

- npm test
- npm run check:skills-index