### PR TITLE
Simplify workflow decisions and preserve execution evidence

### DIFF
--- a/.agents/skills/llm-friendly-context/SKILL.md
+++ b/.agents/skills/llm-friendly-context/SKILL.md
@@ -19,9 +19,9 @@ The goal is stable downstream execution. The next agent should know the target a
    - Keep a prohibition only when it protects an irreversible boundary or shipped contract. Name the protected condition and the allowed action.
    - Example: `Preserve existing public API behavior across the documented compatibility cases.`
 
-2. **Make vague instructions concrete**
-   - Replace subjective terms with observable conditions, paths, commands, schemas, examples, or decision rules.
-   - Terms that usually need clarification before handoff: `appropriate`, `proper`, `related`, `existing behavior`, `optional`, `as needed`, `if needed`, `per convention`, unresolved alternatives, `TBD`, and `placeholder`.
+2. **Resolve outcome-relevant ambiguity**
+   - Clarify an instruction when plausible interpretations would change correctness, requested scope, downstream usability, or verification. Use the least-restrictive sufficient condition, source, or example.
+   - Leave local, reversible choices to the next agent when the stated outcome, constraints, and repository evidence are sufficient to choose. A subjective word alone does not require another rule or decision.
 
 3. **Specify output shape**
    - Define only the sections or fields the next consumer uses.
@@ -46,19 +46,19 @@ The goal is stable downstream execution. The next agent should know the target a
 
 ## Rewrite Patterns
 
-Use these rewrites before treating a prompt, handoff, or artifact as complete.
+Use these rewrites when an ambiguity materially changes the next action or its result. Retain valid local choices within the stated boundaries.
 
 | Ambiguous form | Rewrite as |
 |---|---|
 | `optional` used as an unresolved choice | Required, omitted, or required only under a named condition |
-| Multiple alternatives that the next agent must choose between | The selected option, or the evidence boundary within which the agent may choose |
+| Alternatives with different scope or contract effects | The accepted decision, or the evidence boundary within which the agent may choose |
 | `as needed` / `if needed` | The triggering condition and required action |
 | `per convention` | The file, function, test, or documented convention to follow |
 | `related files` | Specific paths, globs, or search hints |
 | `existing behavior` | The observable behavior, source file, test, API response, or UI state to preserve |
 | `placeholder` | Exact temporary value or behavior, allowed dependencies, and verification expectation |
 | `TBD` used for required information | A blocking unresolved item with owner, required input, or escalation condition |
-| `appropriate` / `proper` | A measurable criterion or checklist |
+| `appropriate` / `proper` with materially different interpretations | The observable success criterion that distinguishes acceptable results |
 
 ## Handoff Checklist
 
@@ -69,7 +69,7 @@ Before sending a prompt or artifact to another agent, verify:
 - [ ] Accepted decisions and constraints are stated once with stable wording.
 - [ ] The next consumer can identify the artifact or result it needs.
 - [ ] Success criteria are observable.
-- [ ] Ambiguous expressions have been rewritten or marked as unresolved.
+- [ ] Outcome-relevant ambiguities are resolved or identified with their effect; valid local choices remain available.
 - [ ] Every retained prohibition names the protected condition and allowed alternative.
 - [ ] Dependencies needed by the next action are visible.
 - [ ] The next agent can complete its scope or return the unresolved decision with evidence.

--- a/.agents/skills/requirement-convergence/references/criteria.md
+++ b/.agents/skills/requirement-convergence/references/criteria.md
@@ -20,7 +20,7 @@ Ask when the layer is unclear. Treating all three as equally binding turns explo
 
 Present cost and its unknowns before asking what to exclude. Record exclusions in the user's wording. Treat an empty `nonGoals` list as ready only when the user considered exclusions and chose none.
 
-An agent-proposed capability remains a question until the user accepts or excludes it. Only then does it enter the record as a user decision.
+Agent-proposed capabilities are candidates, not user decisions. Ask about a candidate only when accepting or excluding it is necessary to settle the requested scope; leave unnecessary suggestions out of the convergence record.
 
 ## cost
 
@@ -45,18 +45,18 @@ Mark each supporting item `observed` or `inferred`, with its source. Keep unreso
 | `moderate` | The change coordinates across a boundary or adds notable supporting work |
 | `high` | The change affects a public contract, persisted data shape, or dependency platform |
 
-Treat an unknown that could raise the band as a question, and set the band from established evidence.
+Set the band from established evidence and explain material unknowns. Resolve factual unknowns through the shallow inspection above; ask the user when the remaining uncertainty requires a scope or trade-off decision.
 
 ## Challenge Intensity
 
 | Cost band | Response |
 |-----------|----------|
 | `low` | Record and accept when the fields converge |
-| `moderate` | Present the cost and one lower-cost alternative |
+| `moderate` | Present the cost; include a credible lower-cost alternative when it materially changes the user's decision |
 | `high` | Present the trade-off and require the user's explicit choice before design |
 
 The goal is a cost-proportionate decision that preserves user intent. Cost selects challenge intensity; documentation-criteria Structural Scale independently selects the workflow.
 
 ## Solution-in-Disguise Test
 
-When a requirement names a mechanism rather than an outcome, identify materially different ways to achieve the outcome. If alternatives exist, present the named mechanism as one option with its trade-off. If repository or platform constraints make it the only credible route, record that evidence and proceed.
+Distinguish a user-selected mechanism from a suggested means to an outcome. Preserve an explicit selection unless evidence exposes a material feasibility, cost, or contract issue. For a suggested mechanism, present a credible alternative when its trade-off could change the scope decision. If constraints establish the route, or alternatives offer no material benefit for the outcome, record the relevant evidence and proceed.

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -15,14 +15,14 @@ Use test commands, thresholds, boundaries, fixtures, and conventions from the re
 
 ## TDD Gate
 
-For behavior-changing implementation:
+Use RED-GREEN-REFACTOR for behavior-changing implementation when a focused automated test adds or restores necessary behavioral proof:
 
 1. **RED**: Add or select a test that observes the required behavior. Run it and confirm it fails for the targeted missing behavior or regression.
 2. **GREEN**: Make the smallest implementation change that satisfies the behavior. Run the focused test.
 3. **REFACTOR**: Improve the changed code without changing the contract. Re-run the focused test.
 4. **VERIFY**: Run the repository's required quality command and every wider check required by the task boundary.
 
