### PR TITLE
Separate subagent delegation from workflow orchestration

### DIFF
--- a/.agents/skills/subagent-delegation/SKILL.md
+++ b/.agents/skills/subagent-delegation/SKILL.md
@@ -17,15 +17,15 @@ Choose the delegation level before spawning, based on which decisions the child 
 
 | Task type | Default delegation |
 |---|---|
-| Implementation or fixes within confirmed scope; review or verification against supplied criteria; research with a defined question | Delegate through completion, including the required verification. Receive the completed result or an escalation when the child cannot resolve a blocker within its scope. |
+| Implementation or fixes within confirmed scope; review or verification against supplied criteria; research with a defined question | Delegate through completion, including the required verification. Receive the completed result or an escalation for a blocker requiring help beyond the child's assigned scope. |
 | Exploration or design that needs the parent to settle the objective, selection criteria, or a major decision during the work | Name the decision retained by the parent in the assignment. Have the child request that decision when it becomes necessary, with the evidence needed to answer. |
 
-Research and design also use completion delegation when the child can make the required decisions from its assigned scope and evidence. Uncertainty alone does not require parent consultation. Use these defaults directly; only a retained parent decision needs additional consultation instructions.
+Research and design also use completion delegation when the child can make the required decisions from its assigned scope and evidence. Use these defaults directly; only a retained parent decision needs additional consultation instructions.
 
 ## Waiting and Intervention
 
 While the child works, perform only necessary work outside its delegated responsibility, or wait for its notification. For either delegation level, use the longest wait allowed by the active instructions and tool. A wait timeout or routine progress notification leaves the assignment pending; continue waiting.
 
-The child initiates consultation. Inspect its deliverable after receiving the completed result, and preserve the workflow's required verification and review. Intervene during execution for a child decision request, a user change or cancellation, or a material assignment error learned through other necessary work. These triggers use incoming information rather than periodic inspection of the child's output or files.
+The child initiates consultation. Inspect its deliverable after receiving the completed result and apply the required verification and review. Intervene during execution for a child decision request, a user change or cancellation, or a material assignment error learned through other necessary work. Base intervention on these notifications and independently acquired evidence.
 
 Preserve the running assignment until completion or a correction or redirection makes it obsolete. Elapsed time alone leaves it pending. Receive every required child result before producing the final deliverable.

--- a/.agents/skills/subagent-delegation/SKILL.md
+++ b/.agents/skills/subagent-delegation/SKILL.md
@@ -5,7 +5,7 @@ description: "Sets delegation scope, child-initiated consultation, and completio
 
 # Subagent Delegation
 
-Apply this skill before delegating work or managing a running subagent. It covers both custom agents and agents created for the current task. Recipe phases, specialist routing, and approval gates belong to `subagents-orchestration-guide` when executing those workflows.
+Apply this skill before delegating work or managing a running subagent. It covers both custom agents and agents created for the current task.
 
 ## Assignment
 

--- a/.agents/skills/subagent-delegation/SKILL.md
+++ b/.agents/skills/subagent-delegation/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: subagent-delegation
+description: "Sets delegation scope, child-initiated consultation, and completion waiting. Use when spawning, waiting for, or steering any subagent, including a single ad hoc agent or a custom workflow agent."
+---
+
+# Subagent Delegation
+
+Apply this skill before delegating work or managing a running subagent. It covers both custom agents and agents created for the current task. Recipe phases, specialist routing, and approval gates belong to `subagents-orchestration-guide` when executing those workflows.
+
+## Assignment
+
+Give the child its expected outcome, scope, governing inputs, and the result needed by the next consumer. Follow a custom agent's input contract and pass artifact paths instead of repeating their contents. Leave in-scope methods and reversible choices to the child.
+
+Accept semantically equivalent wording in natural-language inputs while preserving exact contracts where software parses them.
+
+Choose the delegation level before spawning, based on which decisions the child owns:
+
+| Task type | Default delegation |
+|---|---|
+| Implementation or fixes within confirmed scope; review or verification against supplied criteria; research with a defined question | Delegate through completion, including the required verification. Receive the completed result or an escalation when the child cannot resolve a blocker within its scope. |
+| Exploration or design that needs the parent to settle the objective, selection criteria, or a major decision during the work | Name the decision retained by the parent in the assignment. Have the child request that decision when it becomes necessary, with the evidence needed to answer. |
+
+Research and design also use completion delegation when the child can make the required decisions from its assigned scope and evidence. Uncertainty alone does not require parent consultation. Use these defaults directly; only a retained parent decision needs additional consultation instructions.
+
+## Waiting and Intervention
+
+While the child works, perform only necessary work outside its delegated responsibility, or wait for its notification. For either delegation level, use the longest wait allowed by the active instructions and tool. A wait timeout or routine progress notification leaves the assignment pending; continue waiting.
+
+The child initiates consultation. Inspect its deliverable after receiving the completed result, and preserve the workflow's required verification and review. Intervene during execution for a child decision request, a user change or cancellation, or a material assignment error learned through other necessary work. These triggers use incoming information rather than periodic inspection of the child's output or files.
+
+Preserve the running assignment until completion or a correction or redirection makes it obsolete. Elapsed time alone leaves it pending. Receive every required child result before producing the final deliverable.

