### PR TITLE
fix: clarify cost-aware delegation (v1.3.8)

### DIFF
--- a/.agents/skills/subagent-delegation/SKILL.md
+++ b/.agents/skills/subagent-delegation/SKILL.md
@@ -24,7 +24,7 @@ Research and design also use completion delegation when the child can make the r
 
 ## Waiting and Intervention
 
-While the child works, perform only necessary work outside its delegated responsibility, or wait for its notification. For either delegation level, use the longest wait allowed by the active instructions and tool. A wait timeout or routine progress notification leaves the assignment pending; continue waiting.
+Minimize total parent-and-child token cost while meeting required quality and user time constraints. While the child works, perform only necessary work outside its delegated responsibility, or wait for its notification. For notification-driven waits, use the longest timeout allowed by instructions and tools to reduce repeated parent context processing; notifications wake the parent early. Shorten it only for a concrete earlier parent action whose expected benefit outweighs the extra coordination cost. A wait timeout or routine progress notification leaves the assignment pending; continue waiting.
 
 The child initiates consultation. Inspect its deliverable after receiving the completed result and apply the required verification and review. Intervene during execution for a child decision request, a user change or cancellation, or a material assignment error learned through other necessary work. Base intervention on these notifications and independently acquired evidence.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-workflows",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Codex CLI workflows that keep larger software changes within the approved scope, from planning through review",
   "license": "MIT",
   "author": "Shinsuke Kagawa",


### PR DESCRIPTION
## Summary

Clarify one paragraph of the subagent delegation skill to minimize total parent-and-child token cost while preserving required quality and user time constraints. Prefer long notification-driven waits to reduce repeated parent context processing; shorter waits require a concrete earlier action whose benefit justifies the coordination cost.

Bump `codex-workflows` from 1.3.7 to 1.3.8.

## Validation

- `npm run check:skills-index`: all 12 skill indexes consistent.
- `npm test`: all 14 CLI tests passed.
- `git diff --check`: passed.
- One fresh `codex exec` session loaded the modified skill and completed a two-phase fixture using one child. All four parent waits requested 60 seconds, consistent with the host's guidance. Notifications woke the parent early; no short polling or unnecessary intervention occurred.

The runtime check is a single smoke test, not a reliability or cost-savings benchmark.
