### PR TITLE
docs: focus README on workflow value

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -66,10 +66,10 @@ El prefijo `$` invoca una skill de forma explícita. Escribe `$recipe-` para ver
 
 | ¿Qué necesitas? | Empieza por |
 |---|---|
-| Entregar de principio a fin un cambio de backend, API, CLI o de propósito general | `$recipe-implement` |
+| Entregar un cambio de principio a fin y dejar que el flujo elija la ruta de backend, frontend o fullstack | `$recipe-implement` |
 | Diseñar ahora e implementar más adelante | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
 | Diseñar y construir un frontend web con React / TypeScript | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
-| Entregar juntos un cambio de backend y otro de frontend React | `$recipe-fullstack-implement` |
+| Empezar directamente con flujos de diseño separados para backend y frontend React | `$recipe-fullstack-implement` |
 | Revisar una implementación frente a su diseño | `$recipe-review` o `$recipe-front-review` |
 | Definir o actualizar reglas de calidad propias del repositorio | `$recipe-quality-profile` |
 | Investigar un problema sin tocar el código | `$recipe-diagnose` |
@@ -109,7 +109,7 @@ Solo se crea un ADR para una decisión duradera dentro del alcance actual cuando
 
 Tras aprobar el alcance, el orquestador ejecuta las tareas, sus verificaciones específicas, los controles aplicables del repositorio y un commit de implementación por tarea. Primero resuelve los problemas a partir de los documentos aprobados y de las pruebas del repositorio. El comportamiento visible sigue siendo una frontera de producto: la implementación no puede ajustarlo por su cuenta para lograr coherencia interna. El orquestador solo consulta al usuario cuando avanzar exige un requisito de producto nuevo, cambiar una decisión principal ya aprobada, usar una autorización que solo posee el usuario o realizar una acción irreversible que no se autorizó.
 
-Los agentes especialistas reciben exactamente los documentos y las rutas que necesitan. Aportan evidencia concreta, pero no tienen autoridad para ampliar el resultado aprobado.
+Cada especialista recibe un trabajo acotado, los documentos y rutas pertinentes y un resultado claro que debe entregar. Se encarga del trabajo hasta completarlo, mientras la sesión principal conserva las decisiones de producto y del flujo, interviene solo cuando hace falta tomar una decisión o resolver un bloqueo concreto y comprueba el resultado antes de pasar a la siguiente fase. Así, los especialistas pueden trabajar con autonomía sin tener autoridad para ampliar el resultado aprobado.
 
 ### Cómo se conservan las decisiones al cambiar de contexto
 