--- a/.agents/skills/subagent-delegation/agents/openai.yaml
+++ b/.agents/skills/subagent-delegation/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Subagent Delegation"
+  short_description: "Delegate work and wait for results"
+  default_prompt: "Use $subagent-delegation to delegate this work and wait for results or a decision request."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: subagents-orchestration-guide
-description: "Guides subagent coordination through implementation workflows. Use when: orchestrating multiple agents, managing workflow phases, determining autonomous execution mode, or coordinating recipe execution."
+description: "Coordinates custom specialists through workflow phases, artifact handoffs, approval gates, and autonomous implementation. Use when executing a workflow recipe or routing its next specialist."
 ---
 
 # Subagents Orchestration Guide
+
+Load `subagent-delegation` for assignment, waiting, and intervention rules. This guide owns workflow-specific coordination.
 
 **Spawn rule**: every `spawn_agent` call uses `fork_turns="none"` so the subagent receives only the task message and explicitly provided context.
 
@@ -14,10 +16,6 @@ The orchestrator owns workflow state and directly performs lightweight coordinat
 ### Execution Plans
 
 Reuse one active execution plan for the recipe. When none exists, create it before substantive multi-step work with the recipe phases and final verification, then update the same plan as evidence is produced. Agent-internal execution plans remain local to each agent. Plans prevent skipped work; their wording or presence is not a user approval gate.
-
-### Prompt Construction Rule
-
-Give each subagent the expected action and the artifact paths or evidence needed for that action. Follow the agent's input contract and supply facts not already carried by the artifact. A compatible value under different wording is usable. Resolve a missing input when it would change the action or make its result unverifiable; use Orchestrator Escalation Resolution when repository and governing evidence cannot supply it.
 
 ### Entry Ownership
 
@@ -62,32 +60,12 @@ Assign work based on each subagent's responsibilities:
 - Self-contained processing until fix completion
 - Final approved judgment (only after fixes are complete)
 
-### Subagent Completion Discipline [MANDATORY]
-
-The orchestrator owns subagent completion. Base waiting decisions on assigned responsibility and observed state, not on an expectation of quick completion. Multi-step search, review, verification, generation, implementation, and quality work can run for extended periods.
-
-Use this contract:
-- Workflow subagents are single-purpose workers expected to converge.
-- When waiting for a workflow subagent, set `timeout_ms` to the maximum value accepted by the active `wait_agent` tool and continue waiting until its completion notification is received.
-- Treat `timed_out=true` as pending and continue waiting.
-- Hold final artifact production until every required subagent output is available.
-
-Treat the following as explicit contradictory evidence:
-- The subagent returns a terminal status such as `approved`, `needs_revision`, `blocked`, `skipped`, `completed`, or `escalation_needed`
-- The orchestrator verifies that it launched the wrong subagent or sent materially incorrect inputs
-- A newer explicit user instruction changes or cancels the task
-
-Close a running subagent only when the user redirects the workflow, the orchestrator corrects a launch mistake, or a newer user instruction supersedes the pending task.
-
-**ENFORCEMENT**: Preserve subagent execution until completion, user redirection, or explicit correction of an orchestrator launch mistake. Speed-based early termination is a CRITICAL VIOLATION.
-
 ## How to Spawn Agents
 
