### PR TITLE
Remove update_plan dependency from agent workflows

### DIFF
--- a/.agents/skills/reviewee-judgment/SKILL.md
+++ b/.agents/skills/reviewee-judgment/SKILL.md
@@ -66,7 +66,7 @@ Establish causal sufficiency before cost can favor a response. A required correc
 
 ## Resolution Method
 
-Before starting, add steps 1–5 to `update_plan` in order; add step 6 only when execution is authorized. Complete each step before starting the next.
+Follow steps 1–5 in order; perform step 6 only when execution is authorized. Complete each step before starting the next.
 
 ### 1. Normalize the Findings
 

--- a/.codex/agents/acceptance-test-generator.toml
+++ b/.codex/agents/acceptance-test-generator.toml
@@ -8,7 +8,7 @@ You generate a minimal set of integration/E2E test skeletons, which may be empty
 
 Load and read each skill completely before taking task actions: `testing`, `documentation-criteria`, `integration-e2e-testing`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -9,7 +9,7 @@ You review completed repository changes against their approved governing sources
 
 Load and read each skill completely before taking task actions: `ai-development-guide`, `coding-rules`, `testing`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/code-verifier.toml
+++ b/.codex/agents/code-verifier.toml
@@ -11,7 +11,7 @@ Your discrepancies are independent facts for orchestrator Resolution. Confirmed 
 
 Load and read each skill completely before taking task actions: `documentation-criteria`, `ai-development-guide`, `coding-rules`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/codebase-analyzer.toml
+++ b/.codex/agents/codebase-analyzer.toml
@@ -9,7 +9,7 @@ You are an AI assistant specializing in objective codebase analysis for design p
 
 Load and read each skill completely before taking task actions: `ai-development-guide`, `coding-rules`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Responsibilities
 

--- a/.codex/agents/design-sync.toml
+++ b/.codex/agents/design-sync.toml
@@ -9,7 +9,7 @@ You are an AI assistant specializing in consistency verification between Design 
 
 Load and read each skill completely before taking task actions: `documentation-criteria`, `coding-rules`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 Operates in an independent context, executing autonomously until task completion.
 

--- a/.codex/agents/document-reviewer.toml
+++ b/.codex/agents/document-reviewer.toml
@@ -9,7 +9,7 @@ You review one PRD, UI Spec, Design Doc, Work Plan, or one complete ADR batch pe
 
 Load and read each skill completely before taking task actions: `documentation-criteria`, `requirement-convergence`, `coding-rules`, `testing`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/integration-test-reviewer.toml
+++ b/.codex/agents/integration-test-reviewer.toml
@@ -9,7 +9,7 @@ You review only integration/E2E tests changed by the current task.
 
 Load and read each skill completely before taking task actions: `testing`, `integration-e2e-testing`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/investigator.toml
+++ b/.codex/agents/investigator.toml
@@ -9,7 +9,7 @@ You are an AI assistant specializing in problem investigation.
 
 Load and read each skill completely before taking task actions: `ai-development-guide`, `coding-rules`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Input and Responsibility Boundaries
 

--- a/.codex/agents/prd-creator.toml
+++ b/.codex/agents/prd-creator.toml
@@ -8,7 +8,7 @@ You create or update one PRD per invocation.
 
 Load and read each skill completely before taking task actions: `documentation-criteria`, `requirement-convergence`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/quality-fixer-frontend.toml
+++ b/.codex/agents/quality-fixer-frontend.toml
@@ -9,7 +9,7 @@ You own self-contained quality assurance and repair for one frontend implementat
 Load and read each skill completely before taking task actions: `coding-rules`, `testing`, `ai-development-guide`.
 When task verification cites a recorded external resource, also load `external-resource-context` before consulting it.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/quality-fixer.toml
+++ b/.codex/agents/quality-fixer.toml
@@ -9,7 +9,7 @@ You own self-contained quality assurance and repair for one implementation task.
 Load and read each skill completely before taking task actions: `coding-rules`, `testing`, `ai-development-guide`.
 When task verification cites a recorded external resource, also load `external-resource-context` before consulting it.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/requirement-analyzer.toml
+++ b/.codex/agents/requirement-analyzer.toml
@@ -9,7 +9,7 @@ You collect decision materials for the orchestrator's requirement confirmation a
 
 Load and read each skill completely before taking task actions: `ai-development-guide`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Responsibilities
 

--- a/.codex/agents/rule-advisor.toml
+++ b/.codex/agents/rule-advisor.toml
@@ -10,7 +10,7 @@ You analyze standalone work and return the smallest applicable skill set plus me
 
 Load and read each skill completely before taking task actions: `task-analyzer`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/scope-discoverer.toml
+++ b/.codex/agents/scope-discoverer.toml
@@ -9,7 +9,7 @@ You are an AI assistant specializing in codebase scope discovery for reverse doc
 
 Load and read each skill completely before taking task actions: `documentation-criteria`, `ai-development-guide`, `coding-rules`, `implementation-approach`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Input Parameters
 

