### PR TITLE
Simplify the Astra setup paths

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -412,7 +412,7 @@ path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.
 enabled = false
 ```
 
-Sustituye las rutas por las tuyas y escríbelas completas. Aquí no funcionan `~` ni las variables de entorno, y en los dos casos la entrada va en el `~/.codex/config.toml` del usuario.
+Escribe la ruta completa: aquí no funcionan `~` ni las variables de entorno.
 
 La forma de usar los flujos no cambia. Las skills se cargan cuando corresponde y cada tarea se ejecuta con el modelo que le conviene.
 

--- a/README.es.md
+++ b/README.es.md
@@ -408,11 +408,11 @@ Si instalaste en un proyecto:
 
 ```toml
 [[skills.config]]
-path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.md"
 enabled = false
 ```
 
-Sustituye `/Users/you` por tu propia ruta y escríbela completa, sin `~` ni variables de entorno. En los dos casos la entrada va en el `~/.codex/config.toml` del usuario: el `.codex/config.toml` del proyecto no funciona, porque Codex ignora ahí las entradas `[[skills.config]]` ([openai/codex#24237](https://github.com/openai/codex/issues/24237)).
+Sustituye las rutas por las tuyas y escríbelas completas. Aquí no funcionan `~` ni las variables de entorno, y en los dos casos la entrada va en el `~/.codex/config.toml` del usuario.
 
 La forma de usar los flujos no cambia. Las skills se cargan cuando corresponde y cada tarea se ejecuta con el modelo que le conviene.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -408,11 +408,11 @@ enabled = false
 
 ```toml
 [[skills.config]]
-path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.md"
 enabled = false
 ```
 
-`/Users/you`は自分のパスに置き換え、`~`や環境変数を使わずフルパスで書きます。どちらの場合もユーザー単位の`~/.codex/config.toml`に書きます。プロジェクト側の`.codex/config.toml`では動きません。Codexはそこに書かれた`[[skills.config]]`を無視します（[openai/codex#24237](https://github.com/openai/codex/issues/24237)）。
+パスは自分の環境のものに置き換え、フルパスで書きます。`~`や環境変数は使えません。どちらの場合もユーザー単位の`~/.codex/config.toml`に書きます。
 
 ワークフローの使い方は変わりません。スキルが適切なタイミングで読み込まれ、タスクに合ったモデルが使われます。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -412,7 +412,7 @@ path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.
 enabled = false
 ```
 
-パスは自分の環境のものに置き換え、フルパスで書きます。`~`や環境変数は使えません。どちらの場合もユーザー単位の`~/.codex/config.toml`に書きます。
+パスはフルパスで書きます。`~`や環境変数は使えません。
 
 ワークフローの使い方は変わりません。スキルが適切なタイミングで読み込まれ、タスクに合ったモデルが使われます。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -412,7 +412,7 @@ path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.
 enabled = false
 ```
 
-경로는 자신의 환경에 맞게 바꾸고 전체 경로로 적습니다. `~`나 환경 변수는 쓸 수 없습니다. 두 경우 모두 사용자 수준 `~/.codex/config.toml`에 넣습니다.
+경로는 전체 경로로 적습니다. `~`나 환경 변수는 쓸 수 없습니다.
 
 워크플로 사용 방식은 그대로입니다. 스킬이 필요한 시점에 로드되고, 작업에 맞는 모델이 사용됩니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -408,11 +408,11 @@ enabled = false
 
 ```toml
 [[skills.config]]
-path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.md"
 enabled = false
 ```
 
-`/Users/you`는 자신의 경로로 바꾸고, `~`나 환경 변수 없이 전체 경로로 적습니다. 두 경우 모두 사용자 수준 `~/.codex/config.toml`에 넣어야 합니다. 프로젝트의 `.codex/config.toml`에서는 동작하지 않습니다. Codex가 그곳의 `[[skills.config]]`를 무시하기 때문입니다([openai/codex#24237](https://github.com/openai/codex/issues/24237)).
+경로는 자신의 환경에 맞게 바꾸고 전체 경로로 적습니다. `~`나 환경 변수는 쓸 수 없습니다. 두 경우 모두 사용자 수준 `~/.codex/config.toml`에 넣습니다.
 
 워크플로 사용 방식은 그대로입니다. 스킬이 필요한 시점에 로드되고, 작업에 맞는 모델이 사용됩니다.
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.
 enabled = false
 ```
 