-Spawn agents using natural language prompts. Provide clear context about what the agent should accomplish. Apply the Spawn rule above.
+Apply `subagent-delegation` and the Spawn rule above. Resolve missing workflow inputs through Orchestrator Escalation Resolution when repository and governing evidence cannot supply them.
 
 ### Spawn Prompt Requirements
 
-- Each spawn prompt must name the target deliverable, input paths, and expected result.
 - When the assigned action writes repository files, include: `The orchestrator has delegated this repository-writing task from the user's requested workflow. This invocation authorizes the repository writes required to produce or update the assigned deliverable within the supplied scope. Perform the writes and return the result.` The orchestrator applies any workflow review or approval gate to the returned artifact afterward.
 - When invoking `task-executor*`, also include the exact task file path, for example: `Execute the implementation task. Task file: docs/plans/tasks/[filename].md.`
 

--- a/.agents/skills/subagents-orchestration-guide/SKILL.md
+++ b/.agents/skills/subagents-orchestration-guide/SKILL.md
@@ -62,7 +62,7 @@ Assign work based on each subagent's responsibilities:
 
 ## How to Spawn Agents
 
-Apply `subagent-delegation` and the Spawn rule above. Resolve missing workflow inputs through Orchestrator Escalation Resolution when repository and governing evidence cannot supply them.
+Apply the Spawn rule above. Resolve missing workflow inputs that affect the next action or its verification from repository and governing evidence; route remaining blockers through Orchestrator Escalation Resolution.
 
 ### Spawn Prompt Requirements
 

--- a/.agents/skills/task-analyzer/SKILL.md
+++ b/.agents/skills/task-analyzer/SKILL.md
@@ -33,7 +33,9 @@ Extract task tags and match them to `skills-index.yaml`. Consider implicit relat
 | Code implementation or refactoring | `coding-rules`, `testing` |
 | Design or implementation planning | `documentation-criteria`, `implementation-approach` |
 | Real boundary proof | `integration-e2e-testing` |
-| Agent handoff or multi-agent workflow | `llm-friendly-context`, `subagents-orchestration-guide` |
+| Spawning, waiting for, or steering a subagent | `subagent-delegation` |
+| Agent handoff content | `llm-friendly-context` |
+| Workflow phases, specialist routing, or approval gates | `subagents-orchestration-guide` |
 
 Select skills in this priority order:
 

--- a/.agents/skills/task-analyzer/references/skills-index.yaml
+++ b/.agents/skills/task-analyzer/references/skills-index.yaml
@@ -159,9 +159,20 @@ skills:
     references:
       - "references/e2e-design.md"
 
+  subagent-delegation:
+    skill: "subagent-delegation"
+    tags: [subagents, delegation, spawning, waiting, intervention, consultation, ad-hoc-agents, custom-agents]
+    typical-use: "Assigning work and waiting for completion or child-initiated consultation from any subagent"
+    size: small
+    key-references:
+      - "Assigned scope and parent-owned decisions"
+    sections:
+      - "Assignment"
+      - "Waiting and Intervention"
+
   subagents-orchestration-guide:
     skill: "subagents-orchestration-guide"
-    tags: [orchestration, workflow, subagents, update-plan, context-isolation, autonomous-execution, guided-autonomous-execution, planning, design-flow, implementation-flow, environment-preparation]
+    tags: [orchestration, workflow, specialist-routing, approval-gates, update-plan, context-isolation, autonomous-execution, guided-autonomous-execution, planning, design-flow, implementation-flow, environment-preparation]
     typical-use: "Orchestrating specialists through implementation workflows, approval points, optional environment preparation, and autonomous execution"
     size: large
     key-references:

--- a/README.es.md
+++ b/README.es.md
@@ -258,6 +258,7 @@ Cada flujo carga las reglas adaptadas al repositorio que necesita la tarea actua
 | `external-resource-context` | Consulta acotada de una fuente externa necesaria para una decisión concreta |
 | `llm-friendly-context` | Contexto claro para los agentes que lo usarán después: prompts, traspasos, artefactos generados, Task Files y observaciones de revisión |
 | `task-analyzer` | Análisis de intención, clasificación de tareas y selección de skills |
+| `subagent-delegation` | Delegar el trabajo a subagentes hasta que lo terminen, con consultas cuando haga falta una decisión |
 | `subagents-orchestration-guide` | Coordinación multiagente, gestión de flujos y ejecución autónoma guiada |
 
 También se incluyen referencias para TypeScript de frontend web, incluidas aplicaciones React (`coding-rules/references/typescript.md` y `testing/references/typescript.md`). No se aplican a TypeScript de backend.