-Documentation, pure configuration, and disposable exploration do not require a RED phase. A productionized spike must gain tests before completion.
+For non-behavioral work or behavior already proven at the required boundary, use the smallest applicable verification instead of creating duplicate proof. Reuse existing evidence only while it remains valid for the changed behavior. Documentation, pure configuration, and disposable exploration do not require a RED phase. A productionized spike must gain tests before completion. Repository-required checks still apply.
 
 ## Proof Selection
 

--- a/.codex/agents/design-sync.toml
+++ b/.codex/agents/design-sync.toml
@@ -13,206 +13,75 @@ Load and read each skill completely before taking task actions: `documentation-c
 
 Operates in an independent context, executing autonomously until task completion.
 
-## Detection Criteria (The Only Rule)
+## Detection Boundary
 
-**Detection Target**: Only compare items explicitly extractable from the source file. Ignore items that are not documented in the source file.
+Compare terms, types, numeric parameters, components, paths, integration points, and acceptance criteria explicitly documented in `source_design`. The source is the comparison starting point; approved requirements, accepted decisions, and the applicable contract determine authority.
 
-**Rationale**: design-sync is a candidate generator for downstream review by the orchestrator and/or a human reviewer. Favor high recall, but keep a strict distinction between confirmed conflicts and candidate conflicts.
+Provide findings for orchestrator or human resolution. Preserve broad discovery of potentially shared contracts while separating confirmed conflicts from uncertain matches. Resolve neither document yourself.
 
-### Match Basis Rules
+## Input
 
-Each detected item MUST include `match_basis` and `confidence`.
+- **source_design**: Path to the newly created or updated Design Doc
 
-**high confidence** (confirmed conflict):
-- `exact_string`: identical identifier string in both documents
-- `explicit_alias`: one document explicitly links the identifier to an alias in the other
+If there are no other non-template Design Docs in `docs/design/`, return `SKIPPED` with `reason: "fewer_than_2_design_docs"`.
 
-**medium confidence** (candidate conflict):
-- `same_endpoint_role`: same user-facing or service-facing endpoint role with differing path/version/handler details
-- `same_integration_role`: same service or component role in the same flow stage with differing method names, parameters, or outputs
-- `same_ac_slot`: same user action or trigger and same outcome category, but differing conditions, constraints, or thresholds
-- `same_numeric_role`: same normalized config or threshold role with differing numeric values
-- `same_term_role`: same normalized domain term role with differing definition text
+## Comparison Process
 
-**Candidate evidence rule**:
-- Medium-confidence matches MUST include a `reason`
-- `reason` MUST describe the structural evidence connecting the items
-- Candidate conflicts require a valid medium-confidence `match_basis`; do not invent new values
+### 1. Identify Source Claims
 
-**General shared signals for candidate matching**:
-- `resource_key`: normalized resource or domain noun extracted from the identifier. Match only when the normalized noun is identical after singular/plural normalization
-- `trigger_key`: normalized trigger phrase describing the initiating user or system action. Match only when the normalized verb family and target resource are both identical
-- `outcome_key`: normalized observable result phrase. Match only when the normalized outcome verb family and target resource are both identical
-- `stage_key`: one of `route_entry`, `service_entry`, `validation`, `persistence_read`, `persistence_write`, `event_emit`, `render`, `other`. Match only when the enumerated stage is identical
+Read the source and identify the documented claims whose meaning another Design Doc could constrain: interfaces, shared responsibilities, values, states, and observable outcomes. Retain the exact source locations and values needed to compare them.
 
-**Numeric-role signals**:
-- `numeric_key`: normalized config or threshold identifier. Match only when the normalized numeric role is identical
-- `unit_key`: normalized measurement unit (`ms`, `seconds`, `minutes`, `percent`, `count`, `bytes`). Match only when the unit is identical
-- `scope_key`: normalized feature or subsystem scope for the numeric parameter (`retry`, `checkout`, `auth`, `cache`). Match only when the scope is identical
+### 2. Locate Related Evidence
 
-**Term-role signals**:
-- `term_key`: normalized canonical term name. Match only when the normalized term is identical
-- `subject_key`: normalized subject that the term defines (`order_fulfillment`, `session_lifecycle`, `inventory_reservation`). Match only when the subject is identical
-- `boundary_key`: normalized boundary or span phrase expressed by the definition (`payment_confirmation_to_carrier_handoff`). Match only when the normalized boundary is identical
+Search the other non-template `docs/design/*.md` files for those responsibilities and contracts, including aliases, equivalent domain terms, and referenced integration partners. Inspect candidate sections far enough to establish whether the claims concern the same contract. A missing exact identifier match does not exclude a documented shared role.
 
-**Signal counting rule**:
-- For `same_endpoint_role`, `same_integration_role`, and `same_ac_slot`, count only `resource_key`, `trigger_key`, `outcome_key`, and `stage_key`
-- For `same_numeric_role`, count only `numeric_key`, `unit_key`, and `scope_key`
-- For `same_term_role`, count only `term_key`, `subject_key`, and `boundary_key`
-- Count a signal only when its matching rule is satisfied exactly
-- Never count `trigger_key` or `outcome_key` when the value is `none`
-- Never count `stage_key` when its value is `other`
-- Never count `unit_key`, `scope_key`, `subject_key`, or `boundary_key` when the value is `none`
-- `same_endpoint_role`, `same_integration_role`, and `same_ac_slot` require at least 2 matching signals
-- `same_numeric_role` requires `numeric_key` plus at least 1 of `unit_key` or `scope_key`
-- `same_term_role` requires `term_key` plus at least 1 of `subject_key` or `boundary_key`
+Read additional sections when they can change contract identity, compatibility, or authority. Return missing evidence to the caller when an unreadable document prevents judging a potentially shared contract.
 
-**Match basis selection order**:
-1. `exact_string`
-2. `explicit_alias`
-3. `same_endpoint_role`
-4. `same_integration_role`
-5. `same_ac_slot`
-6. `same_numeric_role`
-7. `same_term_role`
+### 3. Judge Identity and Compatibility
 
-Select the first rule in this order whose requirements are satisfied.
+Compare the owning responsibility, namespace, actor or resource, lifecycle stage, and applicable conditions or version where they affect meaning. Establish the shared contract from the documents, not from the number of matching words or generated labels.
 
-**Core constraints**:
-- Confirmed conflicts use only `exact_string` or `explicit_alias`
-- Candidate conflicts require an allowed medium-confidence `match_basis` plus that match-basis' required signals
-- Section proximity alone does not establish the same design slot
-- Scope is detection and reporting only. Provide conflict recommendations, but do not resolve conflicts
+Compare values and obligations semantically. Normalize equivalent units and account for explicit version differences, aliases, superseded decisions, and intentional scope differences before reporting incompatibility.
 
-## Input Parameters
+Classify a pair as:
 
-- **source_design**: Path to the newly created/updated Design Doc (this becomes the source of truth)
+- **Confirmed conflict**: direct document evidence establishes the same contract under compatible scope and conditions, and the claims cannot both hold.
+- **Candidate conflict**: documented relationships support a potentially shared contract, but identity or compatibility remains unresolved. State that relationship and the exact uncertainty.
+- **No conflict**: the claims agree, concern distinct contracts, or their difference is explicitly intended.
 
-## Early Termination Condition
+A shared identifier alone does not establish identity. Different identifiers alone do not establish independence. Continue across the source's material shared claims after finding the first issue.
 
-**When target Design Docs count is 0** (no files other than source_design in docs/design/):
-- Return immediately with `sync_status: "SKIPPED"` and `reason: "fewer_than_2_design_docs"`
-- Consistency verification requires at least 2 documents to compare
+### 4. Report Evidence and Impact
 
-## Workflow
+Each finding includes `match_basis`, `confidence`, both document locations and values, and a recommendation grounded in the governing contract. Use `reason` to explain shared identity for confirmed findings and the linking evidence and uncertainty for candidates.
 
-### 1. Parse Source Design Doc
+Keep these `match_basis` labels for reporting:
 
-Read the Design Doc specified in arguments and extract:
+| Label | Evidence described |
+|---|---|
+| `exact_string` | Shared identifier, with scope evidence establishing its meaning |
+| `explicit_alias` | A document explicitly states the equivalence |
+| `same_endpoint_role` | Same documented endpoint responsibility |
+| `same_integration_role` | Same documented component or integration contract |
+| `same_ac_slot` | Same documented trigger and required outcome |
+| `same_numeric_role` | Same parameter or threshold responsibility |
+| `same_term_role` | Same domain concept and definition boundary |
 
-**Extraction Targets**: term definitions, type definitions, numeric parameters, component names, path identifiers, integration points, and acceptance criteria.
+Select the label that best describes the evidence. The label itself determines neither confidence nor authority. Use `confidence: "high"` for confirmed conflicts and `"medium"` for supported candidates.
 
-**Extraction Output**:
-```yaml
-- identifier: "[exact string from source document]"
-  category: "[term | type | numeric | component | path | integration | acceptance-criteria]"
-  section: "[section where found]"
-  context: "[definition | reference | constraint]"
-  resource_key: "[normalized noun or none]"
-  trigger_key: "[normalized trigger phrase or none]"
-  outcome_key: "[normalized observable result phrase or none]"
-  stage_key: "[route_entry | service_entry | validation | persistence_read | persistence_write | event_emit | render | other]"
-  numeric_key: "[normalized config or threshold identifier, else none]"
-  unit_key: "[normalized measurement unit, else none]"
-  scope_key: "[normalized feature or subsystem scope, else none]"
-  term_key: "[normalized canonical term name, else none]"
-  subject_key: "[normalized definition subject, else none]"
-  boundary_key: "[normalized boundary/span phrase, else none]"
-  alias_of: "[exact identifier if explicitly aliased, else none]"
-```
-
-**Key derivation rules**:
-- `resource_key`: normalize the primary domain noun to lowercase snake_case singular. For URL paths, use the last non-parameter path segment. For component/service/class identifiers, use the leading domain noun before suffixes such as `Service`, `Controller`, `Repository`, `Client`. For free-text terms, use the canonical term noun phrase
-- `trigger_key`: normalize to lowercase verb-plus-target form only when the text describes an initiating action. For endpoints, use HTTP method plus normalized resource (for example `post_order`). For acceptance criteria, use the triggering action phrase. Otherwise use `none`
-- `outcome_key`: normalize to lowercase verb-plus-target form only when the text describes an observable result or produced artifact. For pure config names or pure term definitions, use `none`
-- `stage_key`: assign the closest enumerated lifecycle stage from the identifier/context. Use `other` only when no enumerated stage applies
-- `numeric_key`: for numeric parameters, normalize the parameter name to lowercase snake_case without the value or unit (for example `retry_backoff_initial_delay`). Otherwise use `none`
-- `unit_key`: for numeric parameters, normalize the unit token to lowercase canonical form (`ms`, `seconds`, `minutes`, `percent`, `count`, `bytes`). Otherwise use `none`
-- `scope_key`: for numeric parameters, normalize the owning feature or subsystem to lowercase snake_case (`retry`, `checkout`, `auth`, `cache`). Otherwise use `none`
-- `term_key`: for term definitions, normalize the canonical term name to lowercase snake_case. Otherwise use `none`
-- `subject_key`: for term definitions, normalize the subject being defined to lowercase snake_case. Otherwise use `none`
-- `boundary_key`: for term definitions, normalize the boundary/span phrase to lowercase snake_case with `from_to` wording when applicable. Otherwise use `none`
-- `alias_of`: set to the exact referenced identifier only when the document explicitly states an alias/equivalence. Otherwise use `none`
-
-### 2. Survey All Design Docs
-
-- Search `docs/design/*.md` excluding the template and `source_design`
-- Extract target-document items with the same schema and key derivation rules
-
-### 3. Conflict Classification and Severity Assessment
-
-**Conflict Detection Process**:
-1. Extract each item from the source file using the extraction output format
-2. Derive and record all normalized keys for each extracted item: `resource_key`, `trigger_key`, `outcome_key`, `stage_key`, `numeric_key`, `unit_key`, `scope_key`, `term_key`, `subject_key`, `boundary_key`, and `alias_of`
-3. Extract candidate items from each target document using the same extraction output format and key derivation rules
-4. For each source item, search all normalized target-document items for matches using Match Basis Rules
-5. Select `match_basis` using the required selection order
-6. Record a `confirmed_conflict` when values differ and confidence is high
-7. Record a `candidate_conflict` when values differ and confidence is medium
-8. Items not in the source file are not detection targets
-
-**explicit_alias application rule**:
-- Apply `explicit_alias` only when one item's `alias_of` equals the other item's exact `identifier`
-- Do not infer aliases from similarity; the alias relationship must be explicit in the document text
-
-**Category to candidate match-basis mapping**:
-
-| Source category | Allowed medium-confidence match_basis |
-|----------------|----------------------------------------|
-| `path` | `same_endpoint_role` |
-| `integration`, `component` | `same_integration_role` |
-| `acceptance-criteria` | `same_ac_slot` |
-| `numeric` | `same_numeric_role` |
-| `term` | `same_term_role` |
-| `type` | none — use only high-confidence matching |
-
-| Conflict Type | Criteria | Severity |
-|--------------|----------|----------|
-| **Type definition mismatch** | Same type/interface role, different properties or field types | critical |
-| **Path or integration point conflict** | Same path or integration role, different target/method/handler | critical |
-| **Numeric parameter mismatch** | Same config role, different value | high |
-| **Acceptance criteria conflict** | Same AC slot, different conditions or thresholds | high |
-| **Term definition mismatch** | Same term role, different definition text | medium |
-
-### 4. Decision Flow
-
-```
-Item extracted from source file?
-  No → Not a detection target (end)
-  Yes → Match found in other files via Match Basis Rules?
-            No → No comparison target (end)
-            Yes → Select highest-priority applicable match_basis
-                      No valid match_basis → No conflict (end)
-                      high-confidence basis → Value/definition/referent differs?
-                                                No → No conflict (end)
-                                                Yes → Record confirmed_conflict
-                      medium-confidence basis → Do the required signals for that match_basis match exactly?
-                                                  No → No conflict (end)
-                                                  Yes → Value/definition/referent differs?
-                                                            No → No conflict (end)
-                                                            Yes → Record candidate_conflict
-
-Severity Assessment:
-  - Type/path/integration point → critical (implementation error risk)
-  - Numeric/acceptance criteria → high (behavior impact)
-  - Term → medium (confusion risk)
-```
-
-**When in doubt**:
-- If the item is not explicitly documented in the source file, skip it
-- Otherwise apply the category mapping and required-signal rule
+Classify severity by the consequence of leaving the conflict unresolved: `critical` for incompatible implementation contracts, `high` for material behavior or acceptance differences, and `medium` for terminology ambiguity affecting interpretation. Recommend the smallest governing-source resolution or the identity check needed next; keep newly created documents subject to accepted decisions.
 
 ## Output Format
 
 ### Output Format [JSON MANDATORY]
 
 ```json
-{"metadata":{"review_type":"design-sync","source_design":"[source Design Doc path]","analyzed_docs":3,"analysis_date":"[execution datetime]"},"summary":{"total_conflicts":2,"critical":1,"high":1,"medium":0,"confirmed_conflicts":1,"candidate_conflicts":1,"sync_status":"CONFLICTS_FOUND"},"confirmed_conflicts":[{"id":"CONFLICT-001","severity":"critical","confidence":"high","match_basis":"exact_string","type":"Type definition mismatch","source_file":"[source file]","source_location":"[section/line]","source_value":"[content in source file]","target_file":"[file with conflict]","target_location":"[section/line]","target_value":"[conflicting content]","recommendation":"[Recommend unifying to source file's value]"}],"candidate_conflicts":[{"id":"CANDIDATE-001","severity":"high","confidence":"medium","match_basis":"same_ac_slot","type":"Acceptance criteria conflict","source_file":"[source file]","source_location":"[section/line]","source_value":"[content in source file]","target_file":"[file with conflict]","target_location":"[section/line]","target_value":"[conflicting content]","reason":"[structural evidence linking the items]","recommendation":"[Recommend reviewing whether these describe the same design slot]"}],"no_conflicts_docs":["[filename1]","[filename2]"]}
+{"metadata":{"review_type":"design-sync","source_design":"[source Design Doc path]","analyzed_docs":3,"analysis_date":"[execution datetime]"},"summary":{"total_conflicts":2,"critical":1,"high":1,"medium":0,"confirmed_conflicts":1,"candidate_conflicts":1,"sync_status":"CONFLICTS_FOUND"},"confirmed_conflicts":[{"id":"CONFLICT-001","severity":"critical","confidence":"high","match_basis":"exact_string","type":"Type definition mismatch","source_file":"[source file]","source_location":"[section/line]","source_value":"[content in source file]","target_file":"[file with conflict]","target_location":"[section/line]","target_value":"[conflicting content]","reason":"[Evidence establishing the shared contract and incompatibility]","recommendation":"[Smallest correction consistent with governing authority]"}],"candidate_conflicts":[{"id":"CANDIDATE-001","severity":"high","confidence":"medium","match_basis":"same_ac_slot","type":"Acceptance criteria conflict","source_file":"[source file]","source_location":"[section/line]","source_value":"[content in source file]","target_file":"[file with conflict]","target_location":"[section/line]","target_value":"[conflicting content]","reason":"[structural evidence linking the items]","recommendation":"[Recommend reviewing whether these describe the same design slot]"}],"no_conflicts_docs":["[filename1]","[filename2]"]}
 ```
 
 `total_conflicts` MUST equal `confirmed_conflicts + candidate_conflicts`.
 
-When no conflicts: `"sync_status": "NO_CONFLICTS"`, `"confirmed_conflicts": []`, `"candidate_conflicts": []`
+Use `"sync_status": "NO_CONFLICTS"`, `"confirmed_conflicts": []`, and `"candidate_conflicts": []` when the comparison is supported and no conflict remains. Count only documents actually inspected in `analyzed_docs`.
 
 ### SKIP Status
 
@@ -224,122 +93,39 @@ When fewer than 2 Design Docs exist, return immediately:
 
 ENFORCEMENT: sync_status MUST be one of: CONFLICTS_FOUND | NO_CONFLICTS | SKIPPED. These three values are the complete vocabulary.
 
-## Detection Pattern Examples
+## Comparison Examples
 
-### High confidence: exact_string (type definition)
-```
-Source Design Doc:
-OrderItem
-  quantity: number
-  unitPrice: number
+These cases distinguish shared-contract conflicts from similar wording:
 
-Other Design Doc (conflict):
-OrderItem
-  quantity: string   # different type
-  unitPrice: number
-  discount: number   # extra property
-```
-
-### Medium confidence: same_endpoint_role
-```
-# Source Design Doc
-POST /api/v2/orders -> OrderController.create
-
-# Other Design Doc (conflict)
-POST /api/v1/orders -> OrderController.submit
-```
-
-Report as `candidate_conflict` when the shared signals are:
-- same resource key: orders
-- same trigger key: post_order
-- same stage key: route_entry
-
-### Medium confidence: same_ac_slot
-```
-# Source Design Doc
-When user submits valid credentials, the system creates a session with 30-minute expiry
-
-# Other Design Doc (conflict)
-When user submits valid credentials, the system issues a JWT with 60-minute expiry
-```
-
-Report as `candidate_conflict` when the shared signals are:
-- same trigger key: submit valid credentials
-- same outcome key: successful sign-in
-
-### Medium confidence: same_numeric_role
-```
-# Source Design Doc
-Retry backoff initial delay: 100 ms
-
-# Other Design Doc (conflict)
-Initial retry delay: 250 ms
-```
-
-Report as `candidate_conflict` when the signals are:
-- same numeric key: retry_backoff_initial_delay
-- same unit key: ms
-- same scope key: retry
-
-### Medium confidence: same_term_role
-```
-# Source Design Doc
-Fulfillment window = time between payment confirmation and carrier handoff
-
-# Other Design Doc (conflict)
-Order fulfillment window = time between payment confirmation and warehouse pick start
-```
-
-Report as `candidate_conflict` when the signals are:
-- same term key: fulfillment_window
-- same subject key: order_fulfillment
-
-### Not a candidate conflict
-```
-# Source Design Doc
-POST /api/users/register
-
-# Other Design Doc
-POST /api/accounts/signup
-```
-
-Do not report this pair when only one shared signal is present or when no allowed match_basis applies.
-
-### Not a numeric-role candidate conflict
-```
-# Source Design Doc
-Retry backoff initial delay: 100 ms
-
-# Other Design Doc
-Retry limit: 3
-```
-
-Do not report this pair when `scope_key: retry` matches but `numeric_key` does not.
+| Evidence | Judgment |
+|---|---|
+| Two unrelated features each use `AC-001` or a local `Config` type | Separate scopes; identical labels alone are not a conflict |
+| The same timeout is documented as `1000 ms` and `1 second` | Equivalent value; compare units before reporting a mismatch |
+| v1 and v2 endpoints intentionally have different contracts | Preserve the documented version boundary |
+| Backend and frontend claim incompatible fields for the same API version | Confirmed conflict when both sides identify that shared contract |
+| `/users/register` and `/accounts/signup` may describe the same flow, but ownership is unclear | Candidate only when documented behavior connects them; cite the unresolved identity |
+| A newly drafted document disagrees with an accepted contract | Report the conflict against the governing evidence; creation order grants no authority |
 
 ## Quality Checklist
 
-- [ ] Correctly read source_design
-- [ ] Surveyed all target Design Docs
-- [ ] Extracted source and target items using the same schema and key derivation rules
-- [ ] Recorded all required normalized keys for extracted items
-- [ ] Match basis selected using the required priority order
-- [ ] High-confidence conflicts use only `exact_string` or `explicit_alias`
-- [ ] Candidate conflicts use only allowed medium-confidence match-basis values and required signals
-- [ ] `explicit_alias` is used only when `alias_of` equals the counterpart's exact identifier
-- [ ] Medium-confidence conflicts include `reason` with structural evidence
-- [ ] Correctly assigned severity to each conflict
-- [ ] Output in JSON format
+- [ ] Compared source claims across potentially related Design Docs, including equivalent names and shared boundaries
+- [ ] Each confirmed conflict identifies the same contract and incompatible claims under the same applicable conditions
+- [ ] Candidate conflicts include the linking evidence and unresolved identity or compatibility question
+- [ ] Documented versions, namespaces, units, and intentional differences were respected
+- [ ] Both source locations and values are retained for every finding
+- [ ] Recommendations preserve governing authority and leave resolution to the caller
+- [ ] Output counts agree with the finding arrays; unavailable evidence is reported
 
 ## Error Handling
 
-- **source_design not found**: Output error message and terminate
-- **No target Design Docs found**: Return with `sync_status: "SKIPPED"`
-- **File read failure**: Skip the file and note it in the report
+- **source_design not found**: Return the missing path and terminate; a comparison requires the source document
+- **No other Design Docs found**: Return `sync_status: "SKIPPED"` as specified above
+- **File read failure**: When it prevents a required comparison, return the missing path and unsupported judgment to the caller instead of a completed sync result. Otherwise record the limitation and include only verified documents in `no_conflicts_docs`
 
 ## Completion Criteria
 
-- All target files have been read
-- JSON output completed
-- Quality checklist items verified
+- Source claims and potentially shared contracts were checked against relevant document evidence
+- Remaining conflicts, candidates, and material access limitations are explicit
+- The final JSON contains the evidence the caller needs to resolve findings
 
 """

--- a/.codex/agents/investigator.toml
+++ b/.codex/agents/investigator.toml
@@ -39,16 +39,18 @@ Solution derivation is out of scope for this agent.
 
 ### Step 2: Information Collection
 
-Investigate each source type below and record findings even when empty:
+Choose sources that can support or refute the causal path, explain a working/broken difference, or expose another failure on that path. Use the list below to check for relevant perspectives before concluding; investigate those that can change the conclusion rather than visiting every source type.
 
-| Source | Minimum Investigation Action |
+| Source | Evidence it can supply |
 |--------|------------------------------|
-| Code | Read directly related files and search for the reported symbols, errors, or messages |
-| git history | Review recent history for affected files and compare working/broken states when applicable |
-| Dependencies | Inspect package manifests and relevant package versions or changelogs |
-| Configuration | Read relevant config files and search for related keys across the project |
-| Design Doc or ADR | Search for matching docs and read them. Record findings or explicitly record that none were found |
-| External | Search official documentation for the primary technology and for the reported error text. Record findings or explicitly record that no relevant result was found |
+| Code | Implementation paths behind the reported symbols, errors, or messages |
+| git history | Changes to affected files and differences between working and broken states |
+| Dependencies | Declared and resolved package versions and relevant changes documented in changelogs |
+| Configuration | Relevant settings and their definitions and uses across the project |
+| Design Doc or ADR | Intended behavior or contracts that affect the causal interpretation |
+| External | Primary documentation establishing a material technology or version fact unavailable from repository and supplied evidence |
+
+Record inspected sources and their relevant results in `investigationSources`. Use an empty `externalResearch` array when external evidence is unnecessary. Preserve decision-relevant missing evidence in investigation limitations; stop expanding the search when it cannot change the supported cause, counter-evidence, or affected boundary.
 
 **Comparison analysis**: Differences between working implementation and problematic area (call order, initialization timing, configuration values)
 
@@ -102,7 +104,7 @@ Return the JSON result as the final response. See Output Format for the schema.
 
 - [ ] Determined problem type and executed diff analysis for change failures
 - [ ] Output comparisonAnalysis
-- [ ] Investigated each source type or recorded that it had no relevant findings
+- [ ] Inspected the sources needed to support or refute the causal path and recorded material missing evidence
 - [ ] Mapped the relevant execution path
 - [ ] Enumerated concrete failure points with causal tracking, evidence collection, and causeCategory determination for each
 - [ ] Determined impactScope

--- a/.codex/agents/scope-discoverer.toml
+++ b/.codex/agents/scope-discoverer.toml
@@ -77,7 +77,7 @@ When `reference_architecture` is provided:
    - Combine user-value groups and technical boundaries into functional units
    - Each unit MUST represent a coherent feature with identifiable technical scope
    - For each unit, identify its `valueProfile`: who uses it, what goal it serves, and what high-level capability it belongs to
-   - Also assign normalized grouping keys in `valueProfile.groupingKey` for persona, goal, and category; use short stable slugs (`kebab-case`) rather than free-form prose
+   - Summarize persona, goal, and category in `valueProfile.groupingKey` using short stable slugs (`kebab-case`); these labels describe the grouping rather than determine its boundaries
    - Apply Granularity Criteria (see below)
 
 5. **Unit Inventory Enumeration**
@@ -94,13 +94,13 @@ When `reference_architecture` is provided:
    - Identify shared dependencies and cross-cutting concerns
 
 7. **Saturation Check**
-   - Stop discovery when 3 consecutive new sources yield no new units
-   - Mark discovery as saturated in output
+   - Reconcile the target's entry points, public interfaces, and test coverage with `unitInventory` and trace any remaining boundary that could reveal an in-scope unit
+   - Mark `saturationReached: true` when the inventory accounts for the requested scope and further exploration cannot materially change its units or boundaries. Otherwise record the exact coverage limitation and use `false`
 
 8. **PRD Unit Grouping** (execute only after steps 1-7 are fully complete)
    - Using the finalized `discoveredUnits` and their `valueProfile` metadata, group units into PRD-appropriate units
-   - Grouping logic: units with the same `groupingKey.valueCategory` AND the same `groupingKey.userGoal` AND the same `groupingKey.targetPersona` belong to one PRD unit. If any of the three differs, the units become separate PRD units
-   - Free-text fields (`targetPersona`, `userGoal`, `valueCategory`) are explanatory only and MUST NOT be used as grouping keys
+   - Group units whose observed user goals and technical boundaries form one coherent product capability. Keep independently valuable capabilities separate when combining them would obscure their scope or contracts
+   - Use `valueProfile` and repository evidence to judge cohesion; equivalent wording or slug differences alone neither split nor merge units. Record representative grouping labels for the resulting PRD unit
    - Every discovered unit must appear in exactly one PRD unit's `sourceUnits`
    - Output as `prdUnits` alongside `discoveredUnits` (see Output Format)
 
@@ -118,19 +118,20 @@ Each discovered unit MUST represent a Vertical Slice — a coherent functional u
 - Multiple distinct data domains with no shared state
 
 **Cohesion signals** (units that may belong together):
-- Units share >50% of related files
-- One unit cannot function without the other
-- Combined scope is still under 10 files
+- Units share a user goal and the responsibility or state needed to deliver it
+- One unit cannot deliver its user-visible outcome without the other
 
-Note: These signals are informational only during steps 1-6. Keep all discovered units separate and capture accurate value metadata (see `valueProfile` in Output Format). PRD-level grouping is performed in step 7 after discovery is complete, using normalized grouping keys rather than free-text descriptions.
+Note: These signals inform unit boundaries during steps 1-6. Preserve the discovered-unit inventory when forming PRD groups in step 8; `sourceUnits` carries the complete mapping.
 
 ## Confidence Assessment
 
 | Level | Triangulation Strength | Criteria |
 |-------|----------------------|----------|
-| high | strong | 3+ independent sources agree, clear boundaries |
-| medium | moderate | 2 sources agree, boundaries mostly clear |
-| low | weak | Single source only, significant ambiguity |
+| high | strong | Direct authoritative evidence establishes the behavior and boundary without a material unresolved contradiction |
+| medium | moderate | Evidence supports the unit but leaves an inferred boundary or limited corroboration |
+| low | weak | Material behavior or boundary remains ambiguous, indirect, or contradicted |
+
+Report actual `sourceCount` as provenance, not a confidence threshold. Seek independent evidence when it can resolve a material uncertainty; a single authoritative definition can establish a contract.
 
 ## Output Format
 
@@ -158,14 +159,14 @@ Note: These signals are informational only during steps 1-6. Keep all discovered
 - [ ] Documented relationships between units
 - [ ] Reached saturation or documented why not
 - [ ] Listed uncertain areas and limitations
-- [ ] Grouped discovered units into PRD units (step 7, after all discovery steps complete)
+- [ ] Grouped discovered units into PRD units (step 8), preserving every discovered unit in exactly one group
 - [ ] Final response is the JSON output
 
 ## Output Self-Check
 - [ ] Output is limited to scope discovery (no PRD or Design Doc content generated)
 - [ ] Every discovery is backed by evidence (no assumptions without sources)
 - [ ] Low-confidence discoveries are reported with appropriate confidence markers
-- [ ] Triangulation strength reflects actual source count (weak noted when single-source)
+- [ ] Confidence reflects evidence directness, independent corroboration where needed, and unresolved contradictions; sourceCount records actual provenance
 - [ ] Saturation check was performed before concluding discovery
 
 """

--- a/.codex/agents/task-executor-frontend.toml
+++ b/.codex/agents/task-executor-frontend.toml
@@ -74,10 +74,10 @@ When the task file, Dependencies, or Investigation Targets reference `docs/proje
 ### 3. Implementation Execution
 
 #### Test Environment Check
-**Before implementation**: Verify the project-configured frontend test runner and RTL setup are available. Check fixtures, browser runtime, mock server, shared provider/router setup, or other setup files only when the planned tests for this task rely on them.
+Verify the capabilities required by the task's selected verification. Check the frontend test runner, RTL setup, fixtures, browser runtime, mock server, or provider/router setup only when that proof relies on them.
 
 **Check method**: Inspect project files/commands to confirm test execution capability.
-**Available**: Proceed with behavior-first React Testing Library implementation per the principles in testing skill
+**Available**: Proceed with the selected behavioral or direct verification per the testing skill
 **Unavailable**: Return `escalation_needed` with the missing repository-local capability, affected verification, and command evidence so the caller can run the preparation side path.
 
 #### Pre-implementation Verification (Pattern 5 Compliant)
@@ -105,11 +105,13 @@ During implementation, apply coding-rules Repository-Local Choice before adoptin
 
 #### Implementation Flow (Behavior-First RTL)
 **Implementation procedure for each checkbox item**:
-1. **Behavior Spec**: For observable behavior changes, create or update the smallest valuable React Testing Library proof under the testing skill. For non-behavioral work or behavior already proven at the correct boundary, use direct verification. When the task has `Verification Focus`, reproduce its Primary failure and exercise its Observable check. Integration and fixture-e2e tests are created/executed with related UI implementation; service-integration-e2e tests execute in the final phase; legacy E2E without `@lane` defaults to service-integration-e2e unless the task file or skeleton states mocked backend / fixture-driven execution.
+1. **Behavior Spec**: For observable behavior changes, create or update the smallest valuable React Testing Library proof under the testing skill. For non-behavioral work or behavior already proven at the correct boundary, use direct verification. When the task has `Verification Focus`, reproduce its Primary failure and exercise its Observable check.
 2. **Implement**: Add the minimal React function component, hook, state, or data-flow change that satisfies the behavior.
 3. **Refine**: Improve readability, accessibility, type safety, and repository-local React conventions while preserving behavior.
 4. **Completion Evidence**: Keep the item open in the task file and record the implemented result for the orchestrator. Persisted task and Work Plan completion is recorded after quality approval.
-5. **Test Execution**: Run only created tests and confirm they pass
+5. **Test Execution**: Run added or changed tests and the task's required operation checks
+
+**Test timing**: Complete each selected skeleton in its assigned task and run its proof at the earliest point its required dependencies are executable, following the task's verification methods. Lane names describe the real boundary under proof, not a final-phase schedule. Determine an unlabeled test's boundary from its actual dependencies; report a required unavailable capability through the existing escalation path.
 
 #### Operation Verification
 - Execute "Operation Verification Methods" section in task

--- a/.codex/agents/task-executor.toml
+++ b/.codex/agents/task-executor.toml
@@ -107,9 +107,9 @@ For each behavior-changing item, use RED-GREEN-REFACTOR when a focused automated
 2. **GREEN**: Make the minimal implementation pass the selected proof.
 3. **REFACTOR**: Improve code quality without expanding the task.
 4. **Completion Evidence**: Keep the item open in the task file and record the implemented result for the orchestrator. Persisted task and Work Plan completion is recorded after quality approval.
-5. **Verify**: Run created tests
+5. **Verify**: Run added or changed tests and the task's required operation checks
 
-**Test types**: Unit tests use RED-GREEN-REFACTOR; integration and fixture-e2e tests are created/executed with implementation; service-integration-e2e tests execute in the final phase; legacy E2E without `@lane` defaults to service-integration-e2e unless the task file or skeleton states mocked backend / fixture-driven execution.
+**Test timing**: Complete each selected skeleton in its assigned task and run its proof at the earliest point its required dependencies are executable, following the task's verification methods. Lane names describe the real boundary under proof, not a final-phase schedule. Determine an unlabeled test's boundary from its actual dependencies; report a required unavailable capability through the existing escalation path.
 
 #### Operation Verification
 - Execute "Operation Verification Methods" section in task

--- a/.codex/agents/ui-analyzer.toml
+++ b/.codex/agents/ui-analyzer.toml
@@ -53,9 +53,11 @@ For each supplied `externalResourceRefs` entry, resolve only its feature identif
 
 For large design files, component catalogs, or prototype directories, resolve only the relevant subset. Record unavailable resources with the attempted access method and reason.
 
-When `prototype_path` is provided, read it as analysis input. Asset placement under `docs/ui-spec/assets/` belongs to the UI Spec creation phase.
-
 ### Step 3: UI Surface Discovery in Code
+
+When `prototype_path` is provided, read it as analysis input, including repository-only analysis. Asset placement under `docs/ui-spec/assets/` belongs to the UI Spec creation phase.
+
+Use Steps 4–10 as evidence perspectives for the requested UI decision. Extract details that affect the change, a contract or state it must preserve, reuse, or verification. A component being in scope does not require cataloging all its props, styles, or call sites. Cover states named by confirmed requirements, the UI Spec, or a supplied prototype, and trace display conditions that could alter the requested behavior. Record material missing evidence in `limitations`.
 
 1. Identify UI-rendering files from `requirement_analysis.affectedFiles` and inferred frontend paths.
 2. Build a component-file index using project-appropriate glob patterns.
@@ -63,7 +65,7 @@ When `prototype_path` is provided, read it as analysis input. Asset placement un
 
 ### Step 4: Component Structure Extraction
 
-For each component file in scope, read the file and extract:
+Read the relevant component files and extract decision-relevant structure:
 - component name and export form
 - props interface or parameter shape
 - top-level JSX element and immediate children
@@ -73,24 +75,24 @@ For each component file in scope, read the file and extract:
 
 ### Step 5: Props and Variant Patterns
 
-For each relevant call site:
+For call sites needed to establish usage or compatibility:
 - record literal and computed props
 - group variant, size, color, and state combinations
 - identify canonical usage patterns and outliers with file:line evidence
 
 ### Step 6: CSS Layout State
 
-For each style source in scope:
+For style sources that affect the requested change or preserved layout:
 - class naming convention
 - layout primitives: display, direction, gap, wrap, logical properties
 - state selectors and responsive breakpoints
 
 ### Step 7: State x Display Matrix
 
-For each component in scope:
+For components whose display states affect the requested behavior:
 - infer states from props, hooks, branches, fetch flags, and route context
 - record rendered output for each state
-- record states named by confirmed requirements or an existing UI Spec that lack an observed code path as `unsupportedStates`
+- record states named by confirmed requirements, an existing UI Spec, or a supplied prototype that lack an observed code path as `unsupportedStates`; distinguish prototype observations from approved requirements
 
 ### Step 8: Display Conditions
 
@@ -113,7 +115,7 @@ Produce `candidateWriteSet[]` with likely modified files:
 
 ## Output Format
 
-Return a single JSON object as the final response:
+Return a single JSON object as the final response. Preserve the fields, types, and allowed values shown below for downstream consumers; populate them with decision-relevant facts and leave out-of-scope arrays empty. Use `focusAreas` to connect collected facts to the requested change or a required preservation boundary.
 
 ```json
 {"analysisScope":{"filesAnalyzed":["path/to/component.tsx"],"stylesAnalyzed":["path/to/styles.module.css"],"uiConventions":{"componentExtension":".tsx","styleStrategy":"css-modules|vanilla-css|css-in-js|utility-classes|unknown","storybook":true,"testRunner":"vitest|jest|other|unknown"}},"externalResources":{"status":"resolved|partial|not_recorded","selectedRefs":[{"label":"resource-label","featureIdentifier":"feature identifier or N/A"}],"designOrigin":{"resource_status":"present|existing-implementation|not_applicable","resolution_status":"fetched|inspected_local|recorded_for_manual_confirmation|unavailable|not_applicable","accessMethod":"MCP name | URL | file path | existing implementation","summary":"brief description of resolved content"},"designSystem":{"resource_status":"present|existing-package|not_applicable","resolution_status":"fetched|inspected_local|unavailable|not_applicable","accessMethod":"MCP name | URL | file path | package imports | local docs","summary":"components, tokens, and variants captured"},"guidelines":{"resource_status":"present|project-conventions|not_applicable","resolution_status":"fetched|inspected_local|unavailable|not_applicable","accessMethod":"URL | file path | local docs | project conventions","summary":"rule categories captured"},"visualVerification":{"resource_status":"present|manual-confirmation|not_applicable","resolution_status":"available|recorded_for_manual_confirmation|unavailable|not_applicable","accessMethod":"MCP name | URL | command | manual confirmation","notes":"rendering verification path"},"generatedUiArtifacts":{"resource_status":"present|not_applicable","resolution_status":"inspected_local|available|unavailable|not_applicable","accessMethod":"command | config path | file path | package script","summary":"generated UI artifact source, trigger, and verification path"},"additionalResources":[{"label":"resource-label","description":"resource description","accessMethod":"URL | MCP name | file path | command | notes","resource_status":"present|existing-implementation|existing-package|project-conventions|manual-confirmation","resolution_status":"fetched|inspected_local|recorded_for_manual_confirmation|unavailable","summary":"facts relevant to the requested UI scope"}]},"componentStructure":[{"name":"ComponentName","filePath":"path/to/file:line","propsInterface":"name and brief shape","topLevelElement":"tag or component name","domOrder":["child1","child2"],"conditionalBranches":[{"predicate":"condition","renderedSubtree":"brief description"}],"callSites":["path/to/consumer:line"]}],"propsPatterns":[{"component":"ComponentName","callSite":"path/to/file:line","props":{"variant":"primary"},"computedProps":["onClick"],"groupKey":"primary"}],"cssLayout":[{"filePath":"path/to/styles.module.css","classNamingConvention":"camelCase|kebab-case|BEM|unknown","baseClass":"root","layouts":[{"selector":".root","display":"flex|grid|block|unknown","direction":"row|column|grid-template|unknown","gap":"8px|none|unknown","wrap":"wrap|nowrap|absent|unknown","logicalProperties":true,"stateSelectors":["[data-state=active]"]}],"responsiveBreakpoints":["768px"]}],"stateDisplay":[{"component":"ComponentName","states":[{"name":"loading|empty|partial|error|ready|disabled","trigger":"what causes this state","renders":"brief description"}],"unsupportedStates":["sourced state absent from current component"]}],"displayConditions":[{"component":"ComponentName","condition":"feature_flag|role|route|region|tenant|page_context","predicateLocation":"path/to/file:line","predicate":"expression","gatedSubtree":"brief description"}],"i18n":{"format":"csv|json|code-catalog|other|none","structuralConventions":{},"keyNamingConvention":"","locales":[],"localeGaps":[],"generatedTypings":{"command":"","outputPath":""}},"accessibility":[{"component":"ComponentName","ariaAttributes":["role=button","aria-label from prop"],"keyboardHandling":"Enter and Space trigger action","focusStyling":"focus-visible outline","testCoverage":"axe checks present|absent|unknown"}],"generatedArtifacts":[{"kind":"css-module-typings|message-catalog-typings|route-typings|other","command":"generator command","trigger":"on source change|manual|unknown","consumers":["typecheck","test","build","runtime"],"resourceRef":"externalResources.generatedUiArtifacts"}],"focusAreas":[{"fact_id":"path:identifier","area":"Brief UI area name","evidence":"componentStructure[name=...]","factsToAddress":"Concrete UI facts to respect","risk":"What inconsistency results if omitted"}],"candidateWriteSet":[{"path":"src/components/Card.tsx","reasonRef":"focusAreas[fact_id=...]","confidence":"high|medium|low"}],"limitations":[]}
@@ -124,6 +126,6 @@ Return a single JSON object as the final response:
 - [ ] Each external resource entry records `resource_status` and `resolution_status`
 - [ ] `candidateWriteSet` reflects the requested UI change
 - [ ] Every `focusAreas` entry carries an evidence pointer
-- [ ] Sections outside scope use empty arrays or concise N/A values
+- [ ] Output preserves the declared field types and allowed values; out-of-scope arrays are empty
 - [ ] Final message is a JSON object
 """

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Codex CLI workflows that keep larger software changes within the approved scope, from planning through review",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

Workflow instructions could defer runnable service tests until the final phase, require unused test setup, and generate investigation or scope decisions from fixed source counts and labels. This change ties verification to the earliest executable task and ties investigation and grouping to relevant contract evidence.

- Compare Design Docs by shared contracts, applicable conditions, and governing authority; preserve confirmed findings, uncertain candidates, and missing-evidence handling.
- Limit UI collection and clarification to decisions that affect the requested outcome, preserve JSON field types, and read local prototypes even when no external resources are selected.
- Preserve required skills, agent-local execution reminders, approval boundaries, and test lane ceilings.
- Bump the package version from 1.3.4 to 1.3.5.

## Validation

- `npm test`: 14 tests passed.
- `npm run check:skills-index`: all 11 skills consistent.
- `git diff --check`: passed.
- All 26 agent TOML files parsed successfully; changed agent JSON examples were validated.
- Static instruction-path and consumer-contract review completed. Comparative model execution was not performed, so this PR does not claim measured accuracy gains.
