### PR TITLE
Add Astra setup guidance pointing to codex-subagent-playbook

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -375,6 +375,49 @@ your-project/
 
 [Nautilus](https://github.com/shinpr/nautilus) valida ideas de producto y convierte los resultados en un PRD, mientras que [linear-prism](https://github.com/shinpr/linear-prism) convierte requisitos aprobados en incidencias de Linear listas para implementar. [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) aplica el mismo enfoque a Claude Code y puede instalarse junto con codex-workflows.
 
+### ¿Quieres usar Astra aquí?
+
+Ejecutar un flujo completo con Astra agota el límite de uso enseguida. [codex-subagent-playbook](https://github.com/shinpr/codex-subagent-playbook) es un plugin de Codex que elige el modelo de cada subagente, así que solo usa Astra donde realmente cambia el resultado.
+
+<details>
+<summary>Configuración (2 pasos)</summary>
+
+Ejecuta la sesión principal con Sol, o con Astra en reasoning effort bajo. Las skills del plugin deciden qué subagentes usan Astra y cuáles corren con un modelo más económico; la implementación va a Luna.
+
+**1. Instala el plugin**
+
+```bash
+codex plugin marketplace add shinpr/codex-subagent-playbook
+```
+
+Abre `/plugins`, busca **Subagent Playbook** e instálalo.
+
+**2. Desactiva la skill `subagent-delegation` de este repositorio**
+
+Este repositorio y el plugin traen cada uno una skill de delegación, y ninguna tiene prioridad. Qué skill carga cada sesión varía, y nada lo indica ni da error, así que el comportamiento cambia de una ejecución a otra. Abre `~/.codex/config.toml` y añade una entrada que apunte a la skill `subagent-delegation` que instalaste.
+
+Si instalaste con `--user`:
+
+```toml
+[[skills.config]]
+path = "/Users/you/.codex/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+Si instalaste en un proyecto:
+
+```toml
+[[skills.config]]
+path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+Sustituye `/Users/you` por tu propia ruta y escríbela completa, sin `~` ni variables de entorno. En los dos casos la entrada va en el `~/.codex/config.toml` del usuario: el `.codex/config.toml` del proyecto no funciona, porque Codex ignora ahí las entradas `[[skills.config]]` ([openai/codex#24237](https://github.com/openai/codex/issues/24237)).
+
+La forma de usar los flujos no cambia. Las skills se cargan cuando corresponde y cada tarea se ejecuta con el modelo que le conviene.
+
+</details>
+
 ---
 
 ## Motivos de diseño

--- a/README.ja.md
+++ b/README.ja.md
@@ -375,6 +375,49 @@ your-project/
 
 [Nautilus](https://github.com/shinpr/nautilus)はプロダクトのアイデアを検証してPRDにまとめ、[linear-prism](https://github.com/shinpr/linear-prism)は承認済みの要件を実装可能なLinearのissueへ整理します。[claude-code-workflows](https://github.com/shinpr/claude-code-workflows)は同じアプローチをClaude Code向けに提供し、codex-workflowsと同じプロジェクトにインストールできます。
 
+### Astraを効率よく使いたい場合
+
+ワークフロー全体をAstraで走らせると、利用枠をすぐ使い切ります。[codex-subagent-playbook](https://github.com/shinpr/codex-subagent-playbook)はサブエージェントごとにモデルを選ぶCodexプラグインで、結果に差が出る場面だけでAstraを使えます。
+
+<details>
+<summary>セットアップ（2ステップ）</summary>
+
+オーケストレーターはSol、またはAstraをlow reasoning effortで動かします。どのサブエージェントにAstraを割り当て、どれを軽いモデルで動かすかはプラグインのスキルが判断します。実装はLunaが担当します。
+
+**1. プラグインをインストールする**
+
+```bash
+codex plugin marketplace add shinpr/codex-subagent-playbook
+```
+
+`/plugins`を開き、**Subagent Playbook**を選んでインストールします。
+
+**2. このリポジトリの`subagent-delegation`スキルを無効化する**
+
+このリポジトリとプラグインは、どちらも委譲用のスキルを持ちます。優先順位はなく、どちらが読み込まれるかはセッションごとに変わります。どちらが読み込まれたかは表示されず、エラーにもならないため、実行するたびに挙動が変わります。`~/.codex/config.toml`を開き、インストールした`subagent-delegation`スキルを指すエントリを1つ追加します。
+
+`--user`でインストールした場合:
+
+```toml
+[[skills.config]]
+path = "/Users/you/.codex/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+プロジェクトへインストールした場合:
+
+```toml
+[[skills.config]]
+path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+`/Users/you`は自分のパスに置き換え、`~`や環境変数を使わずフルパスで書きます。どちらの場合もユーザー単位の`~/.codex/config.toml`に書きます。プロジェクト側の`.codex/config.toml`では動きません。Codexはそこに書かれた`[[skills.config]]`を無視します（[openai/codex#24237](https://github.com/openai/codex/issues/24237)）。
+
+ワークフローの使い方は変わりません。スキルが適切なタイミングで読み込まれ、タスクに合ったモデルが使われます。
+
+</details>
+
 ---
 
 ## 設計の背景

--- a/README.ko.md
+++ b/README.ko.md
@@ -375,6 +375,49 @@ your-project/
 
 [Nautilus](https://github.com/shinpr/nautilus)는 제품 아이디어를 검증해 PRD로 만들고, [linear-prism](https://github.com/shinpr/linear-prism)은 승인된 요구사항을 바로 구현할 수 있는 Linear 이슈로 정리합니다. [claude-code-workflows](https://github.com/shinpr/claude-code-workflows)는 같은 접근 방식을 Claude Code에 적용하며 codex-workflows와 같은 프로젝트에 설치할 수 있습니다.
 
+### Astra를 효율적으로 쓰려면
+
+워크플로 전체를 Astra로 실행하면 사용 한도를 금방 소진합니다. [codex-subagent-playbook](https://github.com/shinpr/codex-subagent-playbook)은 하위 에이전트마다 모델을 고르는 Codex 플러그인이라, 결과에 차이가 나는 작업에만 Astra를 씁니다.
+
+<details>
+<summary>설정(2단계)</summary>
+
+오케스트레이터는 Sol 또는 Astra를 낮은 reasoning effort로 실행합니다. 어떤 하위 에이전트에 Astra를 쓰고 어떤 것을 더 가벼운 모델로 돌릴지는 플러그인 스킬이 결정합니다. 구현은 Luna가 맡습니다.
+
+**1. 플러그인 설치**
+
+```bash
+codex plugin marketplace add shinpr/codex-subagent-playbook
+```
+
+`/plugins`를 열고 **Subagent Playbook**을 찾아 설치하세요.
+
+**2. 이 저장소의 `subagent-delegation` 스킬 비활성화**
+
+이 저장소와 플러그인은 둘 다 위임 스킬을 제공하며, 어느 쪽도 우선하지 않습니다. 세션마다 어느 쪽이 로드되는지 달라지고, 어느 쪽이 로드됐는지 표시되지도 오류가 나지도 않아서 실행할 때마다 동작이 달라질 수 있습니다. `~/.codex/config.toml`을 열고 설치한 `subagent-delegation` 스킬을 가리키는 항목 하나를 추가하세요.
+
+`--user`로 설치한 경우:
+
+```toml
+[[skills.config]]
+path = "/Users/you/.codex/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+프로젝트에 설치한 경우:
+
+```toml
+[[skills.config]]
+path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+`/Users/you`는 자신의 경로로 바꾸고, `~`나 환경 변수 없이 전체 경로로 적습니다. 두 경우 모두 사용자 수준 `~/.codex/config.toml`에 넣어야 합니다. 프로젝트의 `.codex/config.toml`에서는 동작하지 않습니다. Codex가 그곳의 `[[skills.config]]`를 무시하기 때문입니다([openai/codex#24237](https://github.com/openai/codex/issues/24237)).
+
+워크플로 사용 방식은 그대로입니다. 스킬이 필요한 시점에 로드되고, 작업에 맞는 모델이 사용됩니다.
+
+</details>
+
 ---
 
 ## 설계 배경

--- a/README.md
+++ b/README.md
@@ -376,6 +376,49 @@ your-project/
 
 [Nautilus](https://github.com/shinpr/nautilus) validates product ideas and produces PRDs, while [linear-prism](https://github.com/shinpr/linear-prism) turns approved requirements into implementation-ready Linear issues. [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) brings the same approach to Claude Code and can be installed alongside codex-workflows.
 
+### Want to use Astra here?
+
+Running a whole workflow on Astra burns through usage fast. [codex-subagent-playbook](https://github.com/shinpr/codex-subagent-playbook) is a Codex plugin that picks a model per subagent, so Astra is used only where it changes the outcome.
+
+<details>
+<summary>Setup (2 steps)</summary>
+
+Run the orchestrator on Sol, or on Astra at low reasoning effort. The plugin's skills decide which subagents get Astra and which run on a cheaper model, and implementation goes to Luna.
+
+**1. Install the plugin**
+
+```bash
+codex plugin marketplace add shinpr/codex-subagent-playbook
+```
+
+Open `/plugins`, find **Subagent Playbook**, and install it.
+
+**2. Disable this repository's `subagent-delegation` skill**
+
+This repository and the plugin each ship a delegation skill, and neither takes priority. Which one a session loads varies, and nothing reports it or errors out, so behavior drifts between runs. Open `~/.codex/config.toml` and add one entry pointing at the `subagent-delegation` skill you installed.
+
+If you installed with `--user`:
+
+```toml
+[[skills.config]]
+path = "/Users/you/.codex/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+If you installed into a project:
+
+```toml
+[[skills.config]]
+path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+Replace `/Users/you` with your own path and write it out in full, with no `~` or environment variables. Both cases go in `~/.codex/config.toml`: a project's own `.codex/config.toml` will not work, because Codex ignores `[[skills.config]]` there ([openai/codex#24237](https://github.com/openai/codex/issues/24237)).
+
+Nothing changes in how you use the workflows. The plugin's skills load when they apply, and each task runs on a model that fits it.
+
+</details>
+
 ---
 
 ## Design Rationale

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -375,6 +375,49 @@ your-project/
 
 O [Nautilus](https://github.com/shinpr/nautilus) valida ideias de produto e gera PRDs, enquanto o [linear-prism](https://github.com/shinpr/linear-prism) transforma requisitos aprovados em issues do Linear prontas para implementação. O [claude-code-workflows](https://github.com/shinpr/claude-code-workflows) aplica a mesma abordagem ao Claude Code e pode ser instalado no mesmo projeto que o codex-workflows.
 
+### Quer usar o Astra aqui?
+
+Rodar um fluxo inteiro no Astra esgota o limite de uso rapidamente. O [codex-subagent-playbook](https://github.com/shinpr/codex-subagent-playbook) é um plugin do Codex que escolhe o modelo de cada subagente, então o Astra só é usado onde realmente faz diferença no resultado.
+
+<details>
+<summary>Configuração (2 passos)</summary>
+
+Rode a sessão principal no Sol, ou no Astra com reasoning effort baixo. As skills do plugin decidem quais subagentes usam o Astra e quais rodam em um modelo mais barato; a implementação fica com o Luna.
+
+**1. Instale o plugin**
+
+```bash
+codex plugin marketplace add shinpr/codex-subagent-playbook
+```
+
+Abra `/plugins`, encontre **Subagent Playbook** e instale.
+
+**2. Desative a skill `subagent-delegation` deste repositório**
+
+Este repositório e o plugin trazem cada um uma skill de delegação, e nenhuma tem prioridade. A skill carregada pode variar de uma sessão para outra, e nada indica qual delas foi usada nem acusa erro, então o comportamento também muda entre execuções. Abra `~/.codex/config.toml` e adicione uma entrada apontando para a skill `subagent-delegation` que você instalou.
+
+Se instalou com `--user`:
+
+```toml
+[[skills.config]]
+path = "/Users/you/.codex/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+Se instalou em um projeto:
+
+```toml
+[[skills.config]]
+path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+Troque `/Users/you` pelo seu próprio caminho e escreva-o completo, sem `~` nem variáveis de ambiente. Nos dois casos a entrada vai no `~/.codex/config.toml` do usuário: o `.codex/config.toml` do projeto não funciona, porque o Codex ignora as entradas `[[skills.config]]` ali ([openai/codex#24237](https://github.com/openai/codex/issues/24237)).
+
+A forma de usar os fluxos não muda. As skills são carregadas no momento certo e cada tarefa roda no modelo adequado.
+
+</details>
+
 ---
 
 ## Fundamentos do design

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -375,6 +375,49 @@ your-project/
 
 [Nautilus](https://github.com/shinpr/nautilus)用于验证产品想法并产出PRD，[linear-prism](https://github.com/shinpr/linear-prism)则把已批准的需求整理成可直接实施的Linear任务。[claude-code-workflows](https://github.com/shinpr/claude-code-workflows)在Claude Code中采用同样的方法，并可与codex-workflows安装在同一项目中。
 
+### 想在这里用Astra？
+
+整个工作流都用Astra跑，用量很快就会见底。[codex-subagent-playbook](https://github.com/shinpr/codex-subagent-playbook)是一个Codex插件，按子代理挑选模型，只在会改变结果的环节使用Astra。
+
+<details>
+<summary>设置（2步）</summary>
+
+编排器用Sol，或者把Astra的reasoning effort调低。哪些子代理用Astra、哪些用更便宜的模型，由插件的技能决定；实现交给Luna。
+
+**1. 安装插件**
+
+```bash
+codex plugin marketplace add shinpr/codex-subagent-playbook
+```
+
+打开`/plugins`，找到**Subagent Playbook**并安装。
+
+**2. 关闭本仓库的`subagent-delegation`技能**
+
+本仓库和插件各自都带了委派技能，两者没有优先级之分。每个会话加载哪一个并不固定，也不会有任何提示或报错，因此每次运行的行为都可能不一样。打开`~/.codex/config.toml`，添加一条指向已安装的`subagent-delegation`技能的配置。
+
+使用`--user`安装时：
+
+```toml
+[[skills.config]]
+path = "/Users/you/.codex/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+安装到项目时：
+
+```toml
+[[skills.config]]
+path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+enabled = false
+```
+
+把`/Users/you`换成你自己的路径，并写成完整路径，不要用`~`或环境变量。两种情况都写在用户级`~/.codex/config.toml`里；项目自己的`.codex/config.toml`不生效，因为Codex会忽略那里的`[[skills.config]]`（[openai/codex#24237](https://github.com/openai/codex/issues/24237)）。
+
+工作流的使用方式不变。技能会在需要时加载，每个任务都用合适的模型执行。
+
+</details>
+
 ---
 
 ## 设计思路


### PR DESCRIPTION
Adds a short subsection under **Ecosystem** linking to [codex-subagent-playbook](https://github.com/shinpr/codex-subagent-playbook), with setup collapsed into a `<details>` block. Applied to all six README translations.

Running a full workflow on Astra exhausts usage fast. The plugin selects a model per subagent, so Astra is used only where it changes the outcome, and implementation goes to Luna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)