@@ -344,6 +345,7 @@ your-project/
 │   ├── external-resource-context/
 │   ├── llm-friendly-context/
 │   ├── task-analyzer/
+│   ├── subagent-delegation/
 │   ├── subagents-orchestration-guide/
 │   └── recipe-*/             # Puntos de entrada ($recipe-*)
 ├── .codex/agents/            # Definiciones TOML de subagentes

--- a/README.ja.md
+++ b/README.ja.md
@@ -258,6 +258,7 @@ PRD、ADR、UI Spec、Design Docは長期的に残すプロジェクト文書で
 | `external-resource-context` | 現在の判断に必要な外部情報源を1つに絞って確認する方法 |
 | `llm-friendly-context` | 後続エージェントが迷わず使える、明確なプロンプト、引き継ぎ、生成物、Task File、レビュー指摘 |
 | `task-analyzer` | タスクの意図分析、種類の分類、スキル選択 |
+| `subagent-delegation` | サブエージェントに作業を最後まで任せ、判断が必要なときに相談を受ける |
 | `subagents-orchestration-guide` | マルチエージェントの連携、ワークフローの進行、指針に沿った自律実行 |
 
 Webフロントエンドで使うTypeScript向けには、Reactアプリケーションを含む追加資料（`coding-rules/references/typescript.md`、`testing/references/typescript.md`）も同梱されています。バックエンドTypeScriptには適用されません。
@@ -344,6 +345,7 @@ your-project/
 │   ├── external-resource-context/
 │   ├── llm-friendly-context/
 │   ├── task-analyzer/
+│   ├── subagent-delegation/
 │   ├── subagents-orchestration-guide/
 │   └── recipe-*/             # ワークフローの入口（$recipe-*）
 ├── .codex/agents/            # サブエージェントのTOML定義

--- a/README.ko.md
+++ b/README.ko.md
@@ -258,6 +258,7 @@ PRD, ADR, UI Spec, Design Doc은 장기 프로젝트 문서이므로 커밋해�
 | `external-resource-context` | 현재 결정에 필요한 외부 근거 하나만 선별해 확인 |
 | `llm-friendly-context` | 후속 에이전트를 위한 명확한 프롬프트, 인수인계, 산출물, Task File, 리뷰 의견 |
 | `task-analyzer` | 작업 의도 분석, 유형 분류, 스킬 선택 |
+| `subagent-delegation` | 하위 에이전트에 작업 완료까지 맡기고, 판단이 필요할 때 상의 |
 | `subagents-orchestration-guide` | 다중 에이전트 조율, 워크플로 진행, 가이드에 따른 자율 실행 |
 
 React 애플리케이션을 포함한 웹 프런트엔드 TypeScript용 참고 자료(`coding-rules/references/typescript.md`, `testing/references/typescript.md`)도 포함됩니다. 백엔드 TypeScript에는 적용되지 않습니다.
@@ -344,6 +345,7 @@ your-project/
 │   ├── external-resource-context/
 │   ├── llm-friendly-context/
 │   ├── task-analyzer/
+│   ├── subagent-delegation/
 │   ├── subagents-orchestration-guide/
 │   └── recipe-*/             # 워크플로 진입점($recipe-*)
 ├── .codex/agents/            # 하위 에이전트 TOML 정의

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Recipes load the repository-aware guidance required for the current task. You ra
 | `external-resource-context` | Focused resolution of one external evidence source required by a current decision |
 | `llm-friendly-context` | Clear prompts, handoffs, generated artifacts, task files, and review findings for downstream agents |
 | `task-analyzer` | Task intent analysis, task type classification, skill selection |
+| `subagent-delegation` | Letting subagents finish assigned work, with check-ins when a decision is needed |
 | `subagents-orchestration-guide` | Multi-agent coordination, workflow flows, guided autonomous execution |
 
 Web-frontend references are included for TypeScript used in web frontend work, including React applications (`coding-rules/references/typescript.md`, `testing/references/typescript.md`). They do not apply to backend TypeScript.
@@ -345,6 +346,7 @@ your-project/
 │   ├── external-resource-context/
 │   ├── llm-friendly-context/
 │   ├── task-analyzer/
+│   ├── subagent-delegation/
 │   ├── subagents-orchestration-guide/
 │   └── recipe-*/             # Workflow entry points ($recipe-*)
 ├── .codex/agents/            # Subagent TOML definitions

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Recipes load the repository-aware guidance required for the current task. You ra
 | `external-resource-context` | Focused resolution of one external evidence source required by a current decision |
 | `llm-friendly-context` | Clear prompts, handoffs, generated artifacts, task files, and review findings for downstream agents |
 | `task-analyzer` | Task intent analysis, task type classification, skill selection |
-| `subagent-delegation` | Letting subagents finish assigned work, with check-ins when a decision is needed |
+| `subagent-delegation` | Letting subagents finish assigned work and ask for input when a decision is needed |
 | `subagents-orchestration-guide` | Multi-agent coordination, workflow flows, guided autonomous execution |
 
 Web-frontend references are included for TypeScript used in web frontend work, including React applications (`coding-rules/references/typescript.md`, `testing/references/typescript.md`). They do not apply to backend TypeScript.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -258,6 +258,7 @@ Cada fluxo carrega as orientações adaptadas ao repositório de que a tarefa at
 | `external-resource-context` | Consulta direcionada a uma fonte externa necessária para a decisão atual |
 | `llm-friendly-context` | Contexto claro para os agentes que o usarão depois: prompts, repasses, artefatos gerados, Task Files e observações de revisão |
 | `task-analyzer` | Análise de intenção, classificação de tarefas e seleção de skills |
+| `subagent-delegation` | Delegar o trabalho a subagentes até a conclusão, com consultas quando for preciso tomar uma decisão |
 | `subagents-orchestration-guide` | Coordenação de múltiplos agentes, condução dos fluxos e execução autônoma guiada |
 
 Também há referências para TypeScript de frontend web, incluindo aplicações React (`coding-rules/references/typescript.md` e `testing/references/typescript.md`). Elas não se aplicam a TypeScript de backend.
@@ -344,6 +345,7 @@ your-project/
 │   ├── external-resource-context/
 │   ├── llm-friendly-context/
 │   ├── task-analyzer/
+│   ├── subagent-delegation/
 │   ├── subagents-orchestration-guide/
 │   └── recipe-*/             # Pontos de entrada ($recipe-*)
 ├── .codex/agents/            # Definições TOML dos subagentes

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -258,6 +258,7 @@ PRD、ADR、UI Spec和Design Doc属于需要长期保存的项目文档，应当
 | `external-resource-context` | 针对当前决策，只查找并确认所需的一项外部依据 |
 | `llm-friendly-context` | 供后续代理使用的清晰提示、交接内容、生成文档、Task File和评审意见 |
 | `task-analyzer` | 分析任务意图、任务分类和技能选择 |
+| `subagent-delegation` | 让子代理完成分配的工作，在需要决策时发起讨论 |
 | `subagents-orchestration-guide` | 多代理协调、工作流推进和按既定指引自主执行 |
 
 另有面向Web前端TypeScript（包括React应用）的参考资料：`coding-rules/references/typescript.md`和`testing/references/typescript.md`。这些内容不适用于后端TypeScript。
@@ -344,6 +345,7 @@ your-project/
 │   ├── external-resource-context/
 │   ├── llm-friendly-context/
 │   ├── task-analyzer/
+│   ├── subagent-delegation/
 │   ├── subagents-orchestration-guide/
 │   └── recipe-*/             # 工作流入口（$recipe-*）
 ├── .codex/agents/            # 子代理TOML定义

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Codex CLI workflows that keep larger software changes within the approved scope, from planning through review",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
Subagent waiting guidance was tied to the workflow orchestration skill, leaving ordinary delegation without the same guidance. This change makes completion delegation the default for both custom and ad hoc agents, with the child requesting input when a decision belongs to the parent.

The new `subagent-delegation` skill owns assignment, waiting, and intervention. The orchestration guide retains workflow routing and approval responsibilities. Skill discovery metadata, the selection index, and all six README editions are updated. The package version advances from 1.3.6 to 1.3.7.

Validation: the skill index check, all 14 existing tests, and `git diff --check` pass. Reduced monitoring in fresh agent sessions has not yet been verified.