-Replace the paths above with your own, written out in full. `~` and environment variables do not work here, and both cases go in `~/.codex/config.toml`.
+Write the path out in full: `~` and environment variables do not work here.
 
 Nothing changes in how you use the workflows. The plugin's skills load when they apply, and each task runs on a model that fits it.
 

--- a/README.md
+++ b/README.md
@@ -409,11 +409,11 @@ If you installed into a project:
 
 ```toml
 [[skills.config]]
-path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.md"
 enabled = false
 ```
 
-Replace `/Users/you` with your own path and write it out in full, with no `~` or environment variables. Both cases go in `~/.codex/config.toml`: a project's own `.codex/config.toml` will not work, because Codex ignores `[[skills.config]]` there ([openai/codex#24237](https://github.com/openai/codex/issues/24237)).
+Replace the paths above with your own, written out in full. `~` and environment variables do not work here, and both cases go in `~/.codex/config.toml`.
 
 Nothing changes in how you use the workflows. The plugin's skills load when they apply, and each task runs on a model that fits it.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -408,11 +408,11 @@ Se instalou em um projeto:
 
 ```toml
 [[skills.config]]
-path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.md"
 enabled = false
 ```
 
-Troque `/Users/you` pelo seu próprio caminho e escreva-o completo, sem `~` nem variáveis de ambiente. Nos dois casos a entrada vai no `~/.codex/config.toml` do usuário: o `.codex/config.toml` do projeto não funciona, porque o Codex ignora as entradas `[[skills.config]]` ali ([openai/codex#24237](https://github.com/openai/codex/issues/24237)).
+Troque os caminhos pelos seus e escreva-os completos. `~` e variáveis de ambiente não funcionam aqui, e nos dois casos a entrada vai no `~/.codex/config.toml` do usuário.
 
 A forma de usar os fluxos não muda. As skills são carregadas no momento certo e cada tarefa roda no modelo adequado.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -412,7 +412,7 @@ path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.
 enabled = false
 ```
 
-Troque os caminhos pelos seus e escreva-os completos. `~` e variáveis de ambiente não funcionam aqui, e nos dois casos a entrada vai no `~/.codex/config.toml` do usuário.
+Escreva o caminho completo: `~` e variáveis de ambiente não funcionam aqui.
 
 A forma de usar os fluxos não muda. As skills são carregadas no momento certo e cada tarefa roda no modelo adequado.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -412,7 +412,7 @@ path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.
 enabled = false
 ```
 
-把路径换成你自己的，并写成完整路径，这里不能用`~`或环境变量。两种情况都写在用户级`~/.codex/config.toml`里。
+路径要写完整，这里不能用`~`或环境变量。
 
 工作流的使用方式不变。技能会在需要时加载，每个任务都用合适的模型执行。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -408,11 +408,11 @@ enabled = false
 
 ```toml
 [[skills.config]]
-path = "/Users/you/your-project/.agents/skills/subagent-delegation/SKILL.md"
+path = "/absolute/path/to/your-project/.agents/skills/subagent-delegation/SKILL.md"
 enabled = false
 ```
 
-把`/Users/you`换成你自己的路径，并写成完整路径，不要用`~`或环境变量。两种情况都写在用户级`~/.codex/config.toml`里；项目自己的`.codex/config.toml`不生效，因为Codex会忽略那里的`[[skills.config]]`（[openai/codex#24237](https://github.com/openai/codex/issues/24237)）。
+把路径换成你自己的，并写成完整路径，这里不能用`~`或环境变量。两种情况都写在用户级`~/.codex/config.toml`里。
 
 工作流的使用方式不变。技能会在需要时加载，每个任务都用合适的模型执行。
 


### PR DESCRIPTION
Two fixes to the setup block added in #84.

The project example used `/Users/you/your-project/...`, which assumes the repository sits under the home directory. It now uses an absolute placeholder.

Removes the trailing note about Codex ignoring `[[skills.config]]` in a project config. The step already says which file to edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)