--- a/.codex/agents/security-reviewer.toml
+++ b/.codex/agents/security-reviewer.toml
@@ -9,7 +9,7 @@ You are an AI assistant specializing in security review of implemented code.
 
 Load and read each skill completely before taking task actions: `coding-rules`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Output Boundary
 

--- a/.codex/agents/solver.toml
+++ b/.codex/agents/solver.toml
@@ -9,7 +9,7 @@ You are an AI assistant specializing in solution derivation.
 
 Load and read each skill completely before taking task actions: `ai-development-guide`, `coding-rules`, `implementation-approach`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Input and Responsibility Boundaries
 

--- a/.codex/agents/task-decomposer.toml
+++ b/.codex/agents/task-decomposer.toml
@@ -8,7 +8,7 @@ You convert an approved Work Plan into executable task files while preserving it
 
 Load and read each skill completely before taking task actions: `ai-development-guide`, `testing`, `coding-rules`, `implementation-approach`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Input
 

--- a/.codex/agents/task-executor-frontend.toml
+++ b/.codex/agents/task-executor-frontend.toml
@@ -9,7 +9,7 @@ You are a specialized AI assistant for reliably executing frontend implementatio
 Load and read each skill completely before taking task actions: `coding-rules`, `testing`, `ai-development-guide`, `implementation-approach`.
 When the task cites a recorded external resource, also load `external-resource-context` before consulting it.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Task Scope
 

--- a/.codex/agents/task-executor.toml
+++ b/.codex/agents/task-executor.toml
@@ -9,7 +9,7 @@ You are a specialized AI assistant for reliably executing individual tasks.
 Load and read each skill completely before taking task actions: `coding-rules`, `testing`, `ai-development-guide`, `implementation-approach`.
 When the task cites a recorded external resource, also load `external-resource-context` before consulting it.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Task Scope
 

--- a/.codex/agents/technical-designer-frontend.toml
+++ b/.codex/agents/technical-designer-frontend.toml
@@ -8,7 +8,7 @@ You create one complete frontend ADR batch or one frontend Design Doc per invoca
 
 Load and read each skill completely before taking task actions: `documentation-criteria`, `requirement-convergence`, `coding-rules`, `testing`, `ai-development-guide`, `implementation-approach`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/technical-designer.toml
+++ b/.codex/agents/technical-designer.toml
@@ -8,7 +8,7 @@ You create one complete ADR batch or one Design Doc per invocation.
 
 Load and read each skill completely before taking task actions: `documentation-criteria`, `requirement-convergence`, `coding-rules`, `testing`, `ai-development-guide`, `implementation-approach`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/ui-analyzer.toml
+++ b/.codex/agents/ui-analyzer.toml
@@ -8,7 +8,7 @@ You are a UI fact gathering specialist for frontend design and adjustment prepar
 
 Load and read each skill completely before taking task actions: `coding-rules`, `ai-development-guide`, `external-resource-context`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Input Parameters
 

--- a/.codex/agents/ui-spec-designer.toml
+++ b/.codex/agents/ui-spec-designer.toml
@@ -9,7 +9,7 @@ You create one UI Specification for the confirmed frontend outcome.
 Load and read each skill completely before taking task actions: `documentation-criteria`, `coding-rules`, `llm-friendly-context`.
 Load `external-resource-context` only when the supplied UI Analysis or current decision cites a recorded external resource that must be consulted.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/.codex/agents/verifier.toml
+++ b/.codex/agents/verifier.toml
@@ -9,7 +9,7 @@ You are an AI assistant specializing in investigation result verification.
 
 Load and read each skill completely before taking task actions: `ai-development-guide`, `coding-rules`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Input and Responsibility Boundaries
 

--- a/.codex/agents/work-planner.toml
+++ b/.codex/agents/work-planner.toml
@@ -8,7 +8,7 @@ You create Work Plans that translate approved Design Docs into executable reposi
 
 Load and read each skill completely before taking task actions: `ai-development-guide`, `documentation-criteria`, `coding-rules`, `testing`, `implementation-approach`, `llm-friendly-context`.
 
-**Execution Plan**: For work with multiple dependent actions, use `update_plan` to track them through final verification and reuse an active plan. A single-action task proceeds directly. Complete a plan step after verifying its result; start a dependent step after its prerequisites are satisfied.
+**Execution Discipline**: Follow this agent's required process as written through final verification. Verify each required step's result before treating the step as complete, and complete every required step before settling on the final result; this preserves evidence and reasoning breadth that early convergence would otherwise discard. Begin dependent work only after its prerequisites are satisfied; a single-action task proceeds directly.
 
 ## Inputs
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Codex CLI workflows that keep larger software changes within the approved scope, from planning through review",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

- replace explicit update_plan requirements in 25 custom agent prompts with execution-discipline guidance
- preserve strict ordered execution for the reviewee-judgment resolution method
- restore per-step result verification and explain why avoiding early convergence matters
- bump the package patch version to 1.3.3

## Rationale

Codex now defaults update_plan to disabled. This removes the unavailable tool dependency without adding replacement state or workflow machinery, while retaining direct guidance to follow required procedures through verification.

## Testing

- npm run check:skills-index
- npm test
- git diff --check