@@ -157,6 +157,10 @@ npx codex-workflows install --user
 ```
 
 Las skills se instalan en `$CODEX_HOME/skills/` y los agentes en `$CODEX_HOME/agents/`. Si `CODEX_HOME` no está definido, se usa `~/.codex`.
+
+### Personalizar agentes
+
+Las definiciones de los agentes son archivos TOML normales. En una instalación de proyecto, edita los archivos de `.codex/agents/`; en una instalación de usuario, edita los de `$CODEX_HOME/agents/`. Puedes cambiar `model`, `sandbox_mode` o `developer_instructions`. Los archivos que edites se conservan durante las actualizaciones, como se explica a continuación.
 
 ### Actualizar
 
@@ -367,41 +371,9 @@ your-project/
 
 ---
 
-## Herramientas relacionadas
+## Ecosistema
 
-Cuando una idea de producto todavía necesita exploración o validación, [Nautilus](https://github.com/shinpr/nautilus) puede poner a prueba sus supuestos y convertir los resultados en un PRD. Una vez aprobado, pasa el PRD a `$recipe-implement` o `$recipe-design`.
-
-Si los requisitos ya están en Linear o en un PRD, [linear-prism](https://github.com/shinpr/linear-prism) puede leer el código, dividir el trabajo en incidencias de Linear listas para implementar y registrar qué incidencias bloquean a otras. Usa una incidencia aprobada como entrada para `$recipe-design`.
-
----
-
-## Preguntas frecuentes
-
-**P: ¿Con qué modelos funciona?**
-
-R: Está pensado para los modelos GPT actuales. El modelo se puede configurar por agente en sus archivos TOML.
-
-**P: ¿Puedo personalizar los agentes?**
-
-R: Sí. Edita los archivos TOML de `.codex/agents/` para cambiar `model`, `sandbox_mode` o `developer_instructions`. Las skills obligatorias de cada agente aparecen en `developer_instructions`. Los archivos que modifiques localmente se conservan al ejecutar `npx codex-workflows update`.
-
-En una instalación de usuario, edita los archivos de `$CODEX_HOME/agents/` y usa `npx codex-workflows update --user`. Los archivos de usuario modificados después de la instalación se conservan de la misma manera.
-
-**P: ¿Qué diferencia hay entre `$recipe-implement` y `$recipe-fullstack-implement`?**
-
-R: `$recipe-implement` es el punto de entrada universal. Ejecuta primero requirement-analyzer, determina qué capas están afectadas a partir de la petición y del repositorio, y deriva automáticamente al flujo backend, frontend o fullstack. `$recipe-fullstack-implement` omite esa detección y entra directamente en el flujo fullstack: Design Docs separados por capa, design-sync y ejecución de tareas según la capa. Usa `$recipe-implement` si no estás seguro y `$recipe-fullstack-implement` si ya sabes que la funcionalidad abarca ambas capas.
-
-**P: ¿Funciona con servidores MCP?**
-
-R: Sí. Las skills y los subagentes de Codex funcionan junto con [MCP](https://developers.openai.com/codex/mcp). Las skills operan en la capa de instrucciones y MCP en la de transporte de herramientas. Si el TOML de un agente no define `mcp_servers`, el agente personalizado hereda los `mcp_servers` del padre. Añade configuración MCP local al agente solo para servidores propios o filtrado de herramientas.
-
-**P: ¿Qué relación tiene con claude-code-workflows?**
-
-R: [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) es el proyecto equivalente para Claude Code. Ambos repositorios comparten la misma filosofía, adaptada a los puntos de extensión nativos de cada herramienta. Pueden convivir en un proyecto porque codex-workflows instala sus agentes en `.codex/agents/`, mientras que Claude Code utiliza su propio directorio `.claude/`.
-
-**P: ¿Qué hago si un subagente parece bloqueado?**
-
-R: La sesión principal de Codex es responsable del avance. Revisa la evidencia recibida, repite o corrige los resultados que no sirven y continúa el trabajo que no esté afectado. El resultado de un subagente no detiene por sí solo el flujo.
+[Nautilus](https://github.com/shinpr/nautilus) valida ideas de producto y convierte los resultados en un PRD, mientras que [linear-prism](https://github.com/shinpr/linear-prism) convierte requisitos aprobados en incidencias de Linear listas para implementar. [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) aplica el mismo enfoque a Claude Code y puede instalarse junto con codex-workflows.
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -66,10 +66,10 @@ $recipe-implement JWTによるユーザー認証を追加する
 
 | やりたいこと | 最初に使うもの |
 |---|---|
-| バックエンド、API、CLI、または一般的な変更を一貫して仕上げる | `$recipe-implement` |
+| 変更を一貫して仕上げ、バックエンド・フロントエンド・フルスタックの振り分けを任せる | `$recipe-implement` |
 | 先に設計し、実装はあとで行う | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
 | React / TypeScriptのWebフロントエンドを設計・実装する | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
-| バックエンドとReactフロントエンドをまとめて変更する | `$recipe-fullstack-implement` |
+| バックエンドとReactフロントエンドを別々に設計するフローへ直接進む | `$recipe-fullstack-implement` |
 | 設計どおりに実装されているかレビューする | `$recipe-review` または `$recipe-front-review` |
 | リポジトリ固有の品質ルールを定義・更新する | `$recipe-quality-profile` |
 | コードを変えずに問題を調査する | `$recipe-diagnose` |
@@ -109,7 +109,7 @@ ADRを作るのは、現在のスコープに属し、長く残る選択で、�
 
 実装範囲が承認されると、オーケストレーターがタスク、対象を絞った検証、該当するリポジトリチェック、タスクごとの実装コミットを実行します。問題はまず、承認済み文書とリポジトリの根拠に基づいて解決します。ユーザーから見える挙動はプロダクト上の境界であり、内部的な整合性のために実装側が勝手に変えてよいものではありません。オーケストレーターが確認を求めるのは、新しいプロダクト要件、承認済みの主要設計判断の変更、ユーザーだけが持つ権限、または未承認の不可逆操作が必要になったときだけです。
 
-専門エージェントには、担当作業に必要な文書とパスだけを渡します。エージェントは焦点を絞った根拠を提供しますが、承認済みの成果を広げる権限までは持ちません。
+各専門エージェントには、範囲を明確にした担当作業、関連する文書とパス、求める結果を渡します。専門エージェントは担当作業を完了まで進め、メインセッションはプロダクトとワークフローに関する判断を担います。メインセッションが介入するのは、判断や具体的な行き詰まりへの対応が必要なときだけで、次のフェーズへ進む前に結果を検証します。これにより、専門エージェントの裁量を保ちながら、承認済みの成果を広げる権限までは渡しません。
 
 ### 新しいコンテキストへ判断を引き継ぐ仕組み
 
@@ -157,6 +157,10 @@ npx codex-workflows install --user
 ```
 
 スキルは`$CODEX_HOME/skills/`、エージェントは`$CODEX_HOME/agents/`へインストールされます。`CODEX_HOME`が未設定の場合は`~/.codex`が使われます。
+
+### エージェントをカスタマイズする
+
+エージェント定義は通常のTOMLファイルです。プロジェクト単位でインストールした場合は`.codex/agents/`、ユーザー単位でインストールした場合は`$CODEX_HOME/agents/`のファイルを編集します。`model`、`sandbox_mode`、`developer_instructions`を変更できます。編集したファイルは、後述のとおりアップデート時にも保持されます。
 
 ### 更新
 
@@ -367,41 +371,9 @@ your-project/
 
 ---
 
-## 連携できるツール
+## エコシステム
 
