### PR TITLE
Fix frontend type assertion guidance

### DIFF
--- a/.agents/skills/ai-development-guide/references/frontend.md
+++ b/.agents/skills/ai-development-guide/references/frontend.md
@@ -4,7 +4,7 @@
 
 In addition to the general anti-patterns in SKILL.md, detect these frontend-specific patterns:
 
-1. **Excessive use of type assertions (`as`)** - Abandoning type safety; use `unknown` + type guards instead
+1. **Type assertions standing in for a guarantee** - Back the asserted type with a check or an existing contract that establishes it at the boundary where the assertion is made.
 2. **Pass-through prop chains that obscure state ownership** - Use composition, Context, or the repository's state layer when intermediate components only forward values and a broader owner is clearer; retain explicit props when responsibility remains local and moving ownership upward would add coordination
 3. **Components mixing independently changing responsibilities** - Split when rendering, state/data ownership, or reusable/testable behavior forms an independent responsibility; retain cohesive components when splitting would add avoidable prop/state synchronization
 4. **Commented-out JSX or component code** - Delete it; Git preserves history

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Codex CLI workflows that keep larger software changes within the approved scope, from planning through review",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
Frontend guidance judged type assertions by an undefined usage threshold and prescribed `unknown` plus type guards, conflicting with the existing policy that permits assertions backed by an established invariant.

Require a supporting check or contract at the assertion boundary so valid existing guarantees can be reused. Bump the package patch version from 1.3.5 to 1.3.6.

Validation: `npm test` (14 tests passed), `npm run check:skills-index` (11 skills consistent), and `git diff --check` passed.