-プロダクトのアイデアをさらに探索・検証したい場合は、[Nautilus](https://github.com/shinpr/nautilus)を使って前提を確かめ、その結果をPRDにまとめられます。承認後は、そのPRDを`$recipe-implement`または`$recipe-design`へ渡せます。
-
-要件がすでにLinearや既存のPRDにまとまっている場合は、[linear-prism](https://github.com/shinpr/linear-prism)を使うと、コードベースを読みながら実装可能なLinearのissueへ分解し、依存関係を明示できます。承認したissueは`$recipe-design`の入力にできます。
-
----
-
-## FAQ
-
-**Q: どのモデルで使えますか？**
-
-A: 現行のGPTモデル向けに設計されています。エージェントごとにTOMLファイルでモデルを設定できます。
-
-**Q: エージェントをカスタマイズできますか？**
-
-A: はい。`.codex/agents/`のTOMLファイルを編集すると、`model`、`sandbox_mode`、`developer_instructions`を変更できます。各エージェントが必要とするスキルは`developer_instructions`に記載されています。ローカルで変更したファイルは、`npx codex-workflows update`を実行しても保持されます。
-
-ユーザー単位でインストールした場合は、`$CODEX_HOME/agents/`のファイルを編集し、`npx codex-workflows update --user`を使ってください。インストール後に変更したユーザー単位のファイルも同様に保持されます。
-
-**Q: `$recipe-implement`と`$recipe-fullstack-implement`の違いは？**
-
-A: `$recipe-implement`は汎用の入口です。最初にrequirement-analyzerを実行し、依頼内容とリポジトリの範囲から影響するレイヤーを判定して、バックエンド、フロントエンド、フルスタックのいずれかへ自動的に振り分けます。`$recipe-fullstack-implement`はこの判定を省き、フルスタックフロー（レイヤーごとのDesign Doc、design-sync、レイヤーに応じたタスク実行）へ直接進みます。判断がつかない場合は`$recipe-implement`、機能が両レイヤーにまたがると最初からわかっている場合は`$recipe-fullstack-implement`を使ってください。
-
-**Q: MCPサーバーと一緒に使えますか？**
-
-A: はい。Codexのスキルとサブエージェントは、[MCP](https://developers.openai.com/codex/mcp)と併用できます。スキルは指示レイヤー、MCPはツール転送レイヤーで動作します。エージェントのTOMLで`mcp_servers`を省略すると、カスタムエージェントは親の`mcp_servers`を引き継ぎます。エージェント固有のサーバーやツール制限が必要な場合だけ、個別のMCP設定を追加してください。
-
-**Q: claude-code-workflowsとの関係は？**
-
-A: [claude-code-workflows](https://github.com/shinpr/claude-code-workflows)はClaude Code版にあたります。共通のワークフロー思想を、それぞれのツールが持つ拡張機構に合わせて実装しています。codex-workflowsはエージェント定義を`.codex/agents/`へ、Claude Codeは独自の`.claude/`配下へ配置するため、同じプロジェクト内で併用できます。
-
-**Q: サブエージェントが止まっているように見えたら？**
-
-A: 進行を管理するのはメインのCodexセッションです。返された根拠を確認し、使えない結果なら再実行または修正し、影響を受けない作業はそのまま進めます。1つのサブエージェントの結果だけでワークフロー全体が止まることはありません。
+[Nautilus](https://github.com/shinpr/nautilus)はプロダクトのアイデアを検証してPRDにまとめ、[linear-prism](https://github.com/shinpr/linear-prism)は承認済みの要件を実装可能なLinearのissueへ整理します。[claude-code-workflows](https://github.com/shinpr/claude-code-workflows)は同じアプローチをClaude Code向けに提供し、codex-workflowsと同じプロジェクトにインストールできます。
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -66,10 +66,10 @@ $recipe-implement JWT 사용자 인증 추가
 
 | 필요한 작업 | 시작할 레시피 |
 |---|---|
-| 백엔드, API, CLI 또는 일반 변경을 처음부터 끝까지 구현 | `$recipe-implement` |
+| 변경을 처음부터 끝까지 진행하고 백엔드, 프런트엔드 또는 풀스택 경로 선택은 워크플로에 맡기기 | `$recipe-implement` |
 | 먼저 설계하고 나중에 구현 | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
 | React / TypeScript 웹 프런트엔드를 설계하고 구현 | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
-| 백엔드와 React 프런트엔드 변경을 함께 구현 | `$recipe-fullstack-implement` |
+| 백엔드와 React 프런트엔드를 각각 설계하는 흐름으로 바로 시작 | `$recipe-fullstack-implement` |
 | 설계에 맞게 구현되었는지 리뷰 | `$recipe-review` 또는 `$recipe-front-review` |
 | 저장소별 품질 규칙 정의 또는 업데이트 | `$recipe-quality-profile` |
 | 코드를 바꾸지 않고 문제 조사 | `$recipe-diagnose` |
@@ -109,7 +109,7 @@ ADR은 현재 범위에 속하고 오래 유지되는 선택에 실질적으로 
 
 구현 범위가 승인되면 오케스트레이터가 작업, 작업에 맞춘 검증, 적용 가능한 저장소 검사, 작업별 구현 커밋을 실행합니다. 문제는 먼저 승인 문서와 저장소 근거를 사용해 해결합니다. 사용자에게 보이는 동작은 제품 경계이므로 내부 일관성을 위해 구현이 임의로 조정할 수 없습니다. 새로운 제품 요구사항, 승인된 주요 설계 결정 변경, 사용자만 가진 권한, 승인하지 않은 되돌릴 수 없는 작업이 필요할 때만 사용자에게 묻습니다.
 
-전문 에이전트는 작업에 꼭 필요한 문서와 경로만 받습니다. 필요한 범위의 구체적인 근거를 제공하지만 승인된 결과를 넓힐 권한은 없습니다.
+각 전문 에이전트에는 범위가 분명한 작업, 관련 문서와 경로, 반환해야 할 명확한 결과를 제공합니다. 전문 에이전트가 작업을 완료까지 맡는 동안 메인 세션은 제품과 워크플로에 관한 결정을 담당하고, 결정이 필요하거나 구체적인 장애물이 생겼을 때만 개입하며, 다음 단계로 넘어가기 전에 결과를 확인합니다. 따라서 전문 에이전트는 충분한 재량으로 일하되 승인된 결과를 넓힐 권한은 갖지 않습니다.
 
 ### 새 컨텍스트에서도 결정이 유지되는 방식
 
@@ -157,6 +157,10 @@ npx codex-workflows install --user
 ```
 
 스킬은 `$CODEX_HOME/skills/`에, 에이전트는 `$CODEX_HOME/agents/`에 설치됩니다. `CODEX_HOME`이 없으면 기본값은 `~/.codex`입니다.
+
+### 에이전트 사용자 정의
+
+에이전트 정의는 일반 TOML 파일입니다. 프로젝트 수준 설치에서는 `.codex/agents/`의 파일을, 사용자 수준 설치에서는 `$CODEX_HOME/agents/`의 파일을 수정하세요. `model`, `sandbox_mode`, `developer_instructions`를 변경할 수 있습니다. 수정한 파일은 아래 설명처럼 업데이트 시에도 보존됩니다.
 
 ### 업데이트
 
@@ -367,41 +371,9 @@ your-project/
 
 ---
 
-## 함께 사용할 수 있는 도구
+## 에코시스템
 
-제품 아이디어를 더 탐색하거나 검증해야 한다면 [Nautilus](https://github.com/shinpr/nautilus)로 관련 가설을 확인하고 그 결과를 PRD로 정리할 수 있습니다. 승인된 PRD를 `$recipe-implement`나 `$recipe-design`에 전달하세요.
-
-요구사항이 이미 Linear나 기존 PRD에 있다면 [linear-prism](https://github.com/shinpr/linear-prism)이 코드베이스를 읽어 구현 가능한 Linear 이슈로 나누고 이슈 간 의존 관계를 기록할 수 있습니다. 승인된 이슈를 `$recipe-design`의 입력으로 사용하세요.
-
----
-
-## 자주 묻는 질문
-
-**Q: 어떤 모델에서 사용할 수 있나요?**
-
-A: 현재 GPT 모델을 기준으로 설계되었습니다. 에이전트별 TOML 파일에서 모델을 설정할 수 있습니다.
-
-**Q: 에이전트를 사용자 정의할 수 있나요?**
-
-A: 네. `.codex/agents/`의 TOML 파일을 편집해 `model`, `sandbox_mode`, `developer_instructions`를 바꿀 수 있습니다. 각 에이전트의 필수 스킬은 `developer_instructions`에 적혀 있습니다. 로컬에서 수정한 파일은 `npx codex-workflows update`를 실행해도 보존됩니다.
-
-사용자 수준 설치에서는 `$CODEX_HOME/agents/`의 파일을 편집하고 `npx codex-workflows update --user`를 사용하세요. 설치 후 수정한 사용자 수준 파일도 같은 방식으로 보존됩니다.
-
-**Q: `$recipe-implement`와 `$recipe-fullstack-implement`는 무엇이 다른가요?**
-
-A: `$recipe-implement`는 범용 진입점입니다. 먼저 requirement-analyzer를 실행하고 요청과 저장소 범위에서 영향을 받는 계층을 확인한 다음 백엔드, 프런트엔드, 풀스택 흐름으로 자동 분기합니다. `$recipe-fullstack-implement`는 판별을 생략하고 풀스택 흐름(계층별 Design Doc, design-sync, 계층 맞춤 작업 실행)으로 바로 들어갑니다. 잘 모르겠다면 `$recipe-implement`를, 기능이 두 계층에 걸친다는 사실을 알고 있다면 `$recipe-fullstack-implement`를 사용하세요.
-
-**Q: MCP 서버와 함께 사용할 수 있나요?**
-
-A: 네. Codex 스킬과 하위 에이전트는 [MCP](https://developers.openai.com/codex/mcp)와 함께 작동합니다. 스킬은 지침 계층에서, MCP는 도구 전송 계층에서 작동합니다. 에이전트 TOML에 `mcp_servers`가 없으면 사용자 정의 에이전트가 부모의 `mcp_servers`를 상속합니다. 에이전트 전용 서버나 도구 필터링이 필요할 때만 에이전트별 MCP 설정을 추가하세요.
-
-**Q: claude-code-workflows와는 어떤 관계인가요?**
-
-A: [claude-code-workflows](https://github.com/shinpr/claude-code-workflows)는 Claude Code용 대응 프로젝트입니다. 두 저장소는 같은 워크플로 철학을 공유하되 각 도구의 기본 확장 지점에 맞게 구현되어 있습니다. codex-workflows는 에이전트 정의를 `.codex/agents/`에, Claude Code는 자체 `.claude/` 디렉터리에 설치하므로 한 프로젝트에서 함께 사용할 수 있습니다.
-
-**Q: 하위 에이전트가 멈춘 것처럼 보이면 어떻게 하나요?**
-
-A: 메인 Codex 세션이 진행을 책임집니다. 반환된 근거를 확인하고, 사용할 수 없는 결과는 다시 시도하거나 수정하며, 영향받지 않은 작업은 계속 진행합니다. 하위 에이전트 하나의 결과만으로 워크플로가 중단되지는 않습니다.
+[Nautilus](https://github.com/shinpr/nautilus)는 제품 아이디어를 검증해 PRD로 만들고, [linear-prism](https://github.com/shinpr/linear-prism)은 승인된 요구사항을 바로 구현할 수 있는 Linear 이슈로 정리합니다. [claude-code-workflows](https://github.com/shinpr/claude-code-workflows)는 같은 접근 방식을 Claude Code에 적용하며 codex-workflows와 같은 프로젝트에 설치할 수 있습니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ $recipe-implement Add user authentication with JWT
 
 | What do you need? | Start with |
 |---|---|
-| Deliver a backend, API, CLI, or general change end to end | `$recipe-implement` |
+| Deliver a change end to end and let the workflow choose the backend, frontend, or fullstack path | `$recipe-implement` |
 | Design first and implement later | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
 | Design and build a React / TypeScript web frontend | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
-| Deliver a backend and React frontend change together | `$recipe-fullstack-implement` |
+| Start directly with separate backend and React frontend design flows | `$recipe-fullstack-implement` |
 | Review an implementation against its design | `$recipe-review` or `$recipe-front-review` |
 | Define or update repository-specific quality rules | `$recipe-quality-profile` |
 | Investigate a problem without changing code | `$recipe-diagnose` |
@@ -109,7 +109,7 @@ Only decisions that affect the product or repository implementation are carried 
 
 After the implementation scope is approved, the orchestrator runs the tasks, focused verification, applicable repository checks, and one implementation commit per task. It resolves problems from the approved documents and repository evidence first. User-visible behavior remains a product boundary rather than something the implementation may adjust for internal consistency. The orchestrator asks you only when progress requires a new product requirement, a change to a major approved design decision, authority only you hold, or an irreversible action you did not authorize.
 
-Specialist agents receive the exact documents and paths needed for their work. They supply focused evidence without inheriting authority to expand the approved outcome.
+Each specialist gets a bounded job, the relevant documents and paths, and a clear result to return. The specialist carries that job through completion while the main session keeps product and workflow decisions, steps in only for a decision or concrete blocker, and checks the result before the next phase. This gives specialists room to work without giving them authority to widen the approved outcome.
 
 ### How decisions survive fresh contexts
 
@@ -158,6 +158,10 @@ npx codex-workflows install --user
 
 This installs skills into `$CODEX_HOME/skills/` and agents into
 `$CODEX_HOME/agents/`. When `CODEX_HOME` is not set, it defaults to `~/.codex`.
+
+### Customize agents
+
+Agent definitions are regular TOML files. For a project installation, edit files in `.codex/agents/`; for a user-level installation, edit files in `$CODEX_HOME/agents/`. You can change the `model`, `sandbox_mode`, or `developer_instructions`. Updates preserve files you have edited, as described below.
 
 ### Update
 
@@ -368,43 +372,9 @@ your-project/
 
 ---
 
-## Works With
+## Ecosystem
 
-When a product idea still needs discovery or validation, [Nautilus](https://github.com/shinpr/nautilus) can test the assumptions behind it and turn the results into a PRD. Pass the approved PRD to `$recipe-implement` or `$recipe-design`.
-
-If requirements already live in Linear or an existing PRD, [linear-prism](https://github.com/shinpr/linear-prism) can read the codebase, split the work into implementation-ready Linear issues, and record blocking relationships. Use an approved issue as input to `$recipe-design`.
-
----
-
-## FAQ
-
-**Q: What models does this work with?**
-
-A: Designed for current GPT models. Models are configurable per agent in the TOML files.
-
-**Q: Can I customize the agents?**
-
-A: Yes. Edit the TOML files in `.codex/agents/` to change `model`, `sandbox_mode`, or `developer_instructions`. Each agent names its required skills in `developer_instructions`. Files you modify locally are preserved during `npx codex-workflows update`.
-
-For a user-level installation, edit the files in `$CODEX_HOME/agents/` and use
-`npx codex-workflows update --user`. User-level files modified after installation
-are preserved in the same way.
-
-**Q: What's the difference between `$recipe-implement` and `$recipe-fullstack-implement`?**
-
-A: `$recipe-implement` is the universal entry point. It runs requirement-analyzer first, uses the request and repository scope to identify affected layers, and automatically routes to backend, frontend, or fullstack flow. `$recipe-fullstack-implement` skips the detection and goes straight into the fullstack flow (separate Design Docs per layer, design-sync, layer-aware task execution). Use `$recipe-implement` when you're not sure; use `$recipe-fullstack-implement` when you know upfront that the feature spans both layers.
-
-**Q: Does this work with MCP servers?**
-
-A: Yes. Codex skills and subagents work alongside [MCP](https://developers.openai.com/codex/mcp). Skills operate at the instruction layer, while MCP operates at the tool transport layer. Custom agents inherit parent `mcp_servers` when the agent TOML omits `mcp_servers`; add agent-local MCP config only for agent-specific servers or tool filtering.
-
-**Q: How is this related to claude-code-workflows?**
-
-A: [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) is the Claude Code counterpart. The repositories share the same workflow philosophy, adapted to each tool's native extension points. They can coexist in the same project because codex-workflows installs its agent definitions under `.codex/agents/` and Claude Code uses its own `.claude/` files.
-
-**Q: What if a subagent seems stuck?**
-
-A: The main Codex session owns progress. It inspects the returned evidence, retries or repairs unusable results, and continues unaffected work. A subagent result does not stop the workflow by itself.
+[Nautilus](https://github.com/shinpr/nautilus) validates product ideas and produces PRDs, while [linear-prism](https://github.com/shinpr/linear-prism) turns approved requirements into implementation-ready Linear issues. [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) brings the same approach to Claude Code and can be installed alongside codex-workflows.
 
 ---
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -66,10 +66,10 @@ O prefixo `$` invoca uma skill explicitamente. Digite `$recipe-` para ver os flu
 
 | O que você precisa? | Comece por |
 |---|---|
-| Entregar de ponta a ponta uma mudança de backend, API, CLI ou de propósito geral | `$recipe-implement` |
+| Entregar uma mudança de ponta a ponta e deixar o fluxo escolher entre backend, frontend e fullstack | `$recipe-implement` |
 | Projetar agora e implementar depois | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
 | Projetar e construir um frontend web com React / TypeScript | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
-| Entregar juntos uma mudança de backend e outra de frontend React | `$recipe-fullstack-implement` |
+| Iniciar diretamente com fluxos de design separados para o backend e o frontend React | `$recipe-fullstack-implement` |
 | Revisar uma implementação com base no design | `$recipe-review` ou `$recipe-front-review` |
 | Definir ou atualizar regras de qualidade específicas do repositório | `$recipe-quality-profile` |
 | Investigar um problema sem alterar o código | `$recipe-diagnose` |
@@ -109,7 +109,7 @@ Somente decisões que afetam o produto ou a implementação do repositório segu
 
 Depois da aprovação do escopo, o orquestrador executa as tarefas, as verificações específicas, as checagens aplicáveis do repositório e um commit de implementação por tarefa. Primeiro, resolve problemas com base nos documentos aprovados e nas evidências do repositório. O comportamento percebido pelo usuário continua sendo um limite de produto: a implementação não pode ajustá-lo por conta própria em nome da consistência interna. O orquestrador só consulta o usuário quando avançar exige um novo requisito de produto, uma mudança em uma decisão principal já aprovada, uma autorização que apenas o usuário possui ou uma ação irreversível que não foi autorizada.
 
-Os agentes especialistas recebem exatamente os documentos e caminhos necessários para o trabalho. Eles apresentam evidências específicas, mas não têm autoridade para ampliar o resultado aprovado.
+Cada especialista recebe um trabalho com escopo definido, os documentos e caminhos relevantes e um resultado claro para entregar. O especialista conduz esse trabalho até o fim, enquanto a sessão principal mantém as decisões de produto e do fluxo, só intervém diante de uma decisão ou bloqueio concreto e verifica o resultado antes da próxima fase. Assim, os especialistas têm espaço para trabalhar sem receber autoridade para ampliar o resultado aprovado.
 
 ### Como as decisões sobrevivem à troca de contexto
 
@@ -157,6 +157,10 @@ npx codex-workflows install --user
 ```
 
 As skills são instaladas em `$CODEX_HOME/skills/` e os agentes em `$CODEX_HOME/agents/`. Quando `CODEX_HOME` não está definido, o padrão é `~/.codex`.
+
+### Personalizar agentes
+
+As definições dos agentes são arquivos TOML comuns. Em uma instalação de projeto, edite os arquivos em `.codex/agents/`; em uma instalação de usuário, edite os arquivos em `$CODEX_HOME/agents/`. É possível alterar `model`, `sandbox_mode` ou `developer_instructions`. Os arquivos editados são preservados nas atualizações, conforme explicado a seguir.
 
 ### Atualizar
 
@@ -367,41 +371,9 @@ your-project/
 
 ---
 
-## Ferramentas relacionadas
+## Ecossistema
 
-Quando uma ideia de produto ainda precisa de descoberta ou validação, o [Nautilus](https://github.com/shinpr/nautilus) pode testar as premissas por trás dela e transformar os resultados em um PRD. Depois da aprovação, passe o PRD para `$recipe-implement` ou `$recipe-design`.
-
-Se os requisitos já estiverem no Linear ou em um PRD existente, o [linear-prism](https://github.com/shinpr/linear-prism) pode ler o código, dividir o trabalho em issues do Linear prontas para implementação e registrar as dependências entre elas. Use uma issue aprovada como entrada para `$recipe-design`.
-
----
-
-## Perguntas frequentes
-
-**P: Com quais modelos funciona?**
-
-R: O projeto foi criado para os modelos GPT atuais. O modelo pode ser configurado por agente nos arquivos TOML.
-
-**P: Posso personalizar os agentes?**
-
-R: Sim. Edite os arquivos TOML em `.codex/agents/` para alterar `model`, `sandbox_mode` ou `developer_instructions`. As skills obrigatórias de cada agente aparecem em `developer_instructions`. Os arquivos modificados localmente são preservados ao executar `npx codex-workflows update`.
-
-Em uma instalação de usuário, edite os arquivos em `$CODEX_HOME/agents/` e use `npx codex-workflows update --user`. Arquivos de usuário alterados após a instalação são preservados da mesma forma.
-
-**P: Qual é a diferença entre `$recipe-implement` e `$recipe-fullstack-implement`?**
-
-R: `$recipe-implement` é o ponto de entrada universal. Primeiro ele executa requirement-analyzer, identifica as camadas afetadas com base no pedido e no escopo do repositório e encaminha automaticamente para o fluxo backend, frontend ou fullstack. `$recipe-fullstack-implement` pula essa detecção e entra direto no fluxo fullstack: Design Docs separados por camada, design-sync e execução de tarefas de acordo com a camada. Use `$recipe-implement` quando não tiver certeza e `$recipe-fullstack-implement` quando já souber que a funcionalidade envolve as duas camadas.
-
-**P: Funciona com servidores MCP?**
-
-R: Sim. As skills e os subagentes do Codex funcionam junto com o [MCP](https://developers.openai.com/codex/mcp). As skills operam na camada de instruções, enquanto o MCP opera na camada de transporte de ferramentas. Se o TOML do agente não definir `mcp_servers`, o agente personalizado herda os `mcp_servers` do pai. Adicione configuração MCP específica ao agente apenas quando precisar de servidores próprios ou filtragem de ferramentas.
-
-**P: Como este projeto se relaciona com o claude-code-workflows?**
-
-R: [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) é o projeto equivalente para Claude Code. Os dois repositórios compartilham a mesma filosofia de fluxo, adaptada aos pontos de extensão nativos de cada ferramenta. Eles podem coexistir no mesmo projeto porque o codex-workflows instala as definições em `.codex/agents/`, enquanto o Claude Code usa seu próprio diretório `.claude/`.
-
-**P: O que fazer se um subagente parecer travado?**
-
-R: A sessão principal do Codex é responsável pelo andamento. Ela inspeciona as evidências recebidas, repete ou corrige resultados inutilizáveis e continua o trabalho não afetado. O resultado de um subagente, por si só, não interrompe o fluxo.
+O [Nautilus](https://github.com/shinpr/nautilus) valida ideias de produto e gera PRDs, enquanto o [linear-prism](https://github.com/shinpr/linear-prism) transforma requisitos aprovados em issues do Linear prontas para implementação. O [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) aplica a mesma abordagem ao Claude Code e pode ser instalado no mesmo projeto que o codex-workflows.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,10 +66,10 @@ $recipe-implement 使用JWT添加用户认证
 
 | 你的目标 | 从这里开始 |
 |---|---|
-| 完整交付后端、API、CLI或一般改动 | `$recipe-implement` |
+| 端到端交付改动，由工作流自动选择后端、前端或全栈路径 | `$recipe-implement` |
 | 先完成设计，稍后再实现 | `$recipe-design` → `$recipe-plan` → `$recipe-build` |
 | 设计并实现React / TypeScript Web前端 | `$recipe-front-design` → `$recipe-front-plan` → `$recipe-front-build` |
-| 同时交付后端和React前端改动 | `$recipe-fullstack-implement` |
+| 直接进入后端与React前端分别设计的流程 | `$recipe-fullstack-implement` |
 | 按照设计评审实现 | `$recipe-review` 或 `$recipe-front-review` |
 | 定义或更新仓库专属质量规则 | `$recipe-quality-profile` |
 | 调查问题但不修改代码 | `$recipe-diagnose` |
@@ -109,7 +109,7 @@ flowchart LR
 
 实现范围获批后，编排器会执行任务、针对性验证、适用的仓库检查，并为每项任务生成一次实现提交。遇到问题时，它会优先根据已批准的文档和仓库证据自行解决。用户可见行为始终是产品边界，不能为了内部一致性而由实现擅自调整。只有当继续推进需要新增产品需求、改变已批准的主要设计决策、使用只有你拥有的权限，或执行未经授权且无法撤销的操作时，编排器才会询问你。
 
-专业代理只会收到为各自工作明确指定的文档和路径。它们负责提供与任务直接相关的依据，但无权扩大已经批准的目标。
+每个专业代理都会拿到边界明确的任务、相关文档和路径，以及需要返回的明确结果。专业代理负责把任务执行到完成；主会话保留产品和工作流决策权，只在需要决策或遇到具体阻碍时介入，并在进入下一阶段前检查结果。这样既让专业代理有足够空间完成工作，也不会让它们擅自扩大已批准的目标。
 
 ### 如何让决策在新上下文中继续生效
 
@@ -157,6 +157,10 @@ npx codex-workflows install --user
 ```
 
 技能会安装到`$CODEX_HOME/skills/`，代理会安装到`$CODEX_HOME/agents/`。未设置`CODEX_HOME`时，默认使用`~/.codex`。
+
+### 自定义代理
+
+代理定义都是普通的TOML文件。项目级安装请编辑`.codex/agents/`中的文件；用户级安装请编辑`$CODEX_HOME/agents/`中的文件。你可以修改`model`、`sandbox_mode`或`developer_instructions`。按照下文说明，更新程序会保留已编辑的文件。
 
 ### 更新
 
@@ -367,41 +371,9 @@ your-project/
 
 ---
 
-## 配套工具
+## 生态系统
 
-产品想法还需要进一步探索或验证时，可以用[Nautilus](https://github.com/shinpr/nautilus)检验相关假设，并将结果整理成PRD。PRD获批后，可将其交给`$recipe-implement`或`$recipe-design`。
-
-如果需求已经记录在Linear或现有PRD中，[linear-prism](https://github.com/shinpr/linear-prism)可以结合代码库，将工作拆成可直接实施的Linear任务，并明确任务之间的依赖关系。获批的任务可作为`$recipe-design`的输入。
-
----
-
-## 常见问题
-
-**问：支持哪些模型？**
-
-答：本项目面向当前的GPT模型设计。每个代理使用的模型都可以在TOML文件中配置。
-
-**问：可以自定义代理吗？**
-
-答：可以。编辑`.codex/agents/`中的TOML文件，即可修改`model`、`sandbox_mode`或`developer_instructions`。每个代理所需的技能都列在`developer_instructions`中。本地修改过的文件会在运行`npx codex-workflows update`时保留。
-
-如果采用用户级安装，请编辑`$CODEX_HOME/agents/`中的文件，并使用`npx codex-workflows update --user`。安装后修改的用户级文件也会以同样方式保留。
-
-**问：`$recipe-implement`和`$recipe-fullstack-implement`有什么区别？**
-
-答：`$recipe-implement`是通用入口。它会先运行requirement-analyzer，根据需求和仓库范围判断受影响的层，再自动进入后端、前端或全栈流程。`$recipe-fullstack-implement`跳过判断，直接进入全栈流程（每层单独的Design Doc、design-sync，以及按层分配任务）。如果不确定该走哪条路径，请使用`$recipe-implement`；如果一开始就知道功能横跨前后端，请使用`$recipe-fullstack-implement`。
-
-**问：能与MCP服务器一起使用吗？**
-
-答：可以。Codex技能和子代理可以与[MCP](https://developers.openai.com/codex/mcp)同时使用。技能位于指令层，MCP位于工具传输层。代理TOML没有设置`mcp_servers`时，自定义代理会继承父级的`mcp_servers`；只有代理需要专属服务器或工具过滤时，才需要添加代理级MCP配置。
-
-**问：它与claude-code-workflows有什么关系？**
-
-答：[claude-code-workflows](https://github.com/shinpr/claude-code-workflows)是面向Claude Code的对应项目。两个仓库采用相同的工作流理念，再针对各自工具原生的扩展方式进行适配。它们可以安装在同一项目中，因为codex-workflows把代理定义放在`.codex/agents/`，Claude Code则使用自己的`.claude/`目录。
-
-**问：子代理似乎卡住了怎么办？**
-
-答：主Codex会话负责推进工作。它会检查返回的证据，对无法使用的结果重新尝试或修正，同时继续不受影响的其他工作。单个子代理的结果本身不会让整个工作流停止。
+[Nautilus](https://github.com/shinpr/nautilus)用于验证产品想法并产出PRD，[linear-prism](https://github.com/shinpr/linear-prism)则把已批准的需求整理成可直接实施的Linear任务。[claude-code-workflows](https://github.com/shinpr/claude-code-workflows)在Claude Code中采用同样的方法，并可与codex-workflows安装在同一项目中。
 
 ---
 


### PR DESCRIPTION
## Summary

- explain bounded subagent delegation in How It Works instead of as a stuck-agent FAQ
- move recipe selection and agent customization details to the sections where readers need them
- remove the MCP and model compatibility detours along with the now-redundant FAQ
- condense related projects into a short Ecosystem section
- apply the same structure in Chinese, Japanese, Spanish, Korean, and Brazilian Portuguese with language-specific wording

## Checks

- npm test
- npm run check:skills-index
- git diff --check
- README heading, code fence, details block, and local-link consistency checks across all